### PR TITLE
Initiated tests for `reduce_data()`

### DIFF
--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -34,63 +34,65 @@ check_reduce_data_structure <- function(out) {
   expect_type(
     out, "list"
   )
-  
+
   expect_named(
-    out, 
+    out,
     c("community", "age", "age_un")
   )
-  
+
   # ---- community ----
   expect_s3_class(
-    out$community, 
+    out$community,
     "data.frame"
   )
-  
+
   if (ncol(out$community) > 0) {
     expect_true(all(vapply(out$community, is.numeric, logical(1))))
   }
-  
+
   expect_true(
     !is.null(
       rownames(
-        out$community)
+        out$community
+      )
     )
   )
-  
+
   expect_true(
     !is.null(
       colnames(
-        out$community)
+        out$community
+      )
     )
   )
-  
+
   # ---- age ----
   expect_s3_class(
-    out$age, 
+    out$age,
     "data.frame"
   )
-  
+
   expect_true(
     "age" %in% colnames(out$age)
   )
-  
+
   expect_true(
     !is.null(
       rownames(out$age)
     )
   )
-  
+
   expect_equal(
-    rownames(out$age), 
+    rownames(out$age),
     rownames(out$community)
   )
-  
+
   # ---- age_un ----
   if (!is.null(out$age_un)) {
     expect_true(
       is.matrix(out$age_un) || is.data.frame(out$age_un)
     )
-    
+
     expect_equal(
       colnames(out$age_un), rownames(out$community)
     )
@@ -153,11 +155,6 @@ data_null_age_un$age_un <-
   NULL
 
 
-
-
-
-
-
 # --------------------------------------------------- #
 # Test 1: test taxa reduction only
 # --------------------------------------------------- #
@@ -185,9 +182,8 @@ test_that("reduce_data filters taxa correctly using smoothed example data", {
   expect_lte(
     ncol(out_taxa$community), length(full_taxa)
   )
-  
+
   check_reduce_data_structure(out_taxa)
-  
 })
 
 
@@ -223,9 +219,8 @@ test_that("reduce_data filters levels correctly using smoothed example data", {
   expect_equal(
     colnames(out_levels$age_un), rownames(out_levels$community)
   )
-  
+
   check_reduce_data_structure(out_levels)
-  
 })
 
 # --------------------------------------------------- #
@@ -265,11 +260,9 @@ test_that("reduce_data filters taxa and levels correctly using smoothed example 
       data_null_age_un
     )
   )
-  
+
   check_reduce_data_structure(out_both)
 })
-
-
 
 
 # --------------------------------------------------- #
@@ -288,7 +281,7 @@ test_that("reduce_data with both = FALSE doesn't change the data", {
     no_filter,
     data_smooth
   )
-  
+
   check_reduce_data_structure(no_filter)
 })
 
@@ -314,9 +307,8 @@ test_that("reduce_data handles taxa with all-zeros in samples correctly", {
     ncol(out_zeros$community),
     ncol(test_data_zeros$community)
   )
-  
+
   check_reduce_data_structure(out_zeros)
-  
 })
 
 
@@ -342,10 +334,8 @@ test_that("reduce_data handles levels with all-zeros in samples correctly", {
   expect_false(
     "fake_level" %in% colnames(out_empty_levels$age_un)
   )
-  
+
   check_reduce_data_structure(out_empty_levels)
-  
-  
 })
 # --------------------------------------------------- #
 # Test 7: NA taxa
@@ -362,9 +352,8 @@ test_that("reduce_data handles NA in taxon (community) correctly", {
   expect_false(
     "na_taxon" %in% colnames(out_NA_taxon$community)
   )
-  
+
   check_reduce_data_structure(out_NA_taxon)
-  
 })
 
 # --------------------------------------------------- #
@@ -425,9 +414,8 @@ test_that("reduce_data handles all-zero community data correctly", {
       out_all_zero_taxa$age_un
     ) == 0
   )
-  
+
   check_reduce_data_structure(out_all_zero_taxa)
-  
 })
 
 # --------------------------------------------------- #
@@ -458,13 +446,6 @@ test_that("reduce_data handles all-zero levels correctly", {
       out_all_zero_levels$age_un
     ), 0
   )
-  
+
   check_reduce_data_structure(out_all_zero_levels)
-  
 })
-
-
-
-
-
-

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -6,11 +6,13 @@
 # which filters taxa and/or levels based on zero-sum criteria.
 #
 # Test structure:
-# 1. Input Validation Tests
-# 2. No Filtering Tests (both FALSE)
+# 1. Input Validation Tests (Errors)
+# 2. No Filtering Tests (check_taxa = FALSE, check_levels = FALSE)
 # 3. Taxa-Only Filtering Tests (check_taxa=TRUE, check_levels=FALSE)
 # 4. Levels-Only Filtering Tests (check_taxa=FALSE, check_levels=TRUE)
 # 5. Both Filtering Tests (check_taxa=TRUE, check_levels=TRUE)
+# 6. All-zero / All-NA / Empty data cases
+# 7. Output validation
 #
 # ==================================================================== #
 
@@ -19,114 +21,106 @@
 # --------------------------------------------------- #
 
 # 1.1 data_source_reduce validation
-test_that("reduce_data rejects NULL data_source_reduce", {
+test_that(
+  "reduce_data rejects NULL data_source_reduce", {
   expect_error(
-    reduce_data(data_source_reduce = NULL),
+    reduce_data(
+    data_source_reduce = NULL),
     "data_source_reduce.*list"
   )
 })
 
-test_that("reduce_data rejects string data_source_reduce", {
+test_that(
+  "reduce_data rejects string data_source_reduce", {
   expect_error(
-    reduce_data(data_source_reduce = "invalid"),
+    reduce_data(
+    data_source_reduce = "invalid"),
     "data_source_reduce.*list"
   )
 })
 
-test_that("reduce_data rejects numeric data_source_reduce", {
+test_that(
+  "reduce_data rejects numeric data_source_reduce", {
   expect_error(
-    reduce_data(data_source_reduce = 123),
+    reduce_data(
+    data_source_reduce = 123),
     "data_source_reduce.*list"
   )
 })
 
-test_that("reduce_data rejects data.frame data_source_reduce", {
+test_that(
+  "reduce_data rejects data.frame data_source_reduce", {
   expect_error(
-    reduce_data(data_source_reduce = data.frame(x = 1)),
+    reduce_data(
+    data_source_reduce = data.frame(
+    x = 1)),
     "data_source_reduce.*list"
   )
 })
 
-test_that("reduce_data rejects empty list data_source_reduce", {
+test_that(
+  "reduce_data rejects empty list data_source_reduce", {
   expect_error(
-    reduce_data(data_source_reduce = list())
+    reduce_data(
+    data_source_reduce = list(
+    )),
+    "'x' must be an array of at least two dimensions"
   )
 })
 
 # 1.2 check_taxa validation
-test_that("reduce_data rejects invalid check_taxa argument", {
-  raw_data <- 
-  extract_data(
+test_that(
+  "reduce_data rejects invalid check_taxa argument", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
   expect_error(
-    reduce_data(data_source_reduce = raw_data, check_taxa = "TRUE"),
+    reduce_data(
+    data_source_reduce = raw_data, check_taxa = "TRUE"),
     "check_taxa.*logical"
   )
 })
 
-test_that("reduce_data rejects invalid check_taxa argument", {
-  raw_data <- 
-  extract_data(
+test_that(
+  "reduce_data rejects invalid check_taxa argument", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
   expect_error(
-    reduce_data(data_source_reduce = raw_data, check_taxa = 123),
+    reduce_data(
+    data_source_reduce = raw_data, check_taxa = 123),
     "check_taxa.*logical"
   )
 })
 
-test_that("reduce_data rejects invalid check_taxa argument", {
-  raw_data <- 
-  extract_data(
+test_that(
+  "reduce_data rejects invalid check_taxa argument", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
   expect_error(
-    reduce_data(data_source_reduce = raw_data, check_taxa = NULL),
+    reduce_data(
+    data_source_reduce = raw_data, check_taxa = NULL),
     "check_taxa.*logical"
   )
 })
 
 # 1.3 check_levels validation
-test_that("reduce_data rejects invalid check_levels argument", {
-  raw_data <- 
-  extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    reduce_data(data_source_reduce = raw_data, check_levels = "TRUE"),
-    "check_levels.*logical"
-  )
-})
-
-test_that("reduce_data rejects invalid check_levels argument", {
-  raw_data <- 
-  extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    reduce_data(data_source_reduce = raw_data, check_levels = 123),
-    "check_levels.*logical"
-  )
-})
-
-test_that("reduce_data rejects invalid check_levels argument", {
-  raw_data <- 
+test_that(
+  "reduce_data rejects invalid check_levels argument", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -135,16 +129,49 @@ test_that("reduce_data rejects invalid check_levels argument", {
     )
   expect_error(
     reduce_data(
-      data_source_reduce = raw_data, 
+    data_source_reduce = raw_data, check_levels = "TRUE"),
+    "check_levels.*logical"
+  )
+})
+
+test_that(
+  "reduce_data rejects invalid check_levels argument", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(
+    data_source_reduce = raw_data, check_levels = 123),
+    "check_levels.*logical"
+  )
+})
+
+test_that(
+  "reduce_data rejects invalid check_levels argument", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(
+      data_source_reduce = raw_data,
       check_levels = NULL
-      ),
+    ),
     "check_levels.*logical"
   )
 })
 
 # 1.4 data_source_reduce structure validation
-test_that("reduce_data rejects missing community component", {
-  raw_data <- 
+test_that(
+  "reduce_data rejects missing community component", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -152,14 +179,18 @@ test_that("reduce_data rejects missing community component", {
       verbose = FALSE
     )
 
-  incomplete_data <- list(age = raw_data$age, age_un = raw_data$age_un)
+  incomplete_data <-
+    list(age = raw_data$age, age_un = raw_data$age_un)
   expect_error(
-    reduce_data(data_source_reduce = incomplete_data)
+    reduce_data(
+    data_source_reduce = incomplete_data),
+    "'x' must be an array of at least two dimensions"
   )
 })
 
-test_that("reduce_data rejects missing age component", {
-  raw_data <- 
+test_that(
+  "reduce_data rejects missing age component", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -167,14 +198,18 @@ test_that("reduce_data rejects missing age component", {
       verbose = FALSE
     )
 
-  incomplete_data <- list(community = raw_data$community, age_un = raw_data$age_un)
+  incomplete_data <-
+    list(community = raw_data$community, age_un = raw_data$age_un)
   expect_error(
-    reduce_data(data_source_reduce = incomplete_data)
+    reduce_data(
+    data_source_reduce = incomplete_data),
+    "Empty name found at location 1"
   )
 })
 
-test_that("reduce_data rejects matrix community", {
-  raw_data <- 
+test_that(
+  "reduce_data rejects community as matrix", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -182,14 +217,18 @@ test_that("reduce_data rejects matrix community", {
       verbose = FALSE
     )
 
-  raw_data$community <- as.matrix(raw_data$community)
+  raw_data$community <-
+    as.matrix(raw_data$community)
   expect_error(
-    reduce_data(data_source_reduce = raw_data)
+    reduce_data(
+    data_source_reduce = raw_data),
+    "no applicable method for 'select'"
   )
 })
 
-test_that("reduce_data rejects community without rownames", {
-  raw_data <- 
+test_that(
+  "reduce_data rejects age as matrix", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -197,14 +236,19 @@ test_that("reduce_data rejects community without rownames", {
       verbose = FALSE
     )
 
-  rownames(raw_data$community) <- NULL
+  raw_data$age <-
+    as.matrix(raw_data$age)
+
   expect_error(
-    reduce_data(data_source_reduce = raw_data)
+    reduce_data(
+    data_source_reduce = raw_data),
+    "is not TRUE"
   )
 })
 
-test_that("reduce_data rejects community with non-numeric columns", {
-  raw_data <- 
+test_that(
+  "reduce_data rejects community as list", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -212,15 +256,79 @@ test_that("reduce_data rejects community with non-numeric columns", {
       verbose = FALSE
     )
 
-  raw_data$community$text_col <- "NA"
+  raw_data$community <-
+    list(community = raw_data$community)
+
   expect_error(
-    reduce_data(data_source_reduce = raw_data),
+    reduce_data(
+    data_source_reduce = raw_data),
+    "no applicable method for 'select'"
+  )
+})
+
+test_that(
+  "reduce_data rejects age as list", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  raw_data$age <-
+    list(age = raw_data$age)
+
+  expect_error(
+    reduce_data(
+    data_source_reduce = raw_data),
+    "no applicable method for 'select'"
+  )
+})
+
+test_that(
+  "reduce_data validates age_un is not a list", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  raw_data$age_un <-
+    list(age_un = raw_data$age_un)
+
+  expect_error(
+    reduce_data(
+    data_source_reduce = raw_data),
+    "incorrect number of dimensions"
+  )
+})
+
+
+test_that(
+  "reduce_data rejects community with non-numeric columns", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  raw_data$community$text_col <-
+    "NA"
+  expect_error(
+    reduce_data(
+    data_source_reduce = raw_data),
     "'x' must be numeric"
   )
 })
 
-test_that("reduce_data rejects age without rownames", {
-  raw_data <- 
+test_that(
+  "reduce_data validates community must have colnames", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -228,37 +336,78 @@ test_that("reduce_data rejects age without rownames", {
       verbose = FALSE
     )
 
-  rownames(raw_data$age) <- NULL
+  colnames(raw_data$community) <-
+    NULL
+
   expect_error(
-    reduce_data(data_source_reduce = raw_data)
+    reduce_data(
+    data_source_reduce = raw_data),
+    "Can't select within an unnamed vector."
   )
 })
 
+test_that(
+  "reduce_data throws warning if community without rownames", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  rownames(raw_data$community) <-
+    NULL
+  expect_condition(
+    result <-
+      reduce_data(data_source_reduce = raw_data)
+  )
+})
+
+test_that(
+  "reduce_data throws warning if age without rownames", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  rownames(raw_data$age) <-
+    NULL
+  expect_warning(
+    reduce_data(data_source_reduce = raw_data)
+  )
+})
 
 # --------------------------------------------------- #
 # 2. NO FILTERING TESTS (check_taxa=FALSE, check_levels=FALSE)
 # --------------------------------------------------- #
 
-test_that("reduce_data with no filtering returns identical data", {
-  raw_data <- 
+test_that(
+  "reduce_data with no filtering returns identical data", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
-  # one zero column in community
-  raw_data$community[,1] <- 0  
-  # one zero row in community
-  raw_data$community[1,] <- 0 
 
-  result <- 
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = FALSE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = FALSE,
+      check_levels = FALSE
+    )
 
   expect_identical(raw_data, result)
 })
@@ -266,19 +415,22 @@ test_that("reduce_data with no filtering returns identical data", {
 # --------------------------------------------------- #
 # 3. TAXA-ONLY FILTERING TESTS (check_taxa=TRUE, check_levels=FALSE)
 # --------------------------------------------------- #
-test_that("taxa filtering drops taxa with zero column sums", {
-  raw_data <- 
+
+test_that(
+  "taxa filtering drops taxa with zero column sums", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
-  # one zero column in community
-  raw_data$community[,1] <- 0  
 
-  result <- 
+  # one zero column/taxa in community
+  raw_data$community[, 1] <-
+    0
+
+  result <-
     reduce_data(
       data_source_reduce = raw_data,
       check_taxa = TRUE,
@@ -290,35 +442,38 @@ test_that("taxa filtering drops taxa with zero column sums", {
 })
 
 
-test_that("check_levels = FALSE preserves rownames / sample ids", {
-  raw_data <- 
+test_that(
+  "check_levels = FALSE preserves rownames / sample ids", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
-  # one zero column in community
-  raw_data$community[,1] <- 0  
-  # one zero row in community
-  raw_data$community[1,] <- 0 
 
-  result <- 
-  reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = FALSE
-  )
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
   expect_equal(nrow(raw_data$community), nrow(result$community))
   expect_identical(rownames(raw_data$community), rownames(result$community))
   expect_identical(rownames(raw_data$age), rownames(result$age))
   expect_identical(colnames(raw_data$age_un), colnames(result$age_un))
-
 })
 
-test_that("taxa filtering removes all-NA taxa", {
-  raw_data <- 
+test_that(
+  "taxa filtering removes all-NA taxa", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -326,86 +481,77 @@ test_that("taxa filtering removes all-NA taxa", {
       verbose = FALSE
     )
 
-  raw_data$community$na_taxon <- NA
+  raw_data$community$na_taxon <-
+    NA
 
-  result <- reduce_data(
+  result <-
+    reduce_data(
     data_source_reduce = raw_data,
     check_taxa = TRUE,
     check_levels = FALSE
   )
-  
+
   expect_false("na_taxon" %in% colnames(result$community))
-})
-
-test_that("taxa filtering with all-zero community data returns empty community result", {
-  raw_data <- 
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  raw_data$community[,] <- 0
-
-  result <- 
-  reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = FALSE
-  )
-  
-  expect_equal(ncol(result$community), 0)
 })
 
 # --------------------------------------------------- #
 # 4. LEVELS-ONLY FILTERING TESTS (check_taxa=FALSE, check_levels=TRUE)
 # --------------------------------------------------- #
 
-test_that("levels filtering removes zero-sum levels from community", {
-  raw_data <- 
+test_that(
+  "levels filtering removes zero-sum levels from community and age", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
+
   # one zero column in community
-  raw_data$community[,1] <- 0  
+  raw_data$community[, 1] <-
+    0
   # one zero row in community
-  raw_data$community[1,] <- 0
+  raw_data$community[1, ] <-
+    0
 
-  first_level <- rownames(raw_data$community)[1]
-  raw_data$community[1,] <- 0
+  first_level <-
+    rownames(raw_data$community)[1]
+  raw_data$community[1, ] <-
+    0
 
-  result <- reduce_data(
+  result <-
+    reduce_data(
     data_source_reduce = raw_data,
     check_taxa = FALSE,
     check_levels = TRUE
   )
-  
-  expect_true(all(rowSums(result$community, na.rm = TRUE) > 0)) 
+
+  expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
   expect_false(first_level %in% rownames(result$community))
   expect_false(first_level %in% rownames(result$age))
   expect_false(first_level %in% colnames(result$age_un))
 })
 
-test_that("levels filtering preserves community colnames", {
-  raw_data <- 
+test_that(
+  "levels filtering preserves community colnames/taxa", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
+
   # one zero column in community
-  raw_data$community[,1] <- 0  
+  raw_data$community[, 1] <-
+    0
   # one zero row in community
-  raw_data$community[1,] <- 0 
-  
-  result <- reduce_data(
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
     data_source_reduce = raw_data,
     check_taxa = FALSE,
     check_levels = TRUE
@@ -414,65 +560,47 @@ test_that("levels filtering preserves community colnames", {
   expect_identical(colnames(raw_data$community), colnames(result$community))
 })
 
-test_that("levels filtering maintains matching rownames between community and age", {
-  raw_data <- 
+test_that(
+  "levels filtering maintains matching rownames between community and age and age_un", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
+
   # one zero column in community
-  raw_data$community[,1] <- 0  
+  raw_data$community[, 1] <-
+    0
   # one zero row in community
-  raw_data$community[1,] <- 0 
-  
-  result <- reduce_data(
-    data_source_reduce = data_smooth,
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
     check_taxa = FALSE,
     check_levels = TRUE
   )
-  
+
   expect_identical(rownames(result$community), rownames(result$age))
   expect_identical(rownames(result$community), colnames(result$age_un))
 })
 
 
-
-test_that("levels filtering with all zero levels returns empty result", {
-  raw_data <- 
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  raw_data$community[,] <- 0
-
-  result <- reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = TRUE
-  )
-  
-  expect_equal(nrow(result$community), 0)
-  expect_equal(nrow(result$age), 0)
-  expect_equal(ncol(result$age_un), 0)
-})
-
-
-test_that("levels filtering handles NULL age_un", {
-  raw_data <- 
+test_that(
+  "levels filtering works with NULL age_un", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       verbose = FALSE
     )
 
-  raw_data$community[1,] <- 0
-  
+  raw_data$community[1, ] <-
+    0
+
   expect_no_error(
     reduce_data(
       data_source_reduce = raw_data,
@@ -482,76 +610,66 @@ test_that("levels filtering handles NULL age_un", {
   )
 })
 
+test_that(
+  "levels filtering removes all-NA sample", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  first_level <-
+    rownames(raw_data$community[1, ])
+  raw_data$community[1, ] <-
+    NA
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = FALSE,
+    check_levels = TRUE
+  )
+
+  expect_false(first_level %in% rownames(result$community))
+})
+
 # --------------------------------------------------- #
 # 5. BOTH FILTERING TESTS (check_taxa=TRUE, check_levels=TRUE)
 # --------------------------------------------------- #
 
-test_that("both filtering removes zero-sum taxa", {
-  raw_data <- 
+test_that(
+  "both filtering removes zero-sum taxa", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
+
   # one zero column in community
-  raw_data$community[,1] <- 0  
+  raw_data$community[, 1] <-
+    0
   # one zero row in community
-  raw_data$community[1,] <- 0 
-  
-  result <- reduce_data(
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
     data_source_reduce = raw_data,
     check_taxa = TRUE,
     check_levels = TRUE
   )
-  
+
   expect_false("zero_taxon" %in% colnames(result$community))
-})
-
-test_that("both filtering removes zero-sum levels", {
-  raw_data <- 
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  
-  first_level <- rownames(raw_data$community)[1]
-  raw_data$community[1,] <- 0
-
-  result <- reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
-  
-  expect_false(first_level %in% rownames(result$community))
-})
-
-test_that("both filtering removes taxa with zero observations", {
-  raw_data <- 
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  raw_data$community$zero_taxon <- 0
-
-  result <- reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
-  
   expect_true(all(colSums(result$community, na.rm = TRUE) > 0))
 })
 
-test_that("both filtering removes samples with zero taxa", {
-  raw_data <- 
+test_that(
+  "both filtering removes zero-sum levels", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -559,19 +677,60 @@ test_that("both filtering removes samples with zero taxa", {
       verbose = FALSE
     )
 
-  raw_data$community[1,] <- 0
+  first_level <-
+    rownames(raw_data$community)[1]
 
-  result <- reduce_data(
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
     data_source_reduce = raw_data,
     check_taxa = TRUE,
     check_levels = TRUE
   )
-  
+
+  expect_false(first_level %in% rownames(result$community))
+  expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
+  expect_false(first_level %in% rownames(result$community))
+  expect_false(first_level %in% rownames(result$age))
+  expect_false(first_level %in% colnames(result$age_un))
+})
+
+test_that(
+  "both filtering removes samples with zero taxa", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+
   expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
 })
 
-test_that("both filtering maintains matching rownames between community and age", {
-  raw_data <- 
+test_that(
+  "both filtering maintains matching rownames between community and age / age_un", {
+  raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -579,973 +738,409 @@ test_that("both filtering maintains matching rownames between community and age"
       verbose = FALSE
     )
 
-  raw_data$community$zero_taxon <- 0
-  raw_data$community[1,] <- 0
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
 
-  result <- reduce_data(
+  result <-
+    reduce_data(
     data_source_reduce = raw_data,
     check_taxa = TRUE,
     check_levels = TRUE
   )
-  
+
   expect_identical(rownames(result$community), rownames(result$age))
-  expect_identical(colnames(result$age_un), rownames(result$community))
+  expect_identical(rownames(result$community), colnames(result$age_un))
 })
 
+test_that(
+  "both filtering handles NULL age_un", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
 
+  # one zero column in community
+  raw_data$community$zero_taxon <-
+    0
 
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
 
+  # no uncertainty data
+  raw_data$age_un <-
+    NULL
 
+  expect_no_error(
+    result <-
+      reduce_data(
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+  )
 
-
-
-
-
-
-
-
-
-
+  expect_type(result, "list")
+  expect_named(
+    result,
+    c("community", "age")
+  )
+})
 
 
 # WIP below
 
 
-test_that("both filtering maintains matching colnames between age_un and community", {
-  data_smooth <- smooth_community_data(
-    data_source_smooth = extract_data(
+test_that(
+  "reduce_data works with a single sample in community", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
-    ),
-    smooth_method = "m.avg",
-    verbose = FALSE
-  )
-  
-  data_smooth$community$zero_taxon <- 0
-  data_smooth$community[1,] <- 0
-  
-  result <- reduce_data(
-    data_source_reduce = data_smooth,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
-  
-  expect_equal(colnames(result$age_un), rownames(result$community))
+    )
+
+  raw_data$community <-
+    raw_data$community[1, ]
+
+  result <-
+    reduce_data(raw_data)
+
+  expect_equal(nrow(result$community), 1)
+  expect_equal(nrow(result$age), 1)
+  expect_equal(ncol(result$age_un), 1)
 })
 
-test_that("both filtering with all zero data returns empty community", {
-  data_smooth <- smooth_community_data(
-    data_source_smooth = extract_data(
+
+test_that(
+  "reduce_data works with a single taxon in community", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]][1:2],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    result <-
+      reduce_data(raw_data)
+  )
+})
+
+
+
+# --------------------------------------------------- #
+# 6. All Zero Handling
+# --------------------------------------------------- #
+
+test_that(
+  "taxa filtering with all-zero community data returns empty community result", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
-    ),
-    smooth_method = "m.avg",
-    verbose = FALSE
+    )
+
+  raw_data$community[, ] <-
+    0
+
+  result <-
+    reduce_data(
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_equal(ncol(result$community), 0)
+  expect_false(nrow(result$age) == 0)
+  expect_false(ncol(result$age_un) == 0)
+})
+
+test_that(
+  "levels filtering with all zero levels returns empty result", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  raw_data$community[, ] <-
+    0
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = FALSE,
+    check_levels = TRUE
   )
-  
-  data_smooth$community[,] <- 0
-  
-  result <- reduce_data(
-    data_source_reduce = data_smooth,
+
+  expect_equal(nrow(result$community), 0)
+  expect_equal(nrow(result$age), 0)
+  expect_equal(ncol(result$age_un), 0)
+})
+
+test_that(
+  "both filtering with all zero data returns empty result", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  # all zero in community
+  raw_data$community[, ] <-
+    0
+
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
     check_taxa = TRUE,
     check_levels = TRUE
   )
-  
+
   expect_equal(ncol(result$community), 0)
   expect_equal(nrow(result$community), 0)
-})
-
-test_that("both filtering with all zero data returns empty age", {
-  data_smooth <- smooth_community_data(
-    data_source_smooth = extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    ),
-    smooth_method = "m.avg",
-    verbose = FALSE
-  )
-  
-  data_smooth$community[,] <- 0
-  
-  result <- reduce_data(
-    data_source_reduce = data_smooth,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
-  
   expect_equal(nrow(result$age), 0)
+  expect_equal(ncol(result$age_un), 0)
 })
 
-test_that("both filtering with all zero data handles age_un correctly", {
-  data_smooth <- smooth_community_data(
-    data_source_smooth = extract_data(
+
+test_that(
+  "reduce_data validates community has columns", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
-    ),
-    smooth_method = "m.avg",
-    verbose = FALSE
-  )
-  
-  data_smooth$community[,] <- 0
-  
-  result <- reduce_data(
-    data_source_reduce = data_smooth,
+    )
+
+  # 0 columns in community
+  raw_data$community <-
+    raw_data$community[, 0]
+
+  result <-
+    reduce_data(data_source_reduce = raw_data)
+
+  expect_equal(ncol(result$community), 0)
+  expect_equal(nrow(result$community), 0)
+  expect_equal(nrow(result$age), 0)
+  expect_equal(ncol(result$age_un), 0)
+})
+
+
+test_that(
+  "both filtering returns empty result if all data are NA", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+
+  raw_data$community[, ] <-
+    NA
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
     check_taxa = TRUE,
     check_levels = TRUE
   )
-  
-  expect_true(is.null(result$age_un) || ncol(result$age_un) == 0)
+
+  expect_equal(nrow(result$community), 0)
+  expect_equal(nrow(result$age), 0)
+  expect_equal(ncol(result$age_un), 0)
 })
 
-test_that("both filtering handles NULL age_un", {
-  data_smooth <- smooth_community_data(
-    data_source_smooth = extract_data(
+
+# --------------------------------------------------- #
+# 7. OUTPUT VALIDATION
+# --------------------------------------------------- #
+
+
+test_that(
+  "reduce_data produces valid output structure", {
+  raw_data <-
+    extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
-    ),
-    smooth_method = "m.avg",
-    verbose = FALSE
-  )
-  
-  data_smooth$age_un <- NULL
-  data_smooth$community$zero_taxon <- 0
-  data_smooth$community[1,] <- 0
-  
-  expect_no_error(
+    )
+
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
     reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = TRUE
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+
+  expect_type(
+    result, "list"
+  )
+
+  expect_named(
+    result,
+    c("community", "age", "age_un")
+  )
+})
+
+test_that(
+  "reduce_data produces valid community structure", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
+    reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+
+  expect_s3_class(
+    result$community,
+    "data.frame"
+  )
+
+  if (ncol(
+    result$community) > 0) {
+    expect_true(all(vapply(result$community, is.numeric, logical(1))))
+  }
+
+  expect_true(
+    !is.null(
+      rownames(
+        result$community
+      )
+    )
+  )
+
+  expect_true(
+    !is.null(
+      colnames(
+        result$community
+      )
     )
   )
 })
 
-# --------------------------------------------------- #
-# 2.7 All Levels Zero Handling
-# --------------------------------------------------- #
 
-test_that("reduce_data returns zero community rows when all levels are zero", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that(
+  "reduce_data produces valid age structure", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
-  test_all_levels_zero <- data_smooth
-  
-  test_all_levels_zero$community[, ] <- 0
-  
-  out_all_zero_levels <-
+
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
     reduce_data(
-      data_source_reduce = test_all_levels_zero,
-      check_taxa = FALSE,
-      check_levels = TRUE
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+
+  expect_s3_class(
+    result$age,
+    "data.frame"
+  )
+
+  expect_true(
+    "age" %in% colnames(result$age)
+  )
+
+  expect_true(
+    !is.null(
+      rownames(result$age)
     )
-  
+  )
+
   expect_equal(
-    nrow(out_all_zero_levels$community), 0
+    rownames(
+    result$age),
+    rownames(result$community)
   )
 })
 
-test_that("reduce_data returns zero age rows when all levels are zero", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that(
+  "reduce_data produces valid age_un structure", {
+  raw_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  
-  test_all_levels_zero <- data_smooth
-  
-  test_all_levels_zero$community[, ] <- 0
-  
-  out_all_zero_levels <-
+
+  # one zero column in community
+  raw_data$community[, 1] <-
+    0
+  # one zero row in community
+  raw_data$community[1, ] <-
+    0
+
+  result <-
     reduce_data(
-      data_source_reduce = test_all_levels_zero,
-      check_taxa = FALSE,
-      check_levels = TRUE
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+
+  if (!is.null(
+    result$age_un)) {
+    expect_true(
+      is.matrix(result$age_un) || is.data.frame(result$age_un)
     )
-  
+  }
+
   expect_equal(
-    nrow(out_all_zero_levels$age), 0
-  )
-})
-
-test_that("reduce_data returns zero age_un columns when all levels are zero", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  test_all_levels_zero <- data_smooth
-  
-  test_all_levels_zero$community[, ] <- 0
-  
-  out_all_zero_levels <-
-    reduce_data(
-      data_source_reduce = test_all_levels_zero,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
-  
-  expect_equal(
-    ncol(out_all_zero_levels$age_un), 0
-  )
-})
-
-# --------------------------------------------------- #
-# 3. INPUT VALIDATION TESTS
-# --------------------------------------------------- #
-
-# --------------------------------------------------- #
-# 3.1 Data Source Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates NULL data", {
-  expect_error(
-    reduce_data(data_source_reduce = NULL)
-  )
-})
-
-test_that("reduce_data validates string data input", {
-  expect_error(
-    reduce_data(data_source_reduce = "invalid")
-  )
-})
-
-test_that("reduce_data validates numeric data input", {
-  expect_error(
-    reduce_data(data_source_reduce = 123)
-  )
-})
-
-test_that("reduce_data validates data.frame data input", {
-  expect_error(
-    reduce_data(data_source_reduce = data.frame(x = 1))
-  )
-})
-
-test_that("reduce_data validates empty list", {
-  expect_error(
-    reduce_data(data_source_reduce = list())
-  )
-})
-
-# --------------------------------------------------- #
-# 3.2 Required Components Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates missing community component", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  incomplete_data <- list(age = data_smooth$age, age_un = data_smooth$age_un)
-  expect_error(
-    reduce_data(data_source_reduce = incomplete_data)
-  )
-})
-
-test_that("reduce_data validates missing age component", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  incomplete_data <- list(community = data_smooth$community, age_un = data_smooth$age_un)
-  expect_error(
-    reduce_data(data_source_reduce = incomplete_data)
-  )
-})
-
-# --------------------------------------------------- #
-# 3.3 Community Component Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates community is not a matrix", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community <- as.matrix(data_smooth$community)
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community is not a list", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community <- list(x = 1)
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community has rows", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community <- data_smooth$community[0, ]
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community has columns", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community <- data_smooth$community[, 0]
-  
-  expect_no_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community contains only numeric columns", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community$text_col <- "text"
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community must have sampleID/levels/rownames", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  rownames(data_smooth$community) <- NULL
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community must have colnames", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  colnames(data_smooth$community) <- NULL
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community cannot contain Inf values", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community[1, 1] <- Inf
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community cannot contain -Inf values", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$community[1, 1] <- -Inf
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-# --------------------------------------------------- #
-# 3.4 Age Component Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates age is a data.frame", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age <- as.matrix(data_smooth$age)
-  
-  expect_no_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age contains required age column", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age$age <- NULL
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age column is numeric", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age$age <- as.character(data_smooth$age$age)
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age must have sampleID/levels/rownames", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  rownames(data_smooth$age) <- NULL
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age column cannot contain NA values", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age$age[1] <- NA
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age column cannot contain Inf values", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age$age[1] <- Inf
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data allows negative values in age", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age$age[1] <- -1000
-  
-  expect_no_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-# --------------------------------------------------- #
-# 3.5 Age Uncertainty Component Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates age_un is not a list", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age_un <- list(x = 1)
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age_un is not a string", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age_un <- "invalid"
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-# --------------------------------------------------- #
-# 3.6 Cross-Component Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates community and age have same row counts", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age <- data_smooth$age[-1, ]
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates community and age have matching sampleID/levels/rownames", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  rownames(data_smooth$age)[1] <- "different_name"
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age_un dimensions match community", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  data_smooth$age_un <- data_smooth$age_un[, -1]
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-test_that("reduce_data validates age_un column names match community sampleID/levels/rownames", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  colnames(data_smooth$age_un)[1] <- "different_name"
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth)
-  )
-})
-
-# --------------------------------------------------- #
-# 3.7 Parameter Validation
-# --------------------------------------------------- #
-
-test_that("reduce_data validates check_taxa is not a string", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_taxa = "invalid")
-  )
-})
-
-test_that("reduce_data validates check_taxa is not numeric", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_taxa = 123)
-  )
-})
-
-test_that("reduce_data validates check_taxa is not NULL", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_taxa = NULL)
-  )
-})
-
-test_that("reduce_data validates check_taxa has length 1", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_taxa = c(TRUE, FALSE))
-  )
-})
-
-test_that("reduce_data validates check_levels is not a string", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_levels = "invalid")
-  )
-})
-
-test_that("reduce_data validates check_levels is not numeric", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_levels = 123)
-  )
-})
-
-test_that("reduce_data validates check_levels is not NULL", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_levels = NULL)
-  )
-})
-
-test_that("reduce_data validates check_levels has length 1", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_levels = c(TRUE, FALSE))
-  )
-})
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-  
-  expect_error(
-    reduce_data(data_source_reduce = data_smooth, check_levels = c(TRUE, FALSE))
+    colnames(result$age_un), rownames(result$age)
   )
 })

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -79,7 +79,8 @@ test_that("reduce_data rejects invalid check_taxa argument", {
     )
   expect_error(
     reduce_data(
-      data_source_reduce = raw_data, check_taxa = "TRUE"
+      data_source_reduce = raw_data,
+      check_taxa = "TRUE"
     ),
     "check_taxa.*logical"
   )
@@ -95,7 +96,8 @@ test_that("reduce_data rejects invalid check_taxa argument", {
     )
   expect_error(
     reduce_data(
-      data_source_reduce = raw_data, check_taxa = 123
+      data_source_reduce = raw_data,
+      check_taxa = 123
     ),
     "check_taxa.*logical"
   )
@@ -111,7 +113,8 @@ test_that("reduce_data rejects invalid check_taxa argument", {
     )
   expect_error(
     reduce_data(
-      data_source_reduce = raw_data, check_taxa = NULL
+      data_source_reduce = raw_data,
+      check_taxa = NULL
     ),
     "check_taxa.*logical"
   )
@@ -128,7 +131,8 @@ test_that("reduce_data rejects invalid check_levels argument", {
     )
   expect_error(
     reduce_data(
-      data_source_reduce = raw_data, check_levels = "TRUE"
+      data_source_reduce = raw_data,
+      check_levels = "TRUE"
     ),
     "check_levels.*logical"
   )
@@ -144,7 +148,8 @@ test_that("reduce_data rejects invalid check_levels argument", {
     )
   expect_error(
     reduce_data(
-      data_source_reduce = raw_data, check_levels = 123
+      data_source_reduce = raw_data,
+      check_levels = 123
     ),
     "check_levels.*logical"
   )
@@ -798,7 +803,6 @@ test_that("both filtering handles NULL age_un", {
 })
 
 
-
 test_that("reduce_data works with a single sample in community", {
   raw_data <-
     extract_data(
@@ -849,7 +853,7 @@ test_that("taxa filtering with all-zero community data throws error", {
       verbose = FALSE
     )
 
-  raw_data$community[, ] <-
+  raw_data$community[,] <-
     0
 
   expect_error(
@@ -871,7 +875,7 @@ test_that("levels filtering with all zero levels throws error", {
       verbose = FALSE
     )
 
-  raw_data$community[, ] <-
+  raw_data$community[,] <-
     0
 
   expect_error(
@@ -897,7 +901,7 @@ test_that("both filtering with all zero data throws error", {
     )
 
   # all zero in community
-  raw_data$community[, ] <-
+  raw_data$community[,] <-
     0
 
   expect_error(
@@ -941,7 +945,7 @@ test_that("both filtering throws error if all data are NA", {
       verbose = FALSE
     )
 
-  raw_data$community[, ] <-
+  raw_data$community[,] <-
     NA
 
   expect_error(
@@ -959,7 +963,6 @@ test_that("both filtering throws error if all data are NA", {
 # --------------------------------------------------- #
 # 7. OUTPUT VALIDATION
 # --------------------------------------------------- #
-
 
 test_that("reduce_data produces valid output structure", {
   raw_data <-
@@ -985,7 +988,8 @@ test_that("reduce_data produces valid output structure", {
     )
 
   expect_type(
-    result, "list"
+    result,
+    "list"
   )
 
   expect_named(
@@ -1120,7 +1124,8 @@ test_that("reduce_data produces valid age_un structure", {
   }
 
   expect_equal(
-    colnames(result$age_un), rownames(result$age)
+    colnames(result$age_un),
+    rownames(result$age)
   )
 })
 

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -21,56 +21,55 @@
 # --------------------------------------------------- #
 
 # 1.1 data_source_reduce validation
-test_that(
-  "reduce_data rejects NULL data_source_reduce", {
+test_that("reduce_data rejects NULL data_source_reduce", {
   expect_error(
     reduce_data(
-    data_source_reduce = NULL),
+      data_source_reduce = NULL
+    ),
     "data_source_reduce.*list"
   )
 })
 
-test_that(
-  "reduce_data rejects string data_source_reduce", {
+test_that("reduce_data rejects string data_source_reduce", {
   expect_error(
     reduce_data(
-    data_source_reduce = "invalid"),
+      data_source_reduce = "invalid"
+    ),
     "data_source_reduce.*list"
   )
 })
 
-test_that(
-  "reduce_data rejects numeric data_source_reduce", {
+test_that("reduce_data rejects numeric data_source_reduce", {
   expect_error(
     reduce_data(
-    data_source_reduce = 123),
+      data_source_reduce = 123
+    ),
     "data_source_reduce.*list"
   )
 })
 
-test_that(
-  "reduce_data rejects data.frame data_source_reduce", {
+test_that("reduce_data rejects data.frame data_source_reduce", {
   expect_error(
     reduce_data(
-    data_source_reduce = data.frame(
-    x = 1)),
+      data_source_reduce = data.frame(
+        x = 1
+      )
+    ),
     "data_source_reduce.*list"
   )
 })
 
-test_that(
-  "reduce_data rejects empty list data_source_reduce", {
+test_that("reduce_data rejects empty list data_source_reduce", {
   expect_error(
     reduce_data(
-    data_source_reduce = list(
-    )),
+      data_source_reduce = list()
+    ),
     "'x' must be an array of at least two dimensions"
   )
 })
 
 # 1.2 check_taxa validation
-test_that(
-  "reduce_data rejects invalid check_taxa argument", {
+test_that("reduce_data rejects invalid check_taxa argument", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -80,13 +79,13 @@ test_that(
     )
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data, check_taxa = "TRUE"),
+      data_source_reduce = raw_data, check_taxa = "TRUE"
+    ),
     "check_taxa.*logical"
   )
 })
 
-test_that(
-  "reduce_data rejects invalid check_taxa argument", {
+test_that("reduce_data rejects invalid check_taxa argument", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -96,13 +95,13 @@ test_that(
     )
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data, check_taxa = 123),
+      data_source_reduce = raw_data, check_taxa = 123
+    ),
     "check_taxa.*logical"
   )
 })
 
-test_that(
-  "reduce_data rejects invalid check_taxa argument", {
+test_that("reduce_data rejects invalid check_taxa argument", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -112,14 +111,14 @@ test_that(
     )
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data, check_taxa = NULL),
+      data_source_reduce = raw_data, check_taxa = NULL
+    ),
     "check_taxa.*logical"
   )
 })
 
 # 1.3 check_levels validation
-test_that(
-  "reduce_data rejects invalid check_levels argument", {
+test_that("reduce_data rejects invalid check_levels argument", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -129,13 +128,13 @@ test_that(
     )
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data, check_levels = "TRUE"),
+      data_source_reduce = raw_data, check_levels = "TRUE"
+    ),
     "check_levels.*logical"
   )
 })
 
-test_that(
-  "reduce_data rejects invalid check_levels argument", {
+test_that("reduce_data rejects invalid check_levels argument", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -145,13 +144,13 @@ test_that(
     )
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data, check_levels = 123),
+      data_source_reduce = raw_data, check_levels = 123
+    ),
     "check_levels.*logical"
   )
 })
 
-test_that(
-  "reduce_data rejects invalid check_levels argument", {
+test_that("reduce_data rejects invalid check_levels argument", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -169,8 +168,7 @@ test_that(
 })
 
 # 1.4 data_source_reduce structure validation
-test_that(
-  "reduce_data rejects missing community component", {
+test_that("reduce_data rejects missing community component", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -180,16 +178,19 @@ test_that(
     )
 
   incomplete_data <-
-    list(age = raw_data$age, age_un = raw_data$age_un)
+    list(
+      age = raw_data$age,
+      age_un = raw_data$age_un
+    )
   expect_error(
     reduce_data(
-    data_source_reduce = incomplete_data),
+      data_source_reduce = incomplete_data
+    ),
     "'x' must be an array of at least two dimensions"
   )
 })
 
-test_that(
-  "reduce_data rejects missing age component", {
+test_that("reduce_data rejects missing age component", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -199,16 +200,19 @@ test_that(
     )
 
   incomplete_data <-
-    list(community = raw_data$community, age_un = raw_data$age_un)
+    list(
+      community = raw_data$community,
+      age_un = raw_data$age_un
+    )
   expect_error(
     reduce_data(
-    data_source_reduce = incomplete_data),
+      data_source_reduce = incomplete_data
+    ),
     "Empty name found at location 1"
   )
 })
 
-test_that(
-  "reduce_data rejects community as matrix", {
+test_that("reduce_data rejects community as matrix", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -221,13 +225,13 @@ test_that(
     as.matrix(raw_data$community)
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "no applicable method for 'select'"
   )
 })
 
-test_that(
-  "reduce_data rejects age as matrix", {
+test_that("reduce_data rejects age as matrix", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -241,13 +245,13 @@ test_that(
 
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "is not TRUE"
   )
 })
 
-test_that(
-  "reduce_data rejects community as list", {
+test_that("reduce_data rejects community as list", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -261,13 +265,13 @@ test_that(
 
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "'x' must be an array of at least two dimensions"
   )
 })
 
-test_that(
-  "reduce_data rejects age as list", {
+test_that("reduce_data rejects age as list", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -281,13 +285,13 @@ test_that(
 
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "is not TRUE"
   )
 })
 
-test_that(
-  "reduce_data validates age_un is not a list", {
+test_that("reduce_data validates age_un is not a list", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -301,14 +305,14 @@ test_that(
 
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "incorrect number of dimensions"
   )
 })
 
 
-test_that(
-  "reduce_data rejects community with non-numeric columns", {
+test_that("reduce_data rejects community with non-numeric columns", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -321,13 +325,13 @@ test_that(
     "NA"
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "'x' must be numeric"
   )
 })
 
-test_that(
-  "reduce_data validates community must have colnames", {
+test_that("reduce_data validates community must have colnames", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -341,54 +345,55 @@ test_that(
 
   expect_error(
     reduce_data(
-    data_source_reduce = raw_data),
+      data_source_reduce = raw_data
+    ),
     "Can't select within an unnamed vector."
   )
 })
 
-test_that(
-  "reduce_data throws warning if community without rownames", {
-  raw_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  rownames(raw_data$community) <-
-    NULL
-  expect_warning(
-    result <-
-      reduce_data(data_source_reduce = raw_data)
-  )  # ,
-  # no warning implemented yet
-})
-
-test_that(
-  "reduce_data throws warning if age without rownames", {
-  raw_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  rownames(raw_data$age) <-
-    NULL
-  expect_warning(
-    reduce_data(data_source_reduce = raw_data)
-  ) # , 
-  # no warning implemented yet
-})
+# These might be unecessary - thus commented out right now:
+# test_that(
+#   "reduce_data throws warning if community without rownames", {
+#   raw_data <-
+#     extract_data(
+#       data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#       data_age_extract = RRatepol::example_data$sample_age[[1]],
+#       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#       verbose = FALSE
+#     )
+#
+#   rownames(raw_data$community) <-
+#     NULL
+#   expect_warning(
+#     result <-
+#       reduce_data(data_source_reduce = raw_data)
+#   )  # ,
+#   # no warning implemented yet
+# })
+#
+# test_that(
+#   "reduce_data throws warning if age without rownames", {
+#   raw_data <-
+#     extract_data(
+#       data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#       data_age_extract = RRatepol::example_data$sample_age[[1]],
+#       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#       verbose = FALSE
+#     )
+#
+#   rownames(raw_data$age) <-
+#     NULL
+#   expect_warning(
+#     reduce_data(data_source_reduce = raw_data)
+#   ) # ,
+#   # no warning implemented yet
+# })
 
 # --------------------------------------------------- #
 # 2. NO FILTERING TESTS (check_taxa=FALSE, check_levels=FALSE)
 # --------------------------------------------------- #
 
-test_that(
-  "reduce_data with no filtering returns identical data", {
+test_that("reduce_data with no filtering returns identical data", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -418,8 +423,7 @@ test_that(
 # 3. TAXA-ONLY FILTERING TESTS (check_taxa=TRUE, check_levels=FALSE)
 # --------------------------------------------------- #
 
-test_that(
-  "taxa filtering drops taxa with zero column sums", {
+test_that("taxa filtering drops taxa with zero column sums", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -444,8 +448,7 @@ test_that(
 })
 
 
-test_that(
-  "check_levels = FALSE preserves rownames / sample ids", {
+test_that("check_levels = FALSE preserves rownames / sample ids", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -473,8 +476,7 @@ test_that(
   expect_identical(colnames(raw_data$age_un), colnames(result$age_un))
 })
 
-test_that(
-  "taxa filtering removes all-NA taxa", {
+test_that("taxa filtering removes all-NA taxa", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -488,10 +490,10 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = FALSE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
 
   expect_false("na_taxon" %in% colnames(result$community))
 })
@@ -500,8 +502,7 @@ test_that(
 # 4. LEVELS-ONLY FILTERING TESTS (check_taxa=FALSE, check_levels=TRUE)
 # --------------------------------------------------- #
 
-test_that(
-  "levels filtering removes zero-sum levels from community and age", {
+test_that("levels filtering removes zero-sum levels from community and age", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -524,10 +525,10 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
   expect_false(first_level %in% rownames(result$community))
@@ -535,8 +536,7 @@ test_that(
   expect_false(first_level %in% colnames(result$age_un))
 })
 
-test_that(
-  "levels filtering preserves community colnames/taxa", {
+test_that("levels filtering preserves community colnames/taxa", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -554,16 +554,18 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
-  expect_identical(colnames(raw_data$community), colnames(result$community))
+  expect_identical(
+    colnames(raw_data$community),
+    colnames(result$community)
+  )
 })
 
-test_that(
-  "levels filtering maintains matching rownames between community and age and age_un", {
+test_that("levels filtering maintains matching rownames between community and age and age_un", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -581,18 +583,23 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
-  expect_identical(rownames(result$community), rownames(result$age))
-  expect_identical(rownames(result$community), colnames(result$age_un))
+  expect_identical(
+    rownames(result$community),
+    rownames(result$age)
+  )
+  expect_identical(
+    rownames(result$community),
+    colnames(result$age_un)
+  )
 })
 
 
-test_that(
-  "levels filtering works with NULL age_un", {
+test_that("levels filtering works with NULL age_un", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -612,8 +619,7 @@ test_that(
   )
 })
 
-test_that(
-  "levels filtering removes all-NA sample", {
+test_that("levels filtering removes all-NA sample", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -629,10 +635,10 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_false(first_level %in% rownames(result$community))
 })
@@ -641,8 +647,7 @@ test_that(
 # 5. BOTH FILTERING TESTS (check_taxa=TRUE, check_levels=TRUE)
 # --------------------------------------------------- #
 
-test_that(
-  "both filtering removes zero-sum taxa", {
+test_that("both filtering removes zero-sum taxa", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -660,17 +665,16 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_false("zero_taxon" %in% colnames(result$community))
   expect_true(all(colSums(result$community, na.rm = TRUE) > 0))
 })
 
-test_that(
-  "both filtering removes zero-sum levels", {
+test_that("both filtering removes zero-sum levels", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -691,10 +695,10 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_false(first_level %in% rownames(result$community))
   expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
@@ -703,8 +707,7 @@ test_that(
   expect_false(first_level %in% colnames(result$age_un))
 })
 
-test_that(
-  "both filtering removes samples with zero taxa", {
+test_that("both filtering removes samples with zero taxa", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -722,16 +725,15 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
 })
 
-test_that(
-  "both filtering maintains matching rownames between community and age / age_un", {
+test_that("both filtering maintains matching rownames between community and age / age_un", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -749,17 +751,16 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_identical(rownames(result$community), rownames(result$age))
   expect_identical(rownames(result$community), colnames(result$age_un))
 })
 
-test_that(
-  "both filtering handles NULL age_un", {
+test_that("both filtering handles NULL age_un", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -783,10 +784,10 @@ test_that(
   expect_no_error(
     result <-
       reduce_data(
-      data_source_reduce = raw_data,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
+        data_source_reduce = raw_data,
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
   )
 
   expect_type(result, "list")
@@ -798,9 +799,7 @@ test_that(
 
 
 
-
-test_that(
-  "reduce_data works with a single sample in community", {
+test_that("reduce_data works with a single sample in community", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -821,8 +820,7 @@ test_that(
 })
 
 
-test_that(
-  "reduce_data works with a single taxon in community", {
+test_that("reduce_data works with a single taxon in community", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]][1:2],
@@ -838,13 +836,11 @@ test_that(
 })
 
 
-
 # --------------------------------------------------- #
 # 6. All Zero Handling
 # --------------------------------------------------- #
 
-test_that(
-  "taxa filtering with all-zero community data returns empty community result", {
+test_that("taxa filtering with all-zero community data throws error", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -856,20 +852,17 @@ test_that(
   raw_data$community[, ] <-
     0
 
-  result <-
+  expect_error(
     reduce_data(
       data_source_reduce = raw_data,
       check_taxa = TRUE,
       check_levels = FALSE
-    )
-
-  expect_equal(ncol(result$community), 0)
-  expect_false(nrow(result$age) == 0)
-  expect_false(ncol(result$age_un) == 0)
+    ),
+    # none programmed into function yet
+  )
 })
 
-test_that(
-  "levels filtering with all zero levels returns empty result", {
+test_that("levels filtering with all zero levels throws error", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -881,20 +874,20 @@ test_that(
   raw_data$community[, ] <-
     0
 
-  result <-
-    reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = FALSE,
-    check_levels = TRUE
+  expect_error(
+    result <-
+      reduce_data(
+        data_source_reduce = raw_data,
+        check_taxa = FALSE,
+        check_levels = TRUE
+      ),
+    # no error programmed into function yet
+    # e.g.,
+    # "No valid data available after filtering"
   )
-
-  expect_equal(nrow(result$community), 0)
-  expect_equal(nrow(result$age), 0)
-  expect_equal(ncol(result$age_un), 0)
 })
 
-test_that(
-  "both filtering with all zero data returns empty result", {
+test_that("both filtering with all zero data throws error", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -907,23 +900,17 @@ test_that(
   raw_data$community[, ] <-
     0
 
-
-  result <-
+  expect_error(
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ),
+    # none programmed into function yet
   )
-
-  expect_equal(ncol(result$community), 0)
-  expect_equal(nrow(result$community), 0)
-  expect_equal(nrow(result$age), 0)
-  expect_equal(ncol(result$age_un), 0)
 })
 
-
-test_that(
-  "reduce_data validates community has columns", {
+test_that("reduce_data throws error if community has no columns", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -936,18 +923,16 @@ test_that(
   raw_data$community <-
     raw_data$community[, 0]
 
-  result <-
-    reduce_data(data_source_reduce = raw_data)
-
-  expect_equal(ncol(result$community), 0)
-  expect_equal(nrow(result$community), 0)
-  expect_equal(nrow(result$age), 0)
-  expect_equal(ncol(result$age_un), 0)
+  expect_error(
+    reduce_data(data_source_reduce = raw_data),
+    # none programmed into function yet
+    # e.g.,
+    # "community must have at least one taxon"
+  )
 })
 
 
-test_that(
-  "both filtering returns empty result if all data are NA", {
+test_that("both filtering throws error if all data are NA", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -956,30 +941,27 @@ test_that(
       verbose = FALSE
     )
 
-
   raw_data$community[, ] <-
     NA
 
-  result <-
+  expect_error(
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ),
+    # none programmed into function yet
+    # e.g.,
+    # "No valid data available after filtering"
   )
-
-  expect_equal(nrow(result$community), 0)
-  expect_equal(nrow(result$age), 0)
-  expect_equal(ncol(result$age_un), 0)
 })
-
 
 # --------------------------------------------------- #
 # 7. OUTPUT VALIDATION
 # --------------------------------------------------- #
 
 
-test_that(
-  "reduce_data produces valid output structure", {
+test_that("reduce_data produces valid output structure", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -997,10 +979,10 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_type(
     result, "list"
@@ -1012,8 +994,7 @@ test_that(
   )
 })
 
-test_that(
-  "reduce_data produces valid community structure", {
+test_that("reduce_data produces valid community structure", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1031,18 +1012,17 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_s3_class(
     result$community,
     "data.frame"
   )
 
-  if (ncol(
-    result$community) > 0) {
+  if (ncol(result$community) > 0) {
     expect_true(all(vapply(result$community, is.numeric, logical(1))))
   }
 
@@ -1064,8 +1044,7 @@ test_that(
 })
 
 
-test_that(
-  "reduce_data produces valid age structure", {
+test_that("reduce_data produces valid age structure", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1083,10 +1062,10 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_s3_class(
     result$age,
@@ -1105,13 +1084,13 @@ test_that(
 
   expect_equal(
     rownames(
-    result$age),
+      result$age
+    ),
     rownames(result$community)
   )
 })
 
-test_that(
-  "reduce_data produces valid age_un structure", {
+test_that("reduce_data produces valid age_un structure", {
   raw_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1129,13 +1108,12 @@ test_that(
 
   result <-
     reduce_data(
-    data_source_reduce = raw_data,
-    check_taxa = TRUE,
-    check_levels = TRUE
-  )
+      data_source_reduce = raw_data,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
-  if (!is.null(
-    result$age_un)) {
+  if (!is.null(result$age_un)) {
     expect_true(
       is.matrix(result$age_un) || is.data.frame(result$age_un)
     )
@@ -1146,4 +1124,41 @@ test_that(
   )
 })
 
+## This might be a good improvement to the function: reduce two-way in case there are NAs in age
+test_that("reduce_data function drops all-NA samples in age from community?", {
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age$age[1] <-
+    NA # make row all-NA
+  NA_sample <-
+    age[1, ]$sample_id
+  valid_samples <-
+    setdiff(age$sample_id, NA_sample)
 
+  dta <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = age,
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    )
+
+  res <-
+    reduce_data(
+      data_source_reduce = dta,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  expect_identical(
+    rownames(res$community),
+    valid_samples
+  )
+  expect_identical(
+    rownames(res$age),
+    valid_samples
+  )
+  expect_identical(
+    colnames(res$age_un),
+    valid_samples
+  )
+})

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -262,7 +262,7 @@ test_that(
   expect_error(
     reduce_data(
     data_source_reduce = raw_data),
-    "no applicable method for 'select'"
+    "'x' must be an array of at least two dimensions"
   )
 })
 
@@ -282,7 +282,7 @@ test_that(
   expect_error(
     reduce_data(
     data_source_reduce = raw_data),
-    "no applicable method for 'select'"
+    "is not TRUE"
   )
 })
 
@@ -1144,3 +1144,4 @@ test_that(
     colnames(result$age_un), rownames(result$age)
   )
 })
+

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -463,56 +463,6 @@ test_that("reduce_data handles all-zero levels correctly", {
   
 })
 
-# Test 10a: Correct output structure
-test_that("reduce_data returns correct structure and format", {
-
-  out <- 
-    reduce_data(
-      data_smooth, 
-      check_taxa = TRUE, 
-      check_levels = TRUE)
-  
-  check_reduce_data_structure(out)
-  
-})
-
-# Test 10b: Correct output structure
-test_that("reduce_data returns correct structure and format", {
-  
-  out <- 
-    reduce_data(
-      data_smooth, 
-      check_taxa = FALSE, 
-      check_levels = TRUE)
-  
-  check_reduce_data_structure(out)
-  
-})
-
-# Test 10c: Correct output structure
-test_that("reduce_data returns correct structure and format", {
-  
-  out <- 
-    reduce_data(
-      data_smooth, 
-      check_taxa = TRUE, 
-      check_levels = FALSE)
-  
-  check_reduce_data_structure(out)
-  
-})
-
-# Test 10d: Correct output structure
-test_that("reduce_data returns correct structure and format", {
-  
-  out <- 
-    reduce_data(
-      data_smooth, 
-      check_taxa = FALSE, 
-      check_levels = FALSE)
-  
-check_reduce_data_structure(out)
-})
 
 
 

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -1,324 +1,536 @@
-# --------------------------------------------------- #
-# Load and prepare example smoothed data
-# --------------------------------------------------- #
-
-data_smooth <-
-  extract_data(
-    RRatepol::example_data$pollen_data[[1]],
-    RRatepol::example_data$sample_age[[1]],
-    RRatepol::example_data$age_uncertainty[[1]]
-  ) %>%
-  smooth_community_data(
-    smooth_method = c("m.avg"),
-    smooth_n_points = 5,
-    smooth_n_max = 9,
-    smooth_age_range = 500,
-    round_results = FALSE,
-    verbose = FALSE
-  )
-
-
-# Store full taxa and levels
-full_taxa <-
-  colnames(data_smooth$community)
-
-full_levels <-
-  rownames(data_smooth$community)
+# ==================================================================== #
+#                        TESTS FOR reduce_data()                      #
+# ==================================================================== #
+#
+# This file contains comprehensive tests for the reduce_data() function
+# which filters taxa and/or levels based on zero-sum criteria.
+#
+# Test structure:
+# 1. Basic Functionality Tests
+# 2. Edge Case Tests  
+# 3. Input Validation Tests
+#
+# ==================================================================== #
 
 # --------------------------------------------------- #
-# Helper function to validate output structure
+# 1. BASIC FUNCTIONALITY TESTS
 # --------------------------------------------------- #
 
-check_reduce_data_structure <- function(out) {
-  # ---- Top-level structure ----
-  expect_type(
-    out, "list"
-  )
+# --------------------------------------------------- #
+# 1.1 Taxa Reduction Only
+# --------------------------------------------------- #
 
-  expect_named(
-    out,
-    c("community", "age", "age_un")
-  )
-
-  # ---- community ----
-  expect_s3_class(
-    out$community,
-    "data.frame"
-  )
-
-  if (ncol(out$community) > 0) {
-    expect_true(all(vapply(out$community, is.numeric, logical(1))))
-  }
-
-  expect_true(
-    !is.null(
-      rownames(
-        out$community
-      )
-    )
-  )
-
-  expect_true(
-    !is.null(
-      colnames(
-        out$community
-      )
-    )
-  )
-
-  # ---- age ----
-  expect_s3_class(
-    out$age,
-    "data.frame"
-  )
-
-  expect_true(
-    "age" %in% colnames(out$age)
-  )
-
-  expect_true(
-    !is.null(
-      rownames(out$age)
-    )
-  )
-
-  expect_equal(
-    rownames(out$age),
-    rownames(out$community)
-  )
-
-  # ---- age_un ----
-  if (!is.null(out$age_un)) {
-    expect_true(
-      is.matrix(out$age_un) || is.data.frame(out$age_un)
+test_that("reduce_data preserves rownames when filtering taxa only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
     )
 
-    expect_equal(
-      colnames(out$age_un), rownames(out$community)
-    )
-  }
-}
-
-# --------------------------------------------------- #
-# Modified data for edge cases
-# --------------------------------------------------- #
-
-# 1 taxon with zeros
-test_data_zeros <-
-  data_smooth
-
-test_data_zeros$community$fake_taxon <-
-  0
-
-# all taxa zero
-test_all_taxa_zero <-
-  data_smooth
-
-test_all_taxa_zero$community[, ] <-
-  0
-
-# 1 taxon with NA in community
-test_data_NA_taxon <-
-  data_smooth
-
-test_data_NA_taxon$community$na_taxon <-
-  NA
-
-# 1 level with zeros
-test_data_empty_levels <-
-  data_smooth
-
-test_data_empty_levels$community["fake_level", ] <-
-  0
-
-test_data_empty_levels$age["fake_level", ] <-
-  9999
-
-test_data_empty_levels$age_un <-
-  cbind(
-    test_data_empty_levels$age_un,
-    "fake_level" = rep(0, nrow(test_data_empty_levels$age_un))
-  )
-
-# all levels zero
-test_all_levels_zero <-
-  data_smooth
-
-test_all_levels_zero$community[, ] <-
-  0
-
-# without age_un matrix
-data_null_age_un <-
-  data_smooth
-
-data_null_age_un$age_un <-
-  NULL
-
-
-# --------------------------------------------------- #
-# Test 1: test taxa reduction only
-# --------------------------------------------------- #
-
-test_that("reduce_data filters taxa correctly using smoothed example data", {
   out_taxa <-
     reduce_data(
-      data_smooth,
+      data_source_reduce = data_smooth,
       check_taxa = TRUE,
       check_levels = FALSE
     )
 
   expect_true(
-    all(
-      rownames(out_taxa$community) == rownames(data_smooth$community)
-    )
+    all(rownames(data_smooth$community) == rownames(out_taxa$community))
   )
-
-  expect_true(
-    all(
-      colSums(out_taxa$community, na.rm = TRUE) > 0
-    )
-  )
-
-  expect_lte(
-    ncol(out_taxa$community), length(full_taxa)
-  )
-
-  check_reduce_data_structure(out_taxa)
 })
 
+test_that("reduce_data removes zero-sum taxa when filtering taxa only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_taxa <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_true(
+    all(colSums(out_taxa$community, na.rm = TRUE) > 0)
+  )
+})
+
+test_that("reduce_data reduces or maintains number of taxa when filtering taxa only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  full_taxa <- ncol(data_smooth$community)
+
+  out_taxa <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_lte(
+    ncol(out_taxa$community), full_taxa
+  )
+})
+
+test_that("reduce_data returns valid structure when filtering taxa only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_taxa <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_type(
+    out_taxa, "list"
+  )
+})
 
 # --------------------------------------------------- #
-# Test 2: test level reduction only
+# 1.2 Level Reduction Only
 # --------------------------------------------------- #
-test_that("reduce_data filters levels correctly using smoothed example data", {
+
+test_that("reduce_data preserves colnames when filtering levels only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
   out_levels <-
     reduce_data(
-      data_smooth,
+      data_source_reduce = data_smooth,
       check_taxa = FALSE,
       check_levels = TRUE
     )
 
   expect_true(
-    all(
-      colnames(out_levels$community) == colnames(data_smooth$community)
-    )
+    all(colnames(data_smooth$community) == colnames(out_levels$community))
   )
+})
+
+test_that("reduce_data removes zero-sum levels when filtering levels only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_levels <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_true(
     all(rowSums(out_levels$community, na.rm = TRUE) > 0)
   )
+})
+
+test_that("reduce_data reduces or maintains number of levels when filtering levels only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  full_levels <- nrow(data_smooth$community)
+
+  out_levels <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_lte(
-    nrow(out_levels$community), length(full_levels)
+    nrow(out_levels$community), full_levels
   )
+})
+
+test_that("reduce_data maintains matching rownames between age and community when filtering levels only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_levels <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_equal(
-    rownames(out_levels$age), rownames(out_levels$community)
+    rownames(out_levels$community), rownames(out_levels$age)
   )
+})
+
+test_that("reduce_data maintains matching colnames between age_un and community when filtering levels only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_levels <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_equal(
     colnames(out_levels$age_un), rownames(out_levels$community)
   )
-
-  check_reduce_data_structure(out_levels)
 })
 
 # --------------------------------------------------- #
-# Test 3: test both at the same time
+# 1.3 Both Taxa and Levels Filtering
 # --------------------------------------------------- #
-test_that("reduce_data filters taxa and levels correctly using smoothed example data", {
+
+test_that("reduce_data removes zero-sum levels when filtering both taxa and levels", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
   out_both <-
     reduce_data(
-      data_smooth,
+      data_source_reduce = data_smooth,
       check_taxa = TRUE,
       check_levels = TRUE
     )
 
   expect_true(
-    all(
-      rowSums(out_both$community, na.rm = TRUE) > 0
-    )
+    all(rowSums(out_both$community, na.rm = TRUE) > 0)
   )
+})
+
+test_that("reduce_data removes zero-sum taxa when filtering both taxa and levels", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_both <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_true(
-    all(
-      colSums(out_both$community, na.rm = TRUE) > 0
-    )
+    all(colSums(out_both$community, na.rm = TRUE) > 0)
   )
+})
+
+test_that("reduce_data maintains matching rownames between age and community when filtering both", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_both <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_equal(
-    rownames(out_both$age), rownames(out_both$community)
+    rownames(out_both$community), rownames(out_both$age)
   )
+})
+
+test_that("reduce_data maintains matching colnames between age_un and community when filtering both", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  out_both <-
+    reduce_data(
+      data_source_reduce = data_smooth,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_equal(
     colnames(out_both$age_un), rownames(out_both$community)
   )
-
-  # Test: NULL age_un is handled
-  expect_no_error(
-    reduce_data(
-      data_null_age_un
-    )
-  )
-
-  check_reduce_data_structure(out_both)
 })
 
+# --------------------------------------------------- #
+# 1.4 No Filtering
+# --------------------------------------------------- #
 
-# --------------------------------------------------- #
-# Test 4: FALSE input doesn't reduce the data
-# --------------------------------------------------- #
-test_that("reduce_data with both = FALSE doesn't change the data", {
-  # Control: no filtering needed
+test_that("reduce_data with both FALSE doesn't change the data", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
   no_filter <-
     reduce_data(
-      data_smooth,
+      data_source_reduce = data_smooth,
       check_taxa = FALSE,
       check_levels = FALSE
     )
 
   expect_equal(
-    no_filter,
-    data_smooth
+    data_smooth, no_filter
   )
-
-  check_reduce_data_structure(no_filter)
 })
 
-
+# --------------------------------------------------- #
+# 2. EDGE CASE TESTS
+# --------------------------------------------------- #
 
 # --------------------------------------------------- #
-# Test 5: all-zero taxa
+# 2.1 NULL age_un Handling
 # --------------------------------------------------- #
-test_that("reduce_data handles taxa with all-zeros in samples correctly", {
+
+test_that("reduce_data handles NULL age_un correctly when filtering both", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_null_age_un <- data_smooth
+
+  data_null_age_un$age_un <- NULL
+
+  expect_no_error(
+    reduce_data(
+      data_source_reduce = data_null_age_un,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+  )
+})
+
+# --------------------------------------------------- #
+# 2.2 Zero Taxa Handling
+# --------------------------------------------------- #
+
+test_that("reduce_data preserves rownames when removing zero taxa", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_data_zeros <- data_smooth
+
+  test_data_zeros$community$fake_taxon <- 0
+
   out_zeros <-
     reduce_data(
-      test_data_zeros,
+      data_source_reduce = test_data_zeros,
       check_taxa = TRUE,
       check_levels = FALSE
     )
 
   expect_equal(
-    rownames(out_zeros$community),
-    rownames(test_data_zeros$community)
+    rownames(test_data_zeros$community), rownames(out_zeros$community)
   )
-
-  expect_lt(
-    ncol(out_zeros$community),
-    ncol(test_data_zeros$community)
-  )
-
-  check_reduce_data_structure(out_zeros)
 })
 
+test_that("reduce_data reduces number of columns when removing zero taxa", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_data_zeros <- data_smooth
+
+  test_data_zeros$community$fake_taxon <- 0
+
+  out_zeros <-
+    reduce_data(
+      data_source_reduce = test_data_zeros,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_lt(
+    ncol(out_zeros$community), ncol(test_data_zeros$community)
+  )
+})
 
 # --------------------------------------------------- #
-# Test 6: all-zero levels
+# 2.3 Zero Levels Handling
 # --------------------------------------------------- #
-test_that("reduce_data handles levels with all-zeros in samples correctly", {
+
+test_that("reduce_data removes fake level from community when filtering levels", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_data_empty_levels <- data_smooth
+
+  test_data_empty_levels$community["fake_level", ] <- 0
+
+  test_data_empty_levels$age["fake_level", ] <- 9999
+
+  test_data_empty_levels$age_un <-
+    cbind(
+      test_data_empty_levels$age_un,
+      fake_level = rep(9999, nrow(test_data_empty_levels$age_un))
+    )
+
   out_empty_levels <-
     reduce_data(
-      test_data_empty_levels,
+      data_source_reduce = test_data_empty_levels,
       check_taxa = FALSE,
       check_levels = TRUE
     )
@@ -326,25 +538,109 @@ test_that("reduce_data handles levels with all-zeros in samples correctly", {
   expect_false(
     "fake_level" %in% rownames(out_empty_levels$community)
   )
+})
+
+test_that("reduce_data removes fake level from age when filtering levels", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_data_empty_levels <- data_smooth
+
+  test_data_empty_levels$community["fake_level", ] <- 0
+
+  test_data_empty_levels$age["fake_level", ] <- 9999
+
+  test_data_empty_levels$age_un <-
+    cbind(
+      test_data_empty_levels$age_un,
+      fake_level = rep(9999, nrow(test_data_empty_levels$age_un))
+    )
+
+  out_empty_levels <-
+    reduce_data(
+      data_source_reduce = test_data_empty_levels,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_false(
     "fake_level" %in% rownames(out_empty_levels$age)
   )
+})
+
+test_that("reduce_data removes fake level from age_un when filtering levels", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_data_empty_levels <- data_smooth
+
+  test_data_empty_levels$community["fake_level", ] <- 0
+
+  test_data_empty_levels$age["fake_level", ] <- 9999
+
+  test_data_empty_levels$age_un <-
+    cbind(
+      test_data_empty_levels$age_un,
+      fake_level = rep(9999, nrow(test_data_empty_levels$age_un))
+    )
+
+  out_empty_levels <-
+    reduce_data(
+      data_source_reduce = test_data_empty_levels,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_false(
     "fake_level" %in% colnames(out_empty_levels$age_un)
   )
-
-  check_reduce_data_structure(out_empty_levels)
 })
+
 # --------------------------------------------------- #
-# Test 7: NA taxa
+# 2.4 NA Taxa Handling
 # --------------------------------------------------- #
 
-test_that("reduce_data handles NA in taxon (community) correctly", {
+test_that("reduce_data removes NA taxon from community", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_data_NA_taxon <- data_smooth
+
+  test_data_NA_taxon$community$na_taxon <- NA
+
   out_NA_taxon <-
     reduce_data(
-      test_data_NA_taxon,
+      data_source_reduce = test_data_NA_taxon,
       check_taxa = TRUE,
       check_levels = FALSE
     )
@@ -352,100 +648,1002 @@ test_that("reduce_data handles NA in taxon (community) correctly", {
   expect_false(
     "na_taxon" %in% colnames(out_NA_taxon$community)
   )
-
-  check_reduce_data_structure(out_NA_taxon)
 })
 
 # --------------------------------------------------- #
-# Test 8: if all Taxa are zero
+# 2.5 All Taxa Zero - Taxa Filtering Only
 # --------------------------------------------------- #
-test_that("reduce_data handles all-zero community data correctly", {
-  # Test: all taxa zero — everything from community data should be removed
-  # only taxa (no level reduction)
+
+test_that("reduce_data returns zero columns when all taxa are zero with taxa filtering only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_taxa_zero <- data_smooth
+
+  test_all_taxa_zero$community[, ] <- 0
+
   out_all_zero_taxa <-
     reduce_data(
-      test_all_taxa_zero,
+      data_source_reduce = test_all_taxa_zero,
       check_taxa = TRUE,
       check_levels = FALSE
     )
 
   expect_true(
-    ncol(
-      out_all_zero_taxa$community
-    ) == 0
+    ncol(out_all_zero_taxa$community) == 0
   )
+})
 
-  expect_true(
-    nrow(
-      out_all_zero_taxa$age
-    ) != 0
-  )
+test_that("reduce_data preserves age rows when all taxa are zero with taxa filtering only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
 
+  test_all_taxa_zero <- data_smooth
 
-  expect_false(
-    ncol(
-      out_all_zero_taxa$age_un
-    ) == 0
-  )
+  test_all_taxa_zero$community[, ] <- 0
 
-
-  # with levels
   out_all_zero_taxa <-
     reduce_data(
-      test_all_taxa_zero,
+      data_source_reduce = test_all_taxa_zero,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_true(
+    nrow(out_all_zero_taxa$age) == nrow(data_smooth$age)
+  )
+})
+
+test_that("reduce_data preserves age_un columns when all taxa are zero with taxa filtering only", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_taxa_zero <- data_smooth
+
+  test_all_taxa_zero$community[, ] <- 0
+
+  out_all_zero_taxa <-
+    reduce_data(
+      data_source_reduce = test_all_taxa_zero,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_false(
+    is.null(out_all_zero_taxa$age_un)
+  )
+})
+
+# --------------------------------------------------- #
+# 2.6 All Taxa Zero - Both Taxa and Levels Filtering
+# --------------------------------------------------- #
+
+test_that("reduce_data returns zero columns when all taxa are zero with both filtering", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_taxa_zero <- data_smooth
+
+  test_all_taxa_zero$community[, ] <- 0
+
+  out_all_zero_taxa <-
+    reduce_data(
+      data_source_reduce = test_all_taxa_zero,
       check_taxa = TRUE,
       check_levels = TRUE
     )
 
   expect_true(
-    ncol(
-      out_all_zero_taxa$community
-    ) == 0
+    ncol(out_all_zero_taxa$community) == 0
   )
+})
+
+test_that("reduce_data returns zero rows when all taxa are zero with both filtering", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_taxa_zero <- data_smooth
+
+  test_all_taxa_zero$community[, ] <- 0
+
+  out_all_zero_taxa <-
+    reduce_data(
+      data_source_reduce = test_all_taxa_zero,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_true(
-    nrow(
-      out_all_zero_taxa$age
-    ) == 0
+    nrow(out_all_zero_taxa$community) == 0
   )
+})
+
+test_that("reduce_data returns zero age_un columns when all taxa are zero with both filtering", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_taxa_zero <- data_smooth
+
+  test_all_taxa_zero$community[, ] <- 0
+
+  out_all_zero_taxa <-
+    reduce_data(
+      data_source_reduce = test_all_taxa_zero,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
 
   expect_true(
-    ncol(
-      out_all_zero_taxa$age_un
-    ) == 0
+    is.null(out_all_zero_taxa$age_un) || ncol(out_all_zero_taxa$age_un) == 0
   )
-
-  check_reduce_data_structure(out_all_zero_taxa)
 })
 
 # --------------------------------------------------- #
-# Test 9: if all levels are zero
+# 2.7 All Levels Zero Handling
 # --------------------------------------------------- #
-test_that("reduce_data handles all-zero levels correctly", {
+
+test_that("reduce_data returns zero community rows when all levels are zero", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_levels_zero <- data_smooth
+
+  test_all_levels_zero$community[, ] <- 0
+
   out_all_zero_levels <-
     reduce_data(
-      test_all_levels_zero,
+      data_source_reduce = test_all_levels_zero,
       check_taxa = FALSE,
       check_levels = TRUE
     )
 
   expect_equal(
-    nrow(
-      out_all_zero_levels$community
-    ), 0
+    nrow(out_all_zero_levels$community), 0
   )
+})
+
+test_that("reduce_data returns zero age rows when all levels are zero", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_levels_zero <- data_smooth
+
+  test_all_levels_zero$community[, ] <- 0
+
+  out_all_zero_levels <-
+    reduce_data(
+      data_source_reduce = test_all_levels_zero,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_equal(
-    nrow(
-      out_all_zero_levels$age
-    ), 0
+    nrow(out_all_zero_levels$age), 0
   )
+})
+
+test_that("reduce_data returns zero age_un columns when all levels are zero", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  test_all_levels_zero <- data_smooth
+
+  test_all_levels_zero$community[, ] <- 0
+
+  out_all_zero_levels <-
+    reduce_data(
+      data_source_reduce = test_all_levels_zero,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
 
   expect_equal(
-    ncol(
-      out_all_zero_levels$age_un
-    ), 0
+    ncol(out_all_zero_levels$age_un), 0
   )
+})
 
-  check_reduce_data_structure(out_all_zero_levels)
+# --------------------------------------------------- #
+# 3. INPUT VALIDATION TESTS
+# --------------------------------------------------- #
+
+# --------------------------------------------------- #
+# 3.1 Data Source Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates NULL data", {
+  expect_error(
+    reduce_data(data_source_reduce = NULL)
+  )
+})
+
+test_that("reduce_data validates string data input", {
+  expect_error(
+    reduce_data(data_source_reduce = "invalid")
+  )
+})
+
+test_that("reduce_data validates numeric data input", {
+  expect_error(
+    reduce_data(data_source_reduce = 123)
+  )
+})
+
+test_that("reduce_data validates data.frame data input", {
+  expect_error(
+    reduce_data(data_source_reduce = data.frame(x = 1))
+  )
+})
+
+test_that("reduce_data validates empty list", {
+  expect_error(
+    reduce_data(data_source_reduce = list())
+  )
+})
+
+# --------------------------------------------------- #
+# 3.2 Required Components Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates missing community component", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  incomplete_data <- list(age = data_smooth$age, age_un = data_smooth$age_un)
+  expect_error(
+    reduce_data(data_source_reduce = incomplete_data)
+  )
+})
+
+test_that("reduce_data validates missing age component", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  incomplete_data <- list(community = data_smooth$community, age_un = data_smooth$age_un)
+  expect_error(
+    reduce_data(data_source_reduce = incomplete_data)
+  )
+})
+
+# --------------------------------------------------- #
+# 3.3 Community Component Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates community is not a matrix", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community <- as.matrix(data_smooth$community)
+
+  expect_no_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community is not a list", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community <- list(x = 1)
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community has rows", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community <- data_smooth$community[0, ]
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community has columns", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community <- data_smooth$community[, 0]
+
+  expect_no_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community contains only numeric columns", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community$text_col <- "text"
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community must have rownames", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  rownames(data_smooth$community) <- NULL
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community must have colnames", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  colnames(data_smooth$community) <- NULL
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community cannot contain Inf values", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community[1, 1] <- Inf
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community cannot contain -Inf values", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$community[1, 1] <- -Inf
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+# --------------------------------------------------- #
+# 3.4 Age Component Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates age is a data.frame", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age <- as.matrix(data_smooth$age)
+
+  expect_no_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age contains required age column", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age$age <- NULL
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age column is numeric", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age$age <- as.character(data_smooth$age$age)
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age must have rownames", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  rownames(data_smooth$age) <- NULL
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age column cannot contain NA values", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age$age[1] <- NA
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age column cannot contain Inf values", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age$age[1] <- Inf
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data allows negative values in age", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age$age[1] <- -1000
+
+  expect_no_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+# --------------------------------------------------- #
+# 3.5 Age Uncertainty Component Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates age_un is not a list", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age_un <- list(x = 1)
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age_un is not a string", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age_un <- "invalid"
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+# --------------------------------------------------- #
+# 3.6 Cross-Component Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates community and age have same row counts", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age <- data_smooth$age[-1, ]
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates community and age have matching row names", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  rownames(data_smooth$age)[1] <- "different_name"
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age_un dimensions match community", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  data_smooth$age_un <- data_smooth$age_un[, -1]
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+test_that("reduce_data validates age_un column names match community row names", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  colnames(data_smooth$age_un)[1] <- "different_name"
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth)
+  )
+})
+
+# --------------------------------------------------- #
+# 3.7 Parameter Validation
+# --------------------------------------------------- #
+
+test_that("reduce_data validates check_taxa is not a string", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_taxa = "invalid")
+  )
+})
+
+test_that("reduce_data validates check_taxa is not numeric", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_taxa = 123)
+  )
+})
+
+test_that("reduce_data validates check_taxa is not NULL", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_taxa = NULL)
+  )
+})
+
+test_that("reduce_data validates check_taxa has length 1", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_taxa = c(TRUE, FALSE))
+  )
+})
+
+test_that("reduce_data validates check_levels is not a string", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_levels = "invalid")
+  )
+})
+
+test_that("reduce_data validates check_levels is not numeric", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_levels = 123)
+  )
+})
+
+test_that("reduce_data validates check_levels is not NULL", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_levels = NULL)
+  )
+})
+
+test_that("reduce_data validates check_levels has length 1", {
+  data_smooth <-
+    smooth_community_data(
+      data_source_smooth =
+        extract_data(
+          data_community_extract = RRatepol::example_data$pollen_data[[1]],
+          data_age_extract = RRatepol::example_data$sample_age[[1]],
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_levels = c(TRUE, FALSE))
+  )
 })

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -6,835 +6,726 @@
 # which filters taxa and/or levels based on zero-sum criteria.
 #
 # Test structure:
-# 1. Basic Functionality Tests
-# 2. Edge Case Tests  
-# 3. Input Validation Tests
+# 1. Input Validation Tests
+# 2. No Filtering Tests (both FALSE)
+# 3. Taxa-Only Filtering Tests (check_taxa=TRUE, check_levels=FALSE)
+# 4. Levels-Only Filtering Tests (check_taxa=FALSE, check_levels=TRUE)
+# 5. Both Filtering Tests (check_taxa=TRUE, check_levels=TRUE)
 #
 # ==================================================================== #
 
 # --------------------------------------------------- #
-# 1. BASIC FUNCTIONALITY TESTS
+# 1. INPUT VALIDATION TESTS - ERRORS
 # --------------------------------------------------- #
 
-# --------------------------------------------------- #
-# 1.1 Taxa Reduction Only
-# --------------------------------------------------- #
+# 1.1 data_source_reduce validation
+test_that("reduce_data rejects NULL data_source_reduce", {
+  expect_error(
+    reduce_data(data_source_reduce = NULL),
+    "data_source_reduce.*list"
+  )
+})
 
-test_that("reduce_data preserves rownames when filtering taxa only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("reduce_data rejects string data_source_reduce", {
+  expect_error(
+    reduce_data(data_source_reduce = "invalid"),
+    "data_source_reduce.*list"
+  )
+})
+
+test_that("reduce_data rejects numeric data_source_reduce", {
+  expect_error(
+    reduce_data(data_source_reduce = 123),
+    "data_source_reduce.*list"
+  )
+})
+
+test_that("reduce_data rejects data.frame data_source_reduce", {
+  expect_error(
+    reduce_data(data_source_reduce = data.frame(x = 1)),
+    "data_source_reduce.*list"
+  )
+})
+
+test_that("reduce_data rejects empty list data_source_reduce", {
+  expect_error(
+    reduce_data(data_source_reduce = list())
+  )
+})
+
+# 1.2 check_taxa validation
+test_that("reduce_data rejects invalid check_taxa argument", {
+  raw_data <- 
+  extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(data_source_reduce = raw_data, check_taxa = "TRUE"),
+    "check_taxa.*logical"
+  )
+})
+
+test_that("reduce_data rejects invalid check_taxa argument", {
+  raw_data <- 
+  extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(data_source_reduce = raw_data, check_taxa = 123),
+    "check_taxa.*logical"
+  )
+})
+
+test_that("reduce_data rejects invalid check_taxa argument", {
+  raw_data <- 
+  extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(data_source_reduce = raw_data, check_taxa = NULL),
+    "check_taxa.*logical"
+  )
+})
+
+# 1.3 check_levels validation
+test_that("reduce_data rejects invalid check_levels argument", {
+  raw_data <- 
+  extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(data_source_reduce = raw_data, check_levels = "TRUE"),
+    "check_levels.*logical"
+  )
+})
+
+test_that("reduce_data rejects invalid check_levels argument", {
+  raw_data <- 
+  extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(data_source_reduce = raw_data, check_levels = 123),
+    "check_levels.*logical"
+  )
+})
+
+test_that("reduce_data rejects invalid check_levels argument", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    reduce_data(
+      data_source_reduce = raw_data, 
+      check_levels = NULL
+      ),
+    "check_levels.*logical"
+  )
+})
+
+# 1.4 data_source_reduce structure validation
+test_that("reduce_data rejects missing community component", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  out_taxa <-
+  incomplete_data <- list(age = raw_data$age, age_un = raw_data$age_un)
+  expect_error(
+    reduce_data(data_source_reduce = incomplete_data)
+  )
+})
+
+test_that("reduce_data rejects missing age component", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  incomplete_data <- list(community = raw_data$community, age_un = raw_data$age_un)
+  expect_error(
+    reduce_data(data_source_reduce = incomplete_data)
+  )
+})
+
+test_that("reduce_data rejects matrix community", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  raw_data$community <- as.matrix(raw_data$community)
+  expect_error(
+    reduce_data(data_source_reduce = raw_data)
+  )
+})
+
+test_that("reduce_data rejects community without rownames", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  rownames(raw_data$community) <- NULL
+  expect_error(
+    reduce_data(data_source_reduce = raw_data)
+  )
+})
+
+test_that("reduce_data rejects community with non-numeric columns", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  raw_data$community$text_col <- "NA"
+  expect_error(
+    reduce_data(data_source_reduce = raw_data),
+    "'x' must be numeric"
+  )
+})
+
+test_that("reduce_data rejects age without rownames", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  rownames(raw_data$age) <- NULL
+  expect_error(
+    reduce_data(data_source_reduce = raw_data)
+  )
+})
+
+
+# --------------------------------------------------- #
+# 2. NO FILTERING TESTS (check_taxa=FALSE, check_levels=FALSE)
+# --------------------------------------------------- #
+
+test_that("reduce_data with no filtering returns identical data", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+  # one zero row in community
+  raw_data$community[1,] <- 0 
+
+  result <- 
     reduce_data(
-      data_source_reduce = data_smooth,
+    data_source_reduce = raw_data,
+    check_taxa = FALSE,
+    check_levels = FALSE
+  )
+
+  expect_identical(raw_data, result)
+})
+
+# --------------------------------------------------- #
+# 3. TAXA-ONLY FILTERING TESTS (check_taxa=TRUE, check_levels=FALSE)
+# --------------------------------------------------- #
+test_that("taxa filtering drops taxa with zero column sums", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+
+  result <- 
+    reduce_data(
+      data_source_reduce = raw_data,
       check_taxa = TRUE,
       check_levels = FALSE
     )
 
-  expect_true(
-    all(rownames(data_smooth$community) == rownames(out_taxa$community))
-  )
+  expect_true(all(colSums(result$community, na.rm = TRUE) > 0))
+  expect_equal(ncol(result$community), ncol(raw_data$community) - 1)
 })
 
-test_that("reduce_data removes zero-sum taxa when filtering taxa only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+
+test_that("check_levels = FALSE preserves rownames / sample ids", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+  # one zero row in community
+  raw_data$community[1,] <- 0 
+
+  result <- 
+  reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = FALSE
+  )
+  expect_equal(nrow(raw_data$community), nrow(result$community))
+  expect_identical(rownames(raw_data$community), rownames(result$community))
+  expect_identical(rownames(raw_data$age), rownames(result$age))
+  expect_identical(colnames(raw_data$age_un), colnames(result$age_un))
+
+})
+
+test_that("taxa filtering removes all-NA taxa", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  out_taxa <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
+  raw_data$community$na_taxon <- NA
 
-  expect_true(
-    all(colSums(out_taxa$community, na.rm = TRUE) > 0)
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = FALSE
   )
+  
+  expect_false("na_taxon" %in% colnames(result$community))
 })
 
-test_that("reduce_data reduces or maintains number of taxa when filtering taxa only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("taxa filtering with all-zero community data returns empty community result", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  full_taxa <- ncol(data_smooth$community)
+  raw_data$community[,] <- 0
 
-  out_taxa <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_lte(
-    ncol(out_taxa$community), full_taxa
+  result <- 
+  reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = FALSE
   )
-})
-
-test_that("reduce_data returns valid structure when filtering taxa only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  out_taxa <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_type(
-    out_taxa, "list"
-  )
+  
+  expect_equal(ncol(result$community), 0)
 })
 
 # --------------------------------------------------- #
-# 1.2 Level Reduction Only
+# 4. LEVELS-ONLY FILTERING TESTS (check_taxa=FALSE, check_levels=TRUE)
 # --------------------------------------------------- #
 
-test_that("reduce_data preserves colnames when filtering levels only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("levels filtering removes zero-sum levels from community", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+  # one zero row in community
+  raw_data$community[1,] <- 0
 
-  out_levels <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
+  first_level <- rownames(raw_data$community)[1]
+  raw_data$community[1,] <- 0
 
-  expect_true(
-    all(colnames(data_smooth$community) == colnames(out_levels$community))
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = FALSE,
+    check_levels = TRUE
   )
+  
+  expect_true(all(rowSums(result$community, na.rm = TRUE) > 0)) 
+  expect_false(first_level %in% rownames(result$community))
+  expect_false(first_level %in% rownames(result$age))
+  expect_false(first_level %in% colnames(result$age_un))
 })
 
-test_that("reduce_data removes zero-sum levels when filtering levels only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("levels filtering preserves community colnames", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-
-  out_levels <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
-
-  expect_true(
-    all(rowSums(out_levels$community, na.rm = TRUE) > 0)
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+  # one zero row in community
+  raw_data$community[1,] <- 0 
+  
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = FALSE,
+    check_levels = TRUE
   )
+
+  expect_identical(colnames(raw_data$community), colnames(result$community))
 })
 
-test_that("reduce_data reduces or maintains number of levels when filtering levels only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("levels filtering maintains matching rownames between community and age", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-
-  full_levels <- nrow(data_smooth$community)
-
-  out_levels <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
-
-  expect_lte(
-    nrow(out_levels$community), full_levels
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+  # one zero row in community
+  raw_data$community[1,] <- 0 
+  
+  result <- reduce_data(
+    data_source_reduce = data_smooth,
+    check_taxa = FALSE,
+    check_levels = TRUE
   )
+  
+  expect_identical(rownames(result$community), rownames(result$age))
+  expect_identical(rownames(result$community), colnames(result$age_un))
 })
 
-test_that("reduce_data maintains matching rownames between age and community when filtering levels only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+
+
+test_that("levels filtering with all zero levels returns empty result", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  out_levels <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
+  raw_data$community[,] <- 0
 
-  expect_equal(
-    rownames(out_levels$community), rownames(out_levels$age)
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = FALSE,
+    check_levels = TRUE
   )
+  
+  expect_equal(nrow(result$community), 0)
+  expect_equal(nrow(result$age), 0)
+  expect_equal(ncol(result$age_un), 0)
 })
 
-test_that("reduce_data maintains matching colnames between age_un and community when filtering levels only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+
+test_that("levels filtering handles NULL age_un", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
       verbose = FALSE
     )
 
-  out_levels <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
-
-  expect_equal(
-    colnames(out_levels$age_un), rownames(out_levels$community)
-  )
-})
-
-# --------------------------------------------------- #
-# 1.3 Both Taxa and Levels Filtering
-# --------------------------------------------------- #
-
-test_that("reduce_data removes zero-sum levels when filtering both taxa and levels", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  out_both <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-
-  expect_true(
-    all(rowSums(out_both$community, na.rm = TRUE) > 0)
-  )
-})
-
-test_that("reduce_data removes zero-sum taxa when filtering both taxa and levels", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  out_both <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-
-  expect_true(
-    all(colSums(out_both$community, na.rm = TRUE) > 0)
-  )
-})
-
-test_that("reduce_data maintains matching rownames between age and community when filtering both", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  out_both <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-
-  expect_equal(
-    rownames(out_both$community), rownames(out_both$age)
-  )
-})
-
-test_that("reduce_data maintains matching colnames between age_un and community when filtering both", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  out_both <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-
-  expect_equal(
-    colnames(out_both$age_un), rownames(out_both$community)
-  )
-})
-
-# --------------------------------------------------- #
-# 1.4 No Filtering
-# --------------------------------------------------- #
-
-test_that("reduce_data with both FALSE doesn't change the data", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  no_filter <-
-    reduce_data(
-      data_source_reduce = data_smooth,
-      check_taxa = FALSE,
-      check_levels = FALSE
-    )
-
-  expect_equal(
-    data_smooth, no_filter
-  )
-})
-
-# --------------------------------------------------- #
-# 2. EDGE CASE TESTS
-# --------------------------------------------------- #
-
-# --------------------------------------------------- #
-# 2.1 NULL age_un Handling
-# --------------------------------------------------- #
-
-test_that("reduce_data handles NULL age_un correctly when filtering both", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  data_null_age_un <- data_smooth
-
-  data_null_age_un$age_un <- NULL
-
+  raw_data$community[1,] <- 0
+  
   expect_no_error(
     reduce_data(
-      data_source_reduce = data_null_age_un,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-  )
-})
-
-# --------------------------------------------------- #
-# 2.2 Zero Taxa Handling
-# --------------------------------------------------- #
-
-test_that("reduce_data preserves rownames when removing zero taxa", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  test_data_zeros <- data_smooth
-
-  test_data_zeros$community$fake_taxon <- 0
-
-  out_zeros <-
-    reduce_data(
-      data_source_reduce = test_data_zeros,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_equal(
-    rownames(test_data_zeros$community), rownames(out_zeros$community)
-  )
-})
-
-test_that("reduce_data reduces number of columns when removing zero taxa", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  test_data_zeros <- data_smooth
-
-  test_data_zeros$community$fake_taxon <- 0
-
-  out_zeros <-
-    reduce_data(
-      data_source_reduce = test_data_zeros,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_lt(
-    ncol(out_zeros$community), ncol(test_data_zeros$community)
-  )
-})
-
-# --------------------------------------------------- #
-# 2.3 Zero Levels Handling
-# --------------------------------------------------- #
-
-test_that("reduce_data removes fake level from community when filtering levels", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  test_data_empty_levels <- data_smooth
-
-  test_data_empty_levels$community["fake_level", ] <- 0
-
-  test_data_empty_levels$age["fake_level", ] <- 9999
-
-  test_data_empty_levels$age_un <-
-    cbind(
-      test_data_empty_levels$age_un,
-      fake_level = rep(9999, nrow(test_data_empty_levels$age_un))
-    )
-
-  out_empty_levels <-
-    reduce_data(
-      data_source_reduce = test_data_empty_levels,
+      data_source_reduce = raw_data,
       check_taxa = FALSE,
       check_levels = TRUE
     )
-
-  expect_false(
-    "fake_level" %in% rownames(out_empty_levels$community)
-  )
-})
-
-test_that("reduce_data removes fake level from age when filtering levels", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  test_data_empty_levels <- data_smooth
-
-  test_data_empty_levels$community["fake_level", ] <- 0
-
-  test_data_empty_levels$age["fake_level", ] <- 9999
-
-  test_data_empty_levels$age_un <-
-    cbind(
-      test_data_empty_levels$age_un,
-      fake_level = rep(9999, nrow(test_data_empty_levels$age_un))
-    )
-
-  out_empty_levels <-
-    reduce_data(
-      data_source_reduce = test_data_empty_levels,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
-
-  expect_false(
-    "fake_level" %in% rownames(out_empty_levels$age)
-  )
-})
-
-test_that("reduce_data removes fake level from age_un when filtering levels", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  test_data_empty_levels <- data_smooth
-
-  test_data_empty_levels$community["fake_level", ] <- 0
-
-  test_data_empty_levels$age["fake_level", ] <- 9999
-
-  test_data_empty_levels$age_un <-
-    cbind(
-      test_data_empty_levels$age_un,
-      fake_level = rep(9999, nrow(test_data_empty_levels$age_un))
-    )
-
-  out_empty_levels <-
-    reduce_data(
-      data_source_reduce = test_data_empty_levels,
-      check_taxa = FALSE,
-      check_levels = TRUE
-    )
-
-  expect_false(
-    "fake_level" %in% colnames(out_empty_levels$age_un)
   )
 })
 
 # --------------------------------------------------- #
-# 2.4 NA Taxa Handling
+# 5. BOTH FILTERING TESTS (check_taxa=TRUE, check_levels=TRUE)
 # --------------------------------------------------- #
 
-test_that("reduce_data removes NA taxon from community", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("both filtering removes zero-sum taxa", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-
-  test_data_NA_taxon <- data_smooth
-
-  test_data_NA_taxon$community$na_taxon <- NA
-
-  out_NA_taxon <-
-    reduce_data(
-      data_source_reduce = test_data_NA_taxon,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_false(
-    "na_taxon" %in% colnames(out_NA_taxon$community)
+  
+  # one zero column in community
+  raw_data$community[,1] <- 0  
+  # one zero row in community
+  raw_data$community[1,] <- 0 
+  
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
   )
+  
+  expect_false("zero_taxon" %in% colnames(result$community))
 })
 
-# --------------------------------------------------- #
-# 2.5 All Taxa Zero - Taxa Filtering Only
-# --------------------------------------------------- #
-
-test_that("reduce_data returns zero columns when all taxa are zero with taxa filtering only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("both filtering removes zero-sum levels", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
+  
+  first_level <- rownames(raw_data$community)[1]
+  raw_data$community[1,] <- 0
 
-  test_all_taxa_zero <- data_smooth
-
-  test_all_taxa_zero$community[, ] <- 0
-
-  out_all_zero_taxa <-
-    reduce_data(
-      data_source_reduce = test_all_taxa_zero,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_true(
-    ncol(out_all_zero_taxa$community) == 0
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
   )
+  
+  expect_false(first_level %in% rownames(result$community))
 })
 
-test_that("reduce_data preserves age rows when all taxa are zero with taxa filtering only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("both filtering removes taxa with zero observations", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  test_all_taxa_zero <- data_smooth
+  raw_data$community$zero_taxon <- 0
 
-  test_all_taxa_zero$community[, ] <- 0
-
-  out_all_zero_taxa <-
-    reduce_data(
-      data_source_reduce = test_all_taxa_zero,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_true(
-    nrow(out_all_zero_taxa$age) == nrow(data_smooth$age)
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
   )
+  
+  expect_true(all(colSums(result$community, na.rm = TRUE) > 0))
 })
 
-test_that("reduce_data preserves age_un columns when all taxa are zero with taxa filtering only", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("both filtering removes samples with zero taxa", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  test_all_taxa_zero <- data_smooth
+  raw_data$community[1,] <- 0
 
-  test_all_taxa_zero$community[, ] <- 0
-
-  out_all_zero_taxa <-
-    reduce_data(
-      data_source_reduce = test_all_taxa_zero,
-      check_taxa = TRUE,
-      check_levels = FALSE
-    )
-
-  expect_false(
-    is.null(out_all_zero_taxa$age_un)
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
   )
+  
+  expect_true(all(rowSums(result$community, na.rm = TRUE) > 0))
 })
 
-# --------------------------------------------------- #
-# 2.6 All Taxa Zero - Both Taxa and Levels Filtering
-# --------------------------------------------------- #
-
-test_that("reduce_data returns zero columns when all taxa are zero with both filtering", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+test_that("both filtering maintains matching rownames between community and age", {
+  raw_data <- 
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
 
-  test_all_taxa_zero <- data_smooth
+  raw_data$community$zero_taxon <- 0
+  raw_data$community[1,] <- 0
 
-  test_all_taxa_zero$community[, ] <- 0
-
-  out_all_zero_taxa <-
-    reduce_data(
-      data_source_reduce = test_all_taxa_zero,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-
-  expect_true(
-    ncol(out_all_zero_taxa$community) == 0
+  result <- reduce_data(
+    data_source_reduce = raw_data,
+    check_taxa = TRUE,
+    check_levels = TRUE
   )
+  
+  expect_identical(rownames(result$community), rownames(result$age))
+  expect_identical(colnames(result$age_un), rownames(result$community))
 })
 
-test_that("reduce_data returns zero rows when all taxa are zero with both filtering", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# WIP below
+
+
+test_that("both filtering maintains matching colnames between age_un and community", {
+  data_smooth <- smooth_community_data(
+    data_source_smooth = extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
-    )
+    ),
+    smooth_method = "m.avg",
+    verbose = FALSE
+  )
+  
+  data_smooth$community$zero_taxon <- 0
+  data_smooth$community[1,] <- 0
+  
+  result <- reduce_data(
+    data_source_reduce = data_smooth,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+  
+  expect_equal(colnames(result$age_un), rownames(result$community))
+})
 
-  test_all_taxa_zero <- data_smooth
+test_that("both filtering with all zero data returns empty community", {
+  data_smooth <- smooth_community_data(
+    data_source_smooth = extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    ),
+    smooth_method = "m.avg",
+    verbose = FALSE
+  )
+  
+  data_smooth$community[,] <- 0
+  
+  result <- reduce_data(
+    data_source_reduce = data_smooth,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+  
+  expect_equal(ncol(result$community), 0)
+  expect_equal(nrow(result$community), 0)
+})
 
-  test_all_taxa_zero$community[, ] <- 0
+test_that("both filtering with all zero data returns empty age", {
+  data_smooth <- smooth_community_data(
+    data_source_smooth = extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    ),
+    smooth_method = "m.avg",
+    verbose = FALSE
+  )
+  
+  data_smooth$community[,] <- 0
+  
+  result <- reduce_data(
+    data_source_reduce = data_smooth,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+  
+  expect_equal(nrow(result$age), 0)
+})
 
-  out_all_zero_taxa <-
+test_that("both filtering with all zero data handles age_un correctly", {
+  data_smooth <- smooth_community_data(
+    data_source_smooth = extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    ),
+    smooth_method = "m.avg",
+    verbose = FALSE
+  )
+  
+  data_smooth$community[,] <- 0
+  
+  result <- reduce_data(
+    data_source_reduce = data_smooth,
+    check_taxa = TRUE,
+    check_levels = TRUE
+  )
+  
+  expect_true(is.null(result$age_un) || ncol(result$age_un) == 0)
+})
+
+test_that("both filtering handles NULL age_un", {
+  data_smooth <- smooth_community_data(
+    data_source_smooth = extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    ),
+    smooth_method = "m.avg",
+    verbose = FALSE
+  )
+  
+  data_smooth$age_un <- NULL
+  data_smooth$community$zero_taxon <- 0
+  data_smooth$community[1,] <- 0
+  
+  expect_no_error(
     reduce_data(
-      data_source_reduce = test_all_taxa_zero,
+      data_source_reduce = data_smooth,
       check_taxa = TRUE,
       check_levels = TRUE
     )
-
-  expect_true(
-    nrow(out_all_zero_taxa$community) == 0
-  )
-})
-
-test_that("reduce_data returns zero age_un columns when all taxa are zero with both filtering", {
-  data_smooth <-
-    smooth_community_data(
-      data_source_smooth =
-        extract_data(
-          data_community_extract = RRatepol::example_data$pollen_data[[1]],
-          data_age_extract = RRatepol::example_data$sample_age[[1]],
-          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-          verbose = FALSE
-        ),
-      smooth_method = "m.avg",
-      verbose = FALSE
-    )
-
-  test_all_taxa_zero <- data_smooth
-
-  test_all_taxa_zero$community[, ] <- 0
-
-  out_all_zero_taxa <-
-    reduce_data(
-      data_source_reduce = test_all_taxa_zero,
-      check_taxa = TRUE,
-      check_levels = TRUE
-    )
-
-  expect_true(
-    is.null(out_all_zero_taxa$age_un) || ncol(out_all_zero_taxa$age_un) == 0
   )
 })
 
@@ -855,18 +746,18 @@ test_that("reduce_data returns zero community rows when all levels are zero", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   test_all_levels_zero <- data_smooth
-
+  
   test_all_levels_zero$community[, ] <- 0
-
+  
   out_all_zero_levels <-
     reduce_data(
       data_source_reduce = test_all_levels_zero,
       check_taxa = FALSE,
       check_levels = TRUE
     )
-
+  
   expect_equal(
     nrow(out_all_zero_levels$community), 0
   )
@@ -885,18 +776,18 @@ test_that("reduce_data returns zero age rows when all levels are zero", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   test_all_levels_zero <- data_smooth
-
+  
   test_all_levels_zero$community[, ] <- 0
-
+  
   out_all_zero_levels <-
     reduce_data(
       data_source_reduce = test_all_levels_zero,
       check_taxa = FALSE,
       check_levels = TRUE
     )
-
+  
   expect_equal(
     nrow(out_all_zero_levels$age), 0
   )
@@ -915,18 +806,18 @@ test_that("reduce_data returns zero age_un columns when all levels are zero", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   test_all_levels_zero <- data_smooth
-
+  
   test_all_levels_zero$community[, ] <- 0
-
+  
   out_all_zero_levels <-
     reduce_data(
       data_source_reduce = test_all_levels_zero,
       check_taxa = FALSE,
       check_levels = TRUE
     )
-
+  
   expect_equal(
     ncol(out_all_zero_levels$age_un), 0
   )
@@ -987,7 +878,7 @@ test_that("reduce_data validates missing community component", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   incomplete_data <- list(age = data_smooth$age, age_un = data_smooth$age_un)
   expect_error(
     reduce_data(data_source_reduce = incomplete_data)
@@ -1007,7 +898,7 @@ test_that("reduce_data validates missing age component", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   incomplete_data <- list(community = data_smooth$community, age_un = data_smooth$age_un)
   expect_error(
     reduce_data(data_source_reduce = incomplete_data)
@@ -1031,10 +922,10 @@ test_that("reduce_data validates community is not a matrix", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community <- as.matrix(data_smooth$community)
-
-  expect_no_error(
+  
+  expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
 })
@@ -1052,9 +943,9 @@ test_that("reduce_data validates community is not a list", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community <- list(x = 1)
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1073,9 +964,9 @@ test_that("reduce_data validates community has rows", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community <- data_smooth$community[0, ]
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1094,9 +985,9 @@ test_that("reduce_data validates community has columns", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community <- data_smooth$community[, 0]
-
+  
   expect_no_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1115,15 +1006,15 @@ test_that("reduce_data validates community contains only numeric columns", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community$text_col <- "text"
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
 })
 
-test_that("reduce_data validates community must have rownames", {
+test_that("reduce_data validates community must have sampleID/levels/rownames", {
   data_smooth <-
     smooth_community_data(
       data_source_smooth =
@@ -1136,9 +1027,9 @@ test_that("reduce_data validates community must have rownames", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   rownames(data_smooth$community) <- NULL
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1157,9 +1048,9 @@ test_that("reduce_data validates community must have colnames", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   colnames(data_smooth$community) <- NULL
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1178,9 +1069,9 @@ test_that("reduce_data validates community cannot contain Inf values", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community[1, 1] <- Inf
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1199,9 +1090,9 @@ test_that("reduce_data validates community cannot contain -Inf values", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$community[1, 1] <- -Inf
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1224,9 +1115,9 @@ test_that("reduce_data validates age is a data.frame", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age <- as.matrix(data_smooth$age)
-
+  
   expect_no_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1245,9 +1136,9 @@ test_that("reduce_data validates age contains required age column", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age$age <- NULL
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1266,15 +1157,15 @@ test_that("reduce_data validates age column is numeric", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age$age <- as.character(data_smooth$age$age)
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
 })
 
-test_that("reduce_data validates age must have rownames", {
+test_that("reduce_data validates age must have sampleID/levels/rownames", {
   data_smooth <-
     smooth_community_data(
       data_source_smooth =
@@ -1287,9 +1178,9 @@ test_that("reduce_data validates age must have rownames", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   rownames(data_smooth$age) <- NULL
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1308,9 +1199,9 @@ test_that("reduce_data validates age column cannot contain NA values", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age$age[1] <- NA
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1329,9 +1220,9 @@ test_that("reduce_data validates age column cannot contain Inf values", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age$age[1] <- Inf
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1350,9 +1241,9 @@ test_that("reduce_data allows negative values in age", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age$age[1] <- -1000
-
+  
   expect_no_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1375,9 +1266,9 @@ test_that("reduce_data validates age_un is not a list", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age_un <- list(x = 1)
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1396,9 +1287,9 @@ test_that("reduce_data validates age_un is not a string", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age_un <- "invalid"
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1421,15 +1312,15 @@ test_that("reduce_data validates community and age have same row counts", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age <- data_smooth$age[-1, ]
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
 })
 
-test_that("reduce_data validates community and age have matching row names", {
+test_that("reduce_data validates community and age have matching sampleID/levels/rownames", {
   data_smooth <-
     smooth_community_data(
       data_source_smooth =
@@ -1442,9 +1333,9 @@ test_that("reduce_data validates community and age have matching row names", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   rownames(data_smooth$age)[1] <- "different_name"
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1463,15 +1354,15 @@ test_that("reduce_data validates age_un dimensions match community", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   data_smooth$age_un <- data_smooth$age_un[, -1]
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
 })
 
-test_that("reduce_data validates age_un column names match community row names", {
+test_that("reduce_data validates age_un column names match community sampleID/levels/rownames", {
   data_smooth <-
     smooth_community_data(
       data_source_smooth =
@@ -1484,9 +1375,9 @@ test_that("reduce_data validates age_un column names match community row names",
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   colnames(data_smooth$age_un)[1] <- "different_name"
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth)
   )
@@ -1509,7 +1400,7 @@ test_that("reduce_data validates check_taxa is not a string", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_taxa = "invalid")
   )
@@ -1528,7 +1419,7 @@ test_that("reduce_data validates check_taxa is not numeric", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_taxa = 123)
   )
@@ -1547,7 +1438,7 @@ test_that("reduce_data validates check_taxa is not NULL", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_taxa = NULL)
   )
@@ -1566,7 +1457,7 @@ test_that("reduce_data validates check_taxa has length 1", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_taxa = c(TRUE, FALSE))
   )
@@ -1585,7 +1476,7 @@ test_that("reduce_data validates check_levels is not a string", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_levels = "invalid")
   )
@@ -1604,7 +1495,7 @@ test_that("reduce_data validates check_levels is not numeric", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_levels = 123)
   )
@@ -1623,7 +1514,7 @@ test_that("reduce_data validates check_levels is not NULL", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_levels = NULL)
   )
@@ -1642,7 +1533,18 @@ test_that("reduce_data validates check_levels has length 1", {
       smooth_method = "m.avg",
       verbose = FALSE
     )
-
+  
+  expect_error(
+    reduce_data(data_source_reduce = data_smooth, check_levels = c(TRUE, FALSE))
+  )
+})
+          age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+          verbose = FALSE
+        ),
+      smooth_method = "m.avg",
+      verbose = FALSE
+    )
+  
   expect_error(
     reduce_data(data_source_reduce = data_smooth, check_levels = c(TRUE, FALSE))
   )

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -2,8 +2,8 @@
 #                        TESTS FOR reduce_data()                      #
 # ==================================================================== #
 #
-# This file contains comprehensive tests for the reduce_data() function
-# which filters taxa and/or levels based on zero-sum criteria.
+# This file contains comprehensive tests for the reduce_data() function.
+# It filters taxa and/or levels based on zero-sum criteria in community.
 #
 # Test structure:
 # 1. Input Validation Tests (Errors)
@@ -358,10 +358,11 @@ test_that(
 
   rownames(raw_data$community) <-
     NULL
-  expect_condition(
+  expect_warning(
     result <-
       reduce_data(data_source_reduce = raw_data)
-  )
+  )  # ,
+  # no warning implemented yet
 })
 
 test_that(
@@ -378,7 +379,8 @@ test_that(
     NULL
   expect_warning(
     reduce_data(data_source_reduce = raw_data)
-  )
+  ) # , 
+  # no warning implemented yet
 })
 
 # --------------------------------------------------- #
@@ -795,7 +797,6 @@ test_that(
 })
 
 
-# WIP below
 
 
 test_that(
@@ -1144,4 +1145,5 @@ test_that(
     colnames(result$age_un), rownames(result$age)
   )
 })
+
 

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -1,0 +1,520 @@
+# --------------------------------------------------- #
+# Load and prepare example smoothed data
+# --------------------------------------------------- #
+
+data_smooth <-
+  extract_data(
+    RRatepol::example_data$pollen_data[[1]],
+    RRatepol::example_data$sample_age[[1]],
+    RRatepol::example_data$age_uncertainty[[1]]
+  ) %>%
+  smooth_community_data(
+    smooth_method = c("m.avg"),
+    smooth_n_points = 5,
+    smooth_n_max = 9,
+    smooth_age_range = 500,
+    round_results = FALSE,
+    verbose = FALSE
+  )
+
+
+# Store full taxa and levels
+full_taxa <-
+  colnames(data_smooth$community)
+
+full_levels <-
+  rownames(data_smooth$community)
+
+# --------------------------------------------------- #
+# Helper function to validate output structure
+# --------------------------------------------------- #
+
+check_reduce_data_structure <- function(out) {
+  # ---- Top-level structure ----
+  expect_type(
+    out, "list"
+  )
+  
+  expect_named(
+    out, 
+    c("community", "age", "age_un")
+  )
+  
+  # ---- community ----
+  expect_s3_class(
+    out$community, 
+    "data.frame"
+  )
+  
+  if (ncol(out$community) > 0) {
+    expect_true(all(vapply(out$community, is.numeric, logical(1))))
+  }
+  
+  expect_true(
+    !is.null(
+      rownames(
+        out$community)
+    )
+  )
+  
+  expect_true(
+    !is.null(
+      colnames(
+        out$community)
+    )
+  )
+  
+  # ---- age ----
+  expect_s3_class(
+    out$age, 
+    "data.frame"
+  )
+  
+  expect_true(
+    "age" %in% colnames(out$age)
+  )
+  
+  expect_true(
+    !is.null(
+      rownames(out$age)
+    )
+  )
+  
+  expect_equal(
+    rownames(out$age), 
+    rownames(out$community)
+  )
+  
+  # ---- age_un ----
+  if (!is.null(out$age_un)) {
+    expect_true(
+      is.matrix(out$age_un) || is.data.frame(out$age_un)
+    )
+    
+    expect_equal(
+      colnames(out$age_un), rownames(out$community)
+    )
+  }
+}
+
+# --------------------------------------------------- #
+# Modified data for edge cases
+# --------------------------------------------------- #
+
+# 1 taxon with zeros
+test_data_zeros <-
+  data_smooth
+
+test_data_zeros$community$fake_taxon <-
+  0
+
+# all taxa zero
+test_all_taxa_zero <-
+  data_smooth
+
+test_all_taxa_zero$community[, ] <-
+  0
+
+# 1 taxon with NA in community
+test_data_NA_taxon <-
+  data_smooth
+
+test_data_NA_taxon$community$na_taxon <-
+  NA
+
+# 1 level with zeros
+test_data_empty_levels <-
+  data_smooth
+
+test_data_empty_levels$community["fake_level", ] <-
+  0
+
+test_data_empty_levels$age["fake_level", ] <-
+  9999
+
+test_data_empty_levels$age_un <-
+  cbind(
+    test_data_empty_levels$age_un,
+    "fake_level" = rep(0, nrow(test_data_empty_levels$age_un))
+  )
+
+# all levels zero
+test_all_levels_zero <-
+  data_smooth
+
+test_all_levels_zero$community[, ] <-
+  0
+
+# without age_un matrix
+data_null_age_un <-
+  data_smooth
+
+data_null_age_un$age_un <-
+  NULL
+
+
+
+
+
+
+
+# --------------------------------------------------- #
+# Test 1: test taxa reduction only
+# --------------------------------------------------- #
+
+test_that("reduce_data filters taxa correctly using smoothed example data", {
+  out_taxa <-
+    reduce_data(
+      data_smooth,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_true(
+    all(
+      rownames(out_taxa$community) == rownames(data_smooth$community)
+    )
+  )
+
+  expect_true(
+    all(
+      colSums(out_taxa$community, na.rm = TRUE) > 0
+    )
+  )
+
+  expect_lte(
+    ncol(out_taxa$community), length(full_taxa)
+  )
+  
+  check_reduce_data_structure(out_taxa)
+  
+})
+
+
+# --------------------------------------------------- #
+# Test 2: test level reduction only
+# --------------------------------------------------- #
+test_that("reduce_data filters levels correctly using smoothed example data", {
+  out_levels <-
+    reduce_data(
+      data_smooth,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
+
+  expect_true(
+    all(
+      colnames(out_levels$community) == colnames(data_smooth$community)
+    )
+  )
+
+  expect_true(
+    all(rowSums(out_levels$community, na.rm = TRUE) > 0)
+  )
+
+  expect_lte(
+    nrow(out_levels$community), length(full_levels)
+  )
+
+  expect_equal(
+    rownames(out_levels$age), rownames(out_levels$community)
+  )
+
+  expect_equal(
+    colnames(out_levels$age_un), rownames(out_levels$community)
+  )
+  
+  check_reduce_data_structure(out_levels)
+  
+})
+
+# --------------------------------------------------- #
+# Test 3: test both at the same time
+# --------------------------------------------------- #
+test_that("reduce_data filters taxa and levels correctly using smoothed example data", {
+  out_both <-
+    reduce_data(
+      data_smooth,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  expect_true(
+    all(
+      rowSums(out_both$community, na.rm = TRUE) > 0
+    )
+  )
+
+  expect_true(
+    all(
+      colSums(out_both$community, na.rm = TRUE) > 0
+    )
+  )
+
+  expect_equal(
+    rownames(out_both$age), rownames(out_both$community)
+  )
+
+  expect_equal(
+    colnames(out_both$age_un), rownames(out_both$community)
+  )
+
+  # Test: NULL age_un is handled
+  expect_no_error(
+    reduce_data(
+      data_null_age_un
+    )
+  )
+  
+  check_reduce_data_structure(out_both)
+})
+
+
+
+
+# --------------------------------------------------- #
+# Test 4: FALSE input doesn't reduce the data
+# --------------------------------------------------- #
+test_that("reduce_data with both = FALSE doesn't change the data", {
+  # Control: no filtering needed
+  no_filter <-
+    reduce_data(
+      data_smooth,
+      check_taxa = FALSE,
+      check_levels = FALSE
+    )
+
+  expect_equal(
+    no_filter,
+    data_smooth
+  )
+  
+  check_reduce_data_structure(no_filter)
+})
+
+
+
+# --------------------------------------------------- #
+# Test 5: all-zero taxa
+# --------------------------------------------------- #
+test_that("reduce_data handles taxa with all-zeros in samples correctly", {
+  out_zeros <-
+    reduce_data(
+      test_data_zeros,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_equal(
+    rownames(out_zeros$community),
+    rownames(test_data_zeros$community)
+  )
+
+  expect_lt(
+    ncol(out_zeros$community),
+    ncol(test_data_zeros$community)
+  )
+  
+  check_reduce_data_structure(out_zeros)
+  
+})
+
+
+# --------------------------------------------------- #
+# Test 6: all-zero levels
+# --------------------------------------------------- #
+test_that("reduce_data handles levels with all-zeros in samples correctly", {
+  out_empty_levels <-
+    reduce_data(
+      test_data_empty_levels,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
+
+  expect_false(
+    "fake_level" %in% rownames(out_empty_levels$community)
+  )
+
+  expect_false(
+    "fake_level" %in% rownames(out_empty_levels$age)
+  )
+
+  expect_false(
+    "fake_level" %in% colnames(out_empty_levels$age_un)
+  )
+  
+  check_reduce_data_structure(out_empty_levels)
+  
+  
+})
+# --------------------------------------------------- #
+# Test 7: NA taxa
+# --------------------------------------------------- #
+
+test_that("reduce_data handles NA in taxon (community) correctly", {
+  out_NA_taxon <-
+    reduce_data(
+      test_data_NA_taxon,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_false(
+    "na_taxon" %in% colnames(out_NA_taxon$community)
+  )
+  
+  check_reduce_data_structure(out_NA_taxon)
+  
+})
+
+# --------------------------------------------------- #
+# Test 8: if all Taxa are zero
+# --------------------------------------------------- #
+test_that("reduce_data handles all-zero community data correctly", {
+  # Test: all taxa zero — everything from community data should be removed
+  # only taxa (no level reduction)
+  out_all_zero_taxa <-
+    reduce_data(
+      test_all_taxa_zero,
+      check_taxa = TRUE,
+      check_levels = FALSE
+    )
+
+  expect_true(
+    ncol(
+      out_all_zero_taxa$community
+    ) == 0
+  )
+
+  expect_true(
+    nrow(
+      out_all_zero_taxa$age
+    ) != 0
+  )
+
+
+  expect_false(
+    ncol(
+      out_all_zero_taxa$age_un
+    ) == 0
+  )
+
+
+  # with levels
+  out_all_zero_taxa <-
+    reduce_data(
+      test_all_taxa_zero,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  expect_true(
+    ncol(
+      out_all_zero_taxa$community
+    ) == 0
+  )
+
+  expect_true(
+    nrow(
+      out_all_zero_taxa$age
+    ) == 0
+  )
+
+  expect_true(
+    ncol(
+      out_all_zero_taxa$age_un
+    ) == 0
+  )
+  
+  check_reduce_data_structure(out_all_zero_taxa)
+  
+})
+
+# --------------------------------------------------- #
+# Test 9: if all levels are zero
+# --------------------------------------------------- #
+test_that("reduce_data handles all-zero levels correctly", {
+  out_all_zero_levels <-
+    reduce_data(
+      test_all_levels_zero,
+      check_taxa = FALSE,
+      check_levels = TRUE
+    )
+
+  expect_equal(
+    nrow(
+      out_all_zero_levels$community
+    ), 0
+  )
+
+  expect_equal(
+    nrow(
+      out_all_zero_levels$age
+    ), 0
+  )
+
+  expect_equal(
+    ncol(
+      out_all_zero_levels$age_un
+    ), 0
+  )
+  
+  check_reduce_data_structure(out_all_zero_levels)
+  
+})
+
+# Test 10a: Correct output structure
+test_that("reduce_data returns correct structure and format", {
+
+  out <- 
+    reduce_data(
+      data_smooth, 
+      check_taxa = TRUE, 
+      check_levels = TRUE)
+  
+  check_reduce_data_structure(out)
+  
+})
+
+# Test 10b: Correct output structure
+test_that("reduce_data returns correct structure and format", {
+  
+  out <- 
+    reduce_data(
+      data_smooth, 
+      check_taxa = FALSE, 
+      check_levels = TRUE)
+  
+  check_reduce_data_structure(out)
+  
+})
+
+# Test 10c: Correct output structure
+test_that("reduce_data returns correct structure and format", {
+  
+  out <- 
+    reduce_data(
+      data_smooth, 
+      check_taxa = TRUE, 
+      check_levels = FALSE)
+  
+  check_reduce_data_structure(out)
+  
+})
+
+# Test 10d: Correct output structure
+test_that("reduce_data returns correct structure and format", {
+  
+  out <- 
+    reduce_data(
+      data_smooth, 
+      check_taxa = FALSE, 
+      check_levels = FALSE)
+  
+check_reduce_data_structure(out)
+})
+
+
+
+
+


### PR DESCRIPTION
The following tests have been added for the function `reduce_data()`.
Different modifications of the `example_data` were produced to account for edge cases. Within each test there is always a function to test for the correct output structure*.

## Edge cases
1. if one taxon is all-zero in the community data
2. if all taxa are all-zero in the community data
3. if one taxon has NAs in the community data
4. if there is one level with NA in the community data
5. if there is one level with zeros in the community data
6. if all levels are zero in the community data

## Tests
### General functionality:
- Verification that taxa are reduced correctly 
- Verification that levels are reduced correctly
- Verification that both are reduced correctly at the same time
- Verification that `check_taxa = FALSE` and `check_levels = FALSE` does not manipulate the data

### Edge case scenarios:
- Verification of scenario [1]
- Verification of scenario [2]
- Verification of scenario [3]
- Verification of scenario [4]
- Verification of scenario [5]
- Verification of scenario [6]

## Comments:
!* All of the tests for correct output structure fail as long as there is the bug (#44 ) in `extract_data()` that leads to no `sample_id` information in the age uncertainty matrix.