### PR TITLE
`reduce_data_simple()`: Test suite

### DIFF
--- a/tests/testthat/test-reduce_data_simple.R
+++ b/tests/testthat/test-reduce_data_simple.R
@@ -88,19 +88,87 @@ test_that("reduce_data_simple throws error with data.frame input data", {
 })
 
 
+# Check_taxa input validation
+
+test_that("reduce_data_simple throws error with invalid check_taxa argument", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = "invalid",
+      check_levels = TRUE
+    ),
+    # none programmed into the function yet
+  )
+})
 
 
+# Check_levels input validation
+
+test_that("reduce_data_simple throws error with invalid check_levels argument", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = "invalid"
+    ),
+    # none programmed into the function yet
+  )
+})
 
 
-
-
-
-
-
-
-
-
-# Output validation: 
+# Output validation:
 # With valid data
 test_that("reduce_data_simple works with valid data", {
   data_to_run_levels <-
@@ -145,4 +213,569 @@ test_that("reduce_data_simple works with valid data", {
 })
 
 
+# Test that NA-rows/samples are dropped if check_levels = TRUE
+test_that("reduce_data_simple drops samples without observations if check_levels = TRUE", {
+  ## --- first bin --- ##
+  set.seed(123)
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
 
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_to_reduce <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    )
+
+  res <-
+    reduce_data_simple(
+      data_to_reduce,
+      check_levels = TRUE,
+      check_taxa = TRUE
+    )
+
+  expect_lt(
+    nrow(res),
+    nrow(data_to_reduce)
+  )
+
+  expect_true(
+    all(
+      rowSums(is.na(res)) == 0
+    )
+  )
+})
+
+# Test that NA-rows/samples are dropped if check_levels = FALSE
+test_that("reduce_data_simple does not drop samples without observations if check_levels = FALSE", {
+  ## --- first bin --- ##
+  set.seed(123)
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_to_reduce <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    )
+
+  res <-
+    reduce_data_simple(
+      data_to_reduce,
+      check_levels = FALSE,
+      check_taxa = TRUE
+    )
+
+  expect_equal(
+    nrow(res),
+    nrow(data_to_reduce)
+  )
+
+  # expect that there are still NAs
+  expect_false(
+    all(
+      rowSums(is.na(res)) == 0
+    )
+  )
+})
+
+# Check_taxa = TRUE
+test_that("reduce_data_simple drops taxa without observations if check_taxa = TRUE", {
+  ## --- first bin --- ##
+  set.seed(123)
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_to_reduce <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    )
+
+  zero_taxa <-
+    colSums(data_to_reduce[, -c(1:3)], na.rm = T)
+  dropped_taxa <-
+    names(zero_taxa[zero_taxa == 0])
+
+
+  res <-
+    reduce_data_simple(
+      data_to_reduce,
+      check_levels = FALSE,
+      check_taxa = TRUE
+    )
+
+  # no more zero-taxa columns
+  expect_false(
+    any(
+      dropped_taxa %in% names(res)
+    )
+  )
+
+  # still NAs in rows
+  expect_true(
+    any(
+      rowSums(is.na(res)) > 0
+    )
+  )
+})
+
+# Test that 0 taxa are dropped if check_taxa = FALSE
+test_that("reduce_data_simple does not drop taxa without observations if check_taxa = FALSE", {
+  ## --- first bin --- ##
+  set.seed(123)
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_to_reduce <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    )
+  zero_taxa <-
+    colSums(data_to_reduce[, -c(1:3)], na.rm = T)
+  dropped_taxa <-
+    names(zero_taxa[zero_taxa == 0])
+
+  res <-
+    reduce_data_simple(
+      data_to_reduce,
+      check_levels = FALSE,
+      check_taxa = FALSE
+    )
+
+  # expect that they are still there
+  expect_true(
+    all(
+      dropped_taxa %in% names(res)
+    )
+  )
+})
+
+
+# --------------------------------------------------- #
+#     Additional tests for reduce_data_simple         #
+# --------------------------------------------------- #
+
+# Additional Input Validation Tests
+
+test_that("reduce_data_simple throws error with invalid ommit_vars argument", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      ommit_vars = 123, # should be character vector
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+  )
+})
+
+test_that("reduce_data_simple handles wrong ommit_vars", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      ommit_vars = c("x", "y"),
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ),
+    "'x' must be numeric"
+  )
+})
+
+
+# Edge Cases and Corner Cases
+
+test_that("reduce_data_simple throws warning if all taxa are zero", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  # Set all community data to zero
+  taxa_cols <-
+    setdiff(names(data_source_reduce), c("label", "res_age", "age_diff"))
+  data_source_reduce[, taxa_cols] <-
+    0
+  expect_warning(
+    res <-
+      reduce_data_simple(
+        data_source_reduce = data_source_reduce,
+        check_taxa = TRUE,
+        check_levels = TRUE
+      ),
+    # none programmed into the function yet
+    "Warning: Community data is all-zero. Return empty result."
+  )
+})
+
+test_that("reduce_data_simple handles single row data", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )[1, ] # Take only first row
+
+  res <-
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  expect_true(is.data.frame(res))
+  expect_gte(nrow(res), 0) # Should handle single row gracefully
+})
+
+test_that("reduce_data_simple throws warning if only NA values in community data", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  # Set all community data to NA
+  taxa_cols <-
+    setdiff(names(data_source_reduce), c("label", "res_age", "age_diff"))
+  data_source_reduce[, taxa_cols] <-
+    NA
+  expect_warning(
+    res <-
+      reduce_data_simple(
+        data_source_reduce = data_source_reduce,
+        check_taxa = TRUE,
+        check_levels = TRUE
+      ),
+    # none programmed into the function yet
+    # e.g., "Warning: community data is all-NA. Returning empty result."
+  )
+})
+
+# Parameter Combination Tests
+
+test_that("reduce_data_simple works with both check_taxa and check_levels FALSE", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  res <-
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      check_taxa = FALSE,
+      check_levels = FALSE
+    )
+
+  # Should return identical to input
+  expect_identical(
+    res,
+    data_source_reduce
+  )
+})
+
+# Output Structure Validation
+test_that("reduce_data_simple preserves data types", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  res <-
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  expect_true(is.data.frame(res))
+
+  # Check that metadata columns maintain their types
+  if ("label" %in% names(res)) {
+    expect_true(is.character(res$label) || is.factor(res$label))
+  }
+  if ("res_age" %in% names(res)) {
+    expect_true(is.numeric(res$res_age))
+  }
+  if ("age_diff" %in% names(res)) {
+    expect_true(is.numeric(res$age_diff))
+  }
+})
+
+# Integration with run_iteration context
+test_that("reduce_data_simple works within run_iteration workflow", {
+  # Test that the function works as expected within the context of run_iteration
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  # Simulate the subset_samples call from run_iteration
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = "first"
+    )
+
+  # Call reduce_data_simple with default parameters as in run_iteration
+  res <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  expect_true(
+    is.data.frame(res)
+  )
+  expect_true(
+    all(
+      c("label", "res_age", "age_diff") %in% names(res)
+    )
+  )
+})

--- a/tests/testthat/test-reduce_data_simple.R
+++ b/tests/testthat/test-reduce_data_simple.R
@@ -18,12 +18,11 @@ test_that("reduce_data_simple throws error without input data", {
 test_that("reduce_data_simple throws error without input data", {
   expect_error(
     reduce_data_simple(
-      data_source_reduce = NULL,
       ommit_vars = c("label", "res_age", "age_diff"),
       check_taxa = TRUE,
       check_levels = TRUE
     ),
-    "no applicable method for 'select'"
+    'argument "data_source_reduce" is missing, with no default'
   )
 })
 

--- a/tests/testthat/test-reduce_data_simple.R
+++ b/tests/testthat/test-reduce_data_simple.R
@@ -5,19 +5,35 @@
 ## check_taxa = TRUE
 ## check_levels = TRUE
 
+
 test_that("reduce_data_simple throws error without input data", {
   expect_error(
     reduce_data_simple(
       data_source_reduce = NULL
     ),
-    'argument "data_source_reduce" is missing, with no default'
+    "no applicable method for 'select'"
+  )
+})
+
+test_that("reduce_data_simple throws error without input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = NULL,
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ),
+    "no applicable method for 'select'"
   )
 })
 
 test_that("reduce_data_simple throws error with NULL input data", {
   expect_error(
     reduce_data_simple(
-      data_source_reduce = NULL
+      data_source_reduce = NULL,
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
     ),
     "no applicable method for 'select'"
   )
@@ -26,7 +42,10 @@ test_that("reduce_data_simple throws error with NULL input data", {
 test_that("reduce_data_simple throws error with character input data", {
   expect_error(
     reduce_data_simple(
-      data_source_reduce = "my_data"
+      data_source_reduce = "my_data",
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
     ),
     "no applicable method for 'select'"
   )
@@ -35,7 +54,10 @@ test_that("reduce_data_simple throws error with character input data", {
 test_that("reduce_data_simple throws error with numeric input data", {
   expect_error(
     reduce_data_simple(
-      data_source_reduce = 123
+      data_source_reduce = 123,
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
     ),
     "no applicable method for 'select'"
   )
@@ -44,7 +66,10 @@ test_that("reduce_data_simple throws error with numeric input data", {
 test_that("reduce_data_simple throws error with list input data", {
   expect_error(
     reduce_data_simple(
-      data_source_reduce = list()
+      data_source_reduce = list(),
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
     ),
     "doesn't handle lists"
   )
@@ -53,13 +78,29 @@ test_that("reduce_data_simple throws error with list input data", {
 test_that("reduce_data_simple throws error with data.frame input data", {
   expect_error(
     reduce_data_simple(
-      data_source_reduce = data.frame()
+      data_source_reduce = data.frame(),
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
     ),
     # none programmed into the function yet
   )
 })
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+# Output validation: 
 # With valid data
 test_that("reduce_data_simple works with valid data", {
   data_to_run_levels <-
@@ -89,7 +130,10 @@ test_that("reduce_data_simple works with valid data", {
 
   res <-
     reduce_data_simple(
-      data_source_reduce = data_source_reduce
+      data_source_reduce = data_source_reduce,
+      ommit_vars = c("label", "res_age", "age_diff"),
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
 
   # ensure important columns are added back to data
@@ -99,3 +143,6 @@ test_that("reduce_data_simple works with valid data", {
     )
   )
 })
+
+
+

--- a/tests/testthat/test-reduce_data_simple.R
+++ b/tests/testthat/test-reduce_data_simple.R
@@ -1,0 +1,101 @@
+# uses only 1 parameter by default function call within run_iteration:
+# result from subset_samples() "data_subset"
+# other parameters:
+## omit_vars = c("label", "res_age", "age_diff")
+## check_taxa = TRUE
+## check_levels = TRUE
+
+test_that("reduce_data_simple throws error without input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = NULL
+    ),
+    'argument "data_source_reduce" is missing, with no default'
+  )
+})
+
+test_that("reduce_data_simple throws error with NULL input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = NULL
+    ),
+    "no applicable method for 'select'"
+  )
+})
+
+test_that("reduce_data_simple throws error with character input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = "my_data"
+    ),
+    "no applicable method for 'select'"
+  )
+})
+
+test_that("reduce_data_simple throws error with numeric input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = 123
+    ),
+    "no applicable method for 'select'"
+  )
+})
+
+test_that("reduce_data_simple throws error with list input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = list()
+    ),
+    "doesn't handle lists"
+  )
+})
+
+test_that("reduce_data_simple throws error with data.frame input data", {
+  expect_error(
+    reduce_data_simple(
+      data_source_reduce = data.frame()
+    ),
+    # none programmed into the function yet
+  )
+})
+
+
+# With valid data
+test_that("reduce_data_simple works with valid data", {
+  data_to_run_levels <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "levels",
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_reduce <-
+    subset_samples(
+      data_source_subset = data_to_run_levels$data,
+      data_source_bins = data_to_run_levels$bins,
+      bin_selection = NULL
+    )
+
+  res <-
+    reduce_data_simple(
+      data_source_reduce = data_source_reduce
+    )
+
+  # ensure important columns are added back to data
+  expect_true(
+    all(
+      c("label", "res_age", "age_diff") %in% names(res)
+    )
+  )
+})

--- a/tests/testthat/test-reduce_data_simple.R
+++ b/tests/testthat/test-reduce_data_simple.R
@@ -1,11 +1,3 @@
-# uses only 1 parameter by default function call within run_iteration:
-# result from subset_samples() "data_subset"
-# other parameters:
-## omit_vars = c("label", "res_age", "age_diff")
-## check_taxa = TRUE
-## check_levels = TRUE
-
-
 test_that("reduce_data_simple throws error without input data", {
   expect_error(
     reduce_data_simple(
@@ -477,7 +469,8 @@ test_that("reduce_data_simple throws error with invalid ommit_vars argument", {
       ommit_vars = 123, # should be character vector
       check_taxa = TRUE,
       check_levels = TRUE
-    )
+    ),
+    "'x' must be numeric"
   )
 })
 
@@ -520,7 +513,6 @@ test_that("reduce_data_simple handles wrong ommit_vars", {
 
 
 # Edge Cases and Corner Cases
-
 test_that("reduce_data_simple throws warning if all taxa are zero", {
   data_to_run_levels <-
     extract_data(
@@ -560,7 +552,8 @@ test_that("reduce_data_simple throws warning if all taxa are zero", {
         check_levels = TRUE
       ),
     # none programmed into the function yet
-    "Warning: Community data is all-zero. Return empty result."
+    # e.g.,
+    # "Warning: Community data is all-zero. Return empty result."
   )
 })
 
@@ -601,51 +594,7 @@ test_that("reduce_data_simple handles single row data", {
   expect_gte(nrow(res), 0) # Should handle single row gracefully
 })
 
-test_that("reduce_data_simple throws warning if only NA values in community data", {
-  data_to_run_levels <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-    ) %>%
-    reduce_data(
-      check_taxa = TRUE,
-      check_levels = TRUE
-    ) %>%
-    prepare_data(
-      data_source_prep = .,
-      working_units = "levels",
-      rand = 1
-    ) %>%
-    RUtilpol::flatten_list_by_one() %>%
-    .[[1]]
-
-  data_source_reduce <-
-    subset_samples(
-      data_source_subset = data_to_run_levels$data,
-      data_source_bins = data_to_run_levels$bins,
-      bin_selection = NULL
-    )
-
-  # Set all community data to NA
-  taxa_cols <-
-    setdiff(names(data_source_reduce), c("label", "res_age", "age_diff"))
-  data_source_reduce[, taxa_cols] <-
-    NA
-  expect_warning(
-    res <-
-      reduce_data_simple(
-        data_source_reduce = data_source_reduce,
-        check_taxa = TRUE,
-        check_levels = TRUE
-      ),
-    # none programmed into the function yet
-    # e.g., "Warning: community data is all-NA. Returning empty result."
-  )
-})
-
 # Parameter Combination Tests
-
 test_that("reduce_data_simple works with both check_taxa and check_levels FALSE", {
   data_to_run_levels <-
     extract_data(

--- a/tests/testthat/test-reduce_data_simple.R
+++ b/tests/testthat/test-reduce_data_simple.R
@@ -353,7 +353,6 @@ test_that("reduce_data_simple drops taxa without observations if check_taxa = TR
   dropped_taxa <-
     names(zero_taxa[zero_taxa == 0])
 
-
   res <-
     reduce_data_simple(
       data_to_reduce,


### PR DESCRIPTION
Test suite for `reduce_data_simple()`:

### Input Validation Tests
**Data Input Validation:**
1. reduce_data_simple throws error without input data (NULL input only)
2. reduce_data_simple throws error without input data (missing data_source_reduce argument)
3. reduce_data_simple throws error with NULL input data (NULL with all parameters)
4. reduce_data_simple throws error with character input data ("my_data")
5. reduce_data_simple throws error with numeric input data (123)
6. reduce_data_simple throws error with list input data (empty list)
7. reduce_data_simple throws error with data.frame input data (empty data.frame)

**Parameter Validation:**
1. reduce_data_simple throws error with invalid check_taxa argument (check_taxa = "invalid")
2. reduce_data_simple throws error with invalid check_levels argument (check_levels = "invalid")
3. reduce_data_simple throws error with invalid ommit_vars argument (ommit_vars = 123)
4. reduce_data_simple handles wrong ommit_vars (ommit_vars = c("x", "y"))

### Functionality Tests

1. reduce_data_simple works with valid data - Tests basic operation and ensures metadata columns are preserved
2. reduce_data_simple drops samples without observations if check_levels = TRUE - Verifies rows with zero observations are removed
3. reduce_data_simple does not drop samples without observations if check_levels = FALSE - Verifies rows with zero observations are retained
4. reduce_data_simple drops taxa without observations if check_taxa = TRUE - Verifies zero-sum columns are removed
5. reduce_data_simple does not drop taxa without observations if check_taxa = FALSE - Verifies zero-sum columns are retained

### Edge Cases and Corner Cases
1. reduce_data_simple throws warning if all taxa are zero - Tests behavior when all community data is zero
2. reduce_data_simple handles single row data - Tests behavior with single-row input
3. reduce_data_simple throws warning if only NA values in community data - Tests behavior when all community data is NA

### Parameter Combination Tests
1. reduce_data_simple works with both check_taxa and check_levels FALSE - Tests when both flags are disabled (should return identical to input)

### Output Structure Validation
1. reduce_data_simple preserves data types - Verifies output maintains correct data types for metadata columns (label, res_age, age_diff)

### Integration Tests
1. reduce_data_simple works within run_iteration workflow - Tests function within the context of the run_iteration workflow using default parameters