### PR TITLE
`standardise_community_data()`: Test suite

### DIFF
--- a/tests/testthat/test-standardise_community_data.R
+++ b/tests/testthat/test-standardise_community_data.R
@@ -164,7 +164,7 @@ test_that("standardise_community_data throws warning with n_individuals = NULL",
 })
 
 # Character
-test_that("standardise_community_data throws error with character n_individuals", {
+test_that("standardise_community_data returns identical results with character or numeric n_individuals", {
   n_individuals_char <- "10"
 
   data_to_run_bins <-
@@ -228,82 +228,6 @@ test_that("standardise_community_data throws error with character n_individuals"
       data_source_reduce = data_subset_char
     )
 
-  # standardisation
-  set.seed(123)
-  expect_error(
-    data_sd_char <-
-      standardise_community_data(
-        data_source_standard = data_subset_char,
-        n_individuals = n_individuals_char
-      ),
-    # none programmed into the function yet
-  )
-})
-
-test_that("standardise_community_data works with character n_individuals", {
-  n_individuals_char <- "10"
-  
-  data_to_run_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-    ) %>%
-    reduce_data(
-      check_taxa = TRUE,
-      check_levels = TRUE
-    ) %>%
-    prepare_data(
-      data_source_prep = .,
-      working_units = "bins",
-      bin_size = 500,
-      rand = 1
-    ) %>%
-    RUtilpol::flatten_list_by_one() %>%
-    .[[1]]
-  
-  data_source_subset <-
-    data_to_run_bins$data
-  data_source_bins <-
-    data_to_run_bins$bins
-  
-  data_subset <-
-    subset_samples(
-      data_source_subset = data_source_subset,
-      data_source_bins = data_source_bins,
-      bin_selection = "first"
-    ) %>%
-    reduce_data_simple()
-  
-  com_data_sums <-
-    rowSums(
-      subset_community(
-        data_source = data_subset
-      ),
-      na.rm = TRUE
-    )
-  
-  # adjust the value to a minimal of presented values
-  n_individuals_char <-
-    min(
-      c(
-        com_data_sums,
-        n_individuals_char
-      )
-    )
-  
-  # check if all samples has n_individuals of individuals:
-  # -> will not work as intended if n_individuals_char is a character,
-  # leading to incorrect or empty results.
-  
-  data_subset_char <-
-    data_subset[com_data_sums >= n_individuals_char, ]
-  
-  data_subset_char <-
-    reduce_data_simple(
-      data_source_reduce = data_subset_char
-    )
-  
   # standardisation
   set.seed(123)
   expect_no_error(
@@ -314,15 +238,21 @@ test_that("standardise_community_data works with character n_individuals", {
       )
     #
   )
-  
+
+  expect_true(
+    all(
+      rowSums(data_sd_char[, -c(1:3)]) == 10
+    )
+  )
+
   # Control:
   n_individuals_num <- 10
   # adjust the value to a minimal of presented values
-  
+
   # -> will coerce all values to character,
   # which can cause unexpected behavior in
   # subsequent numeric comparisons and subsetting.
-  
+
   n_individuals_num <-
     min(
       c(
@@ -330,31 +260,118 @@ test_that("standardise_community_data works with character n_individuals", {
         n_individuals_num
       )
     )
-  
+
   # check if all samples has n_individuals of individuals
   data_subset_num <-
     data_subset[com_data_sums >= n_individuals_num, ]
-  
+
   data_subset_num <-
     reduce_data_simple(
       data_source_reduce = data_subset_num
     )
-  
+
+  expect_identical(
+    data_subset_char,
+    data_subset_num
+  )
+
+  # standardisation
+  set.seed(123)
   data_sd_num <-
     standardise_community_data(
       data_source_standard = data_subset_num,
       n_individuals = n_individuals_num
     )
-  
+
   expect_identical(
     data_sd_char,
     data_sd_num
-    )
+  )
 })
 
 
 # high n_individuals
-test_that("standardise_community_data works with high n_individuals (within run_iteration workflow)", {
+test_that("standardise_community_data returns n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
+  n_individuals <- 100000
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+  set.seed(123)
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_false(
+    identical(
+      data_subset,
+      data_sd
+    )
+  )
+
+  expect_true(
+    all(rowSums(data_sd[, -c(1:3)]) == n_individuals)
+  )
+})
+
+test_that("standardise_community_data returns standardised data with high n_individuals (within run_iteration workflow)", {
   n_individuals <- 100000
   data_to_run_bins <-
     extract_data(
@@ -479,9 +496,237 @@ test_that("standardise_community_data fails if n_individuals >> than n observati
 })
 
 
+test_that("standardise_community_data fails with negative n_individuals", {
+  n_individuals <- -150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+
+  set.seed(123)
+  expect_error(
+    data_sd <-
+      standardise_community_data(
+        data_source_standard = data_subset,
+        n_individuals = n_individuals
+      ),
+    "invalid 'size' argument"
+  )
+})
+
+# n_individuals = 1
+
+test_that("standardise_community_data works with n_individuals = 1", {
+  n_individuals <- 1
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+
+  set.seed(123)
+
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_true(
+    all(
+      rowSums(data_sd[, -c(1:3)]) == n_individuals
+    )
+  )
+})
+
+# n_individuals = 0
+test_that("standardise_community_data fails with zero n_individuals", {
+  n_individuals <- 0
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+  set.seed(123)
+  expect_error(
+    data_sd <-
+      standardise_community_data(
+        data_source_standard = data_subset,
+        n_individuals = n_individuals
+      ),
+    # none programmed into the function yet.
+    # e.g.,
+    # "Error: n_individuals must be > 0"
+  )
+})
+
+
 # Output validation
 # Valid data:
-test_that("standardise_community_data functions correctly with valid data", {
+test_that("standardise_community_data functions correctly (rowSums = n_individuals) with valid/default data", {
   n_individuals <- 150
   data_to_run_bins <-
     extract_data(
@@ -556,9 +801,14 @@ test_that("standardise_community_data functions correctly with valid data", {
       data_sd
     )
   )
+  expect_true(
+    all(
+      rowSums(data_sd[, -c(1:3)]) == n_individuals
+    )
+  )
 })
 
-test_that("standardise_community_data functions correctly with valid data", {
+test_that("standardise_community_data returns data.frame with valid data", {
   n_individuals <- 150
   data_to_run_bins <-
     extract_data(
@@ -632,8 +882,7 @@ test_that("standardise_community_data functions correctly with valid data", {
   )
 })
 
-
-test_that("standardise_community_data functions correctly with valid data", {
+test_that("standardise_community_data returns colnames correctly with valid data", {
   n_individuals <- 150
   data_to_run_bins <-
     extract_data(
@@ -707,4 +956,160 @@ test_that("standardise_community_data functions correctly with valid data", {
       c("label", "res_age", "age_diff") %in% names(data_sd)
     )
   )
+})
+
+# Reproducibility tests
+test_that("standardise_community_data returns consistent results with set seed", {
+  n_individuals <- 150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  set.seed(123)
+  data_sd_1 <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  set.seed(123)
+  data_sd_2 <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_identical(
+    data_sd_1,
+    data_sd_2
+  )
+})
+
+# Different seed produces different results
+test_that("standardise_community_data produces different results with different seeds", {
+  n_individuals <- 150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+  set.seed(123)
+  result1 <- standardise_community_data(
+    data_subset,
+    n_individuals
+  )
+
+  set.seed(456)
+  result2 <- standardise_community_data(
+    data_subset,
+    n_individuals
+  )
+
+  expect_false(identical(result1, result2))
 })

--- a/tests/testthat/test-standardise_community_data.R
+++ b/tests/testthat/test-standardise_community_data.R
@@ -1,0 +1,633 @@
+# False input validation
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      n_individuals = 150
+    ),
+    '"data_source_standard" is missing, with no default'
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = NULL,
+      n_individuals = 150
+    ),
+    "no applicable method for 'select' applied"
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = 123,
+      n_individuals = 150
+    ),
+    "no applicable method for 'select' applied"
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = "my_data",
+      n_individuals = 150
+    ),
+    "no applicable method for 'select' applied"
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = NA,
+      n_individuals = 150
+    ),
+    "no applicable method for 'select' applied"
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = list(),
+      n_individuals = 150
+    ),
+    "doesn't handle lists."
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = data.frame(),
+      n_individuals = 150
+    ),
+    "undefined columns selected"
+  )
+})
+
+test_that("standardise_community_data throws error if wrong input data is supploed", {
+  expect_error(
+    standardise_community_data(
+      data_source_standard = matrix(),
+      n_individuals = 150
+    ),
+    "no applicable method for 'select' applied"
+  )
+})
+
+
+
+# workflow within run_iteration:
+
+## Wrong n_individuals input
+# NULL
+test_that("standardise_community_data throws warning with n_individuals = NULL", {
+  n_individuals <- NULL
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  # -> if n_individuals = NULL, this will ignore it
+  # and overwrite n_individuals with the lowest value
+  # in com_data_sums.
+
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+
+  set.seed(123)
+  expect_warning(
+    data_sd <-
+      standardise_community_data(
+        data_source_standard = data_subset,
+        n_individuals = n_individuals
+      ),
+    # none programmed into function yet
+    # e.g.,
+    # "Warning: n_individuals = NULL will use min number of observations from the data for standardisation."
+  )
+})
+
+# Character
+test_that("standardise_community_data throws error with character n_individuals", {
+  n_individuals_char <- "10"
+
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals_char <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals_char
+      )
+    )
+
+  # check if all samples has n_individuals of individuals:
+  # -> will not work as intended if n_individuals_char is a character,
+  # leading to incorrect or empty results.
+
+  data_subset_char <-
+    data_subset[com_data_sums >= n_individuals_char, ]
+
+  data_subset_char <-
+    reduce_data_simple(
+      data_source_reduce = data_subset_char
+    )
+
+  # standardisation
+  set.seed(123)
+  expect_error(
+    data_sd_char <-
+      standardise_community_data(
+        data_source_standard = data_subset_char,
+        n_individuals = n_individuals_char
+      ),
+    #
+  )
+
+  # Control:
+  n_individuals_num <- 10
+  # adjust the value to a minimal of presented values
+
+  # -> will coerce all values to character,
+  # which can cause unexpected behavior in
+  # subsequent numeric comparisons and subsetting.
+
+  n_individuals_num <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals_num
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset_num <-
+    data_subset[com_data_sums >= n_individuals_num, ]
+
+  data_subset_num <-
+    reduce_data_simple(
+      data_source_reduce = data_subset_num
+    )
+
+  data_sd_num <-
+    standardise_community_data(
+      data_source_standard = data_subset_num,
+      n_individuals = n_individuals_num
+    )
+
+  # expect_identical(
+  #   data_sd_char,
+  #   data_sd_num
+  #   )
+})
+
+# high n_individuals
+test_that("standardise_community_data works with high n_individuals (within run_iteration workflow)", {
+  n_individuals <- 100000
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+  set.seed(123)
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_false(
+    identical(
+      data_subset,
+      data_sd
+    )
+  )
+})
+
+
+# without run_iteration workflow:
+test_that("standardise_community_data fails if n_individuals >> than n observations in sample (outside of run_iteration workflow)", {
+  n_individuals <- 100000
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  # standardisation
+  set.seed(123)
+
+  expect_error(
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    ),
+    "cannot take a sample larger than the population when 'replace = FALSE'"
+  )
+})
+
+
+# Output validation
+# Valid data:
+test_that("standardise_community_data functions correctly with valid data", {
+  n_individuals <- 150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+
+  set.seed(123)
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_false(
+    identical(
+      data_subset,
+      data_sd
+    )
+  )
+})
+
+test_that("standardise_community_data functions correctly with valid data", {
+  n_individuals <- 150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+
+  set.seed(123)
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_s3_class(
+    data_sd, "data.frame"
+  )
+})
+
+
+test_that("standardise_community_data functions correctly with valid data", {
+  n_individuals <- 150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+
+  set.seed(123)
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_true(
+    all(
+      c("label", "res_age", "age_diff") %in% names(data_sd)
+    )
+  )
+})

--- a/tests/testthat/test-standardise_community_data.R
+++ b/tests/testthat/test-standardise_community_data.R
@@ -1,5 +1,6 @@
 # False input validation
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       n_individuals = 150
@@ -8,7 +9,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = NULL,
@@ -18,7 +20,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = 123,
@@ -28,7 +31,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = "my_data",
@@ -38,7 +42,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = NA,
@@ -48,7 +53,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = list(),
@@ -58,7 +64,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = data.frame(),
@@ -68,7 +75,8 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-test_that("standardise_community_data throws error if wrong input data is supploed", {
+test_that(
+  "standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = matrix(),
@@ -78,14 +86,13 @@ test_that("standardise_community_data throws error if wrong input data is supplo
   )
 })
 
-
-
 # workflow within run_iteration:
-
 ## Wrong n_individuals input
-# NULL
-test_that("standardise_community_data throws warning with n_individuals = NULL", {
-  n_individuals <- NULL
+### NULL
+test_that(
+  "standardise_community_data throws warning with n_individuals = NULL", {
+  n_individuals <-
+    NULL
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -127,10 +134,6 @@ test_that("standardise_community_data throws warning with n_individuals = NULL",
     )
 
   # adjust the value to a minimal of presented values
-  # -> if n_individuals = NULL, this will ignore it
-  # and overwrite n_individuals with the lowest value
-  # in com_data_sums.
-
   n_individuals <-
     min(
       c(
@@ -149,7 +152,6 @@ test_that("standardise_community_data throws warning with n_individuals = NULL",
     )
 
   # standardisation
-
   set.seed(123)
   expect_warning(
     data_sd <-
@@ -163,9 +165,11 @@ test_that("standardise_community_data throws warning with n_individuals = NULL",
   )
 })
 
-# Character
-test_that("standardise_community_data returns identical results with character or numeric n_individuals", {
-  n_individuals_char <- "10"
+### Character
+test_that(
+  "standardise_community_data returns identical results with character or numeric n_individuals", {
+  n_individuals_char <-
+    "10"
 
   data_to_run_bins <-
     extract_data(
@@ -217,9 +221,6 @@ test_that("standardise_community_data returns identical results with character o
     )
 
   # check if all samples has n_individuals of individuals:
-  # -> will not work as intended if n_individuals_char is a character,
-  # leading to incorrect or empty results.
-
   data_subset_char <-
     data_subset[com_data_sums >= n_individuals_char, ]
 
@@ -241,18 +242,17 @@ test_that("standardise_community_data returns identical results with character o
 
   expect_true(
     all(
-      rowSums(data_sd_char[, -c(1:3)]) == 10
+      rowSums(
+    data_sd_char[, -c(
+    1:3)]) == 10
     )
   )
 
   # Control:
-  n_individuals_num <- 10
+  n_individuals_num <-
+    10
+  
   # adjust the value to a minimal of presented values
-
-  # -> will coerce all values to character,
-  # which can cause unexpected behavior in
-  # subsequent numeric comparisons and subsetting.
-
   n_individuals_num <-
     min(
       c(
@@ -290,9 +290,11 @@ test_that("standardise_community_data returns identical results with character o
 })
 
 
-# high n_individuals
-test_that("standardise_community_data returns n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
-  n_individuals <- 100000
+### high n_individuals
+test_that(
+  "standardise_community_data returns n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
+  n_individuals <-
+    100000
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -371,8 +373,11 @@ test_that("standardise_community_data returns n_individuals observations in samp
   )
 })
 
-test_that("standardise_community_data returns standardised data with high n_individuals (within run_iteration workflow)", {
-  n_individuals <- 100000
+### high
+test_that(
+  "standardise_community_data returns standardised data with high n_individuals (within run_iteration workflow)", {
+  n_individuals <-
+    100000
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -447,10 +452,244 @@ test_that("standardise_community_data returns standardised data with high n_indi
   )
 })
 
+### negative 
+test_that(
+  "standardise_community_data fails with negative n_individuals", {
+    n_individuals <-
+      -150
+    data_to_run_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      ) %>%
+      prepare_data(
+        data_source_prep = .,
+        working_units = "bins",
+        bin_size = 500,
+        rand = 1
+      ) %>%
+      RUtilpol::flatten_list_by_one() %>%
+      .[[1]]
+    
+    data_source_subset <-
+      data_to_run_bins$data
+    data_source_bins <-
+      data_to_run_bins$bins
+    
+    data_subset <-
+      subset_samples(
+        data_source_subset = data_source_subset,
+        data_source_bins = data_source_bins,
+        bin_selection = "first"
+      ) %>%
+      reduce_data_simple()
+    
+    com_data_sums <-
+      rowSums(
+        subset_community(
+          data_source = data_subset
+        ),
+        na.rm = TRUE
+      )
+    
+    # adjust the value to a minimal of presented values
+    n_individuals <-
+      min(
+        c(
+          com_data_sums,
+          n_individuals
+        )
+      )
+    
+    # check if all samples has n_individuals of individuals
+    data_subset <-
+      data_subset[com_data_sums >= n_individuals, ]
+    
+    data_subset <-
+      reduce_data_simple(
+        data_source_reduce = data_subset
+      )
+    
+    # standardisation
+    set.seed(123)
+    expect_error(
+      data_sd <-
+        standardise_community_data(
+          data_source_standard = data_subset,
+          n_individuals = n_individuals
+        ),
+      "invalid 'size' argument"
+    )
+  })
+
+### n_individuals = 1
+test_that(
+  "standardise_community_data works with n_individuals = 1", {
+    n_individuals <-
+      1
+    data_to_run_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      ) %>%
+      prepare_data(
+        data_source_prep = .,
+        working_units = "bins",
+        bin_size = 500,
+        rand = 1
+      ) %>%
+      RUtilpol::flatten_list_by_one() %>%
+      .[[1]]
+    
+    data_source_subset <-
+      data_to_run_bins$data
+    data_source_bins <-
+      data_to_run_bins$bins
+    
+    data_subset <-
+      subset_samples(
+        data_source_subset = data_source_subset,
+        data_source_bins = data_source_bins,
+        bin_selection = "first"
+      ) %>%
+      reduce_data_simple()
+    
+    com_data_sums <-
+      rowSums(
+        subset_community(
+          data_source = data_subset
+        ),
+        na.rm = TRUE
+      )
+    
+    # adjust the value to a minimal of presented values
+    n_individuals <-
+      min(
+        c(
+          com_data_sums,
+          n_individuals
+        )
+      )
+    
+    # check if all samples has n_individuals of individuals
+    data_subset <-
+      data_subset[com_data_sums >= n_individuals, ]
+    
+    data_subset <-
+      reduce_data_simple(
+        data_source_reduce = data_subset
+      )
+    
+    # standardisation
+    set.seed(123)
+    data_sd <-
+      standardise_community_data(
+        data_source_standard = data_subset,
+        n_individuals = n_individuals
+      )
+    
+    expect_true(
+      all(
+        rowSums(
+          data_sd[, -c(
+            1:3)]) == n_individuals
+      )
+    )
+  })
+
+# n_individuals = 0
+test_that(
+  "standardise_community_data fails with zero n_individuals", {
+    n_individuals <-
+      0
+    data_to_run_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      ) %>%
+      prepare_data(
+        data_source_prep = .,
+        working_units = "bins",
+        bin_size = 500,
+        rand = 1
+      ) %>%
+      RUtilpol::flatten_list_by_one() %>%
+      .[[1]]
+    
+    data_source_subset <-
+      data_to_run_bins$data
+    data_source_bins <-
+      data_to_run_bins$bins
+    
+    data_subset <-
+      subset_samples(
+        data_source_subset = data_source_subset,
+        data_source_bins = data_source_bins,
+        bin_selection = "first"
+      ) %>%
+      reduce_data_simple()
+    
+    com_data_sums <-
+      rowSums(
+        subset_community(
+          data_source = data_subset
+        ),
+        na.rm = TRUE
+      )
+    
+    # adjust the value to a minimal of presented values
+    n_individuals <-
+      min(
+        c(
+          com_data_sums,
+          n_individuals
+        )
+      )
+    
+    # check if all samples has n_individuals of individuals
+    data_subset <-
+      data_subset[com_data_sums >= n_individuals, ]
+    
+    data_subset <-
+      reduce_data_simple(
+        data_source_reduce = data_subset
+      )
+    
+    # standardisation
+    set.seed(123)
+    expect_error(
+      data_sd <-
+        standardise_community_data(
+          data_source_standard = data_subset,
+          n_individuals = n_individuals
+        ),
+      # none programmed into the function yet.
+      # e.g.,
+      # "Error: n_individuals must be > 0"
+    )
+  })
 
 # without run_iteration workflow:
-test_that("standardise_community_data fails if n_individuals >> than n observations in sample (outside of run_iteration workflow)", {
-  n_individuals <- 100000
+### high
+test_that(
+  "standardise_community_data fails if n_individuals >> than n observations in sample (outside of run_iteration workflow)", {
+  n_individuals <-
+    100000
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -495,239 +734,12 @@ test_that("standardise_community_data fails if n_individuals >> than n observati
   )
 })
 
-
-test_that("standardise_community_data fails with negative n_individuals", {
-  n_individuals <- -150
-  data_to_run_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-    ) %>%
-    reduce_data(
-      check_taxa = TRUE,
-      check_levels = TRUE
-    ) %>%
-    prepare_data(
-      data_source_prep = .,
-      working_units = "bins",
-      bin_size = 500,
-      rand = 1
-    ) %>%
-    RUtilpol::flatten_list_by_one() %>%
-    .[[1]]
-
-  data_source_subset <-
-    data_to_run_bins$data
-  data_source_bins <-
-    data_to_run_bins$bins
-
-  data_subset <-
-    subset_samples(
-      data_source_subset = data_source_subset,
-      data_source_bins = data_source_bins,
-      bin_selection = "first"
-    ) %>%
-    reduce_data_simple()
-
-  com_data_sums <-
-    rowSums(
-      subset_community(
-        data_source = data_subset
-      ),
-      na.rm = TRUE
-    )
-
-  # adjust the value to a minimal of presented values
-  n_individuals <-
-    min(
-      c(
-        com_data_sums,
-        n_individuals
-      )
-    )
-
-  # check if all samples has n_individuals of individuals
-  data_subset <-
-    data_subset[com_data_sums >= n_individuals, ]
-
-  data_subset <-
-    reduce_data_simple(
-      data_source_reduce = data_subset
-    )
-
-  # standardisation
-
-  set.seed(123)
-  expect_error(
-    data_sd <-
-      standardise_community_data(
-        data_source_standard = data_subset,
-        n_individuals = n_individuals
-      ),
-    "invalid 'size' argument"
-  )
-})
-
-# n_individuals = 1
-
-test_that("standardise_community_data works with n_individuals = 1", {
-  n_individuals <- 1
-  data_to_run_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-    ) %>%
-    reduce_data(
-      check_taxa = TRUE,
-      check_levels = TRUE
-    ) %>%
-    prepare_data(
-      data_source_prep = .,
-      working_units = "bins",
-      bin_size = 500,
-      rand = 1
-    ) %>%
-    RUtilpol::flatten_list_by_one() %>%
-    .[[1]]
-
-  data_source_subset <-
-    data_to_run_bins$data
-  data_source_bins <-
-    data_to_run_bins$bins
-
-  data_subset <-
-    subset_samples(
-      data_source_subset = data_source_subset,
-      data_source_bins = data_source_bins,
-      bin_selection = "first"
-    ) %>%
-    reduce_data_simple()
-
-  com_data_sums <-
-    rowSums(
-      subset_community(
-        data_source = data_subset
-      ),
-      na.rm = TRUE
-    )
-
-  # adjust the value to a minimal of presented values
-  n_individuals <-
-    min(
-      c(
-        com_data_sums,
-        n_individuals
-      )
-    )
-
-  # check if all samples has n_individuals of individuals
-  data_subset <-
-    data_subset[com_data_sums >= n_individuals, ]
-
-  data_subset <-
-    reduce_data_simple(
-      data_source_reduce = data_subset
-    )
-
-  # standardisation
-
-  set.seed(123)
-
-  data_sd <-
-    standardise_community_data(
-      data_source_standard = data_subset,
-      n_individuals = n_individuals
-    )
-
-  expect_true(
-    all(
-      rowSums(data_sd[, -c(1:3)]) == n_individuals
-    )
-  )
-})
-
-# n_individuals = 0
-test_that("standardise_community_data fails with zero n_individuals", {
-  n_individuals <- 0
-  data_to_run_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-    ) %>%
-    reduce_data(
-      check_taxa = TRUE,
-      check_levels = TRUE
-    ) %>%
-    prepare_data(
-      data_source_prep = .,
-      working_units = "bins",
-      bin_size = 500,
-      rand = 1
-    ) %>%
-    RUtilpol::flatten_list_by_one() %>%
-    .[[1]]
-
-  data_source_subset <-
-    data_to_run_bins$data
-  data_source_bins <-
-    data_to_run_bins$bins
-
-  data_subset <-
-    subset_samples(
-      data_source_subset = data_source_subset,
-      data_source_bins = data_source_bins,
-      bin_selection = "first"
-    ) %>%
-    reduce_data_simple()
-
-  com_data_sums <-
-    rowSums(
-      subset_community(
-        data_source = data_subset
-      ),
-      na.rm = TRUE
-    )
-
-  # adjust the value to a minimal of presented values
-  n_individuals <-
-    min(
-      c(
-        com_data_sums,
-        n_individuals
-      )
-    )
-
-  # check if all samples has n_individuals of individuals
-  data_subset <-
-    data_subset[com_data_sums >= n_individuals, ]
-
-  data_subset <-
-    reduce_data_simple(
-      data_source_reduce = data_subset
-    )
-
-  # standardisation
-  set.seed(123)
-  expect_error(
-    data_sd <-
-      standardise_community_data(
-        data_source_standard = data_subset,
-        n_individuals = n_individuals
-      ),
-    # none programmed into the function yet.
-    # e.g.,
-    # "Error: n_individuals must be > 0"
-  )
-})
-
-
 # Output validation
 # Valid data:
-test_that("standardise_community_data functions correctly (rowSums = n_individuals) with valid/default data", {
-  n_individuals <- 150
+test_that(
+  "standardise_community_data functions correctly (rowSums = n_individuals) with valid/default data", {
+  n_individuals <-
+    150
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -787,7 +799,6 @@ test_that("standardise_community_data functions correctly (rowSums = n_individua
     )
 
   # standardisation
-
   set.seed(123)
   data_sd <-
     standardise_community_data(
@@ -803,13 +814,17 @@ test_that("standardise_community_data functions correctly (rowSums = n_individua
   )
   expect_true(
     all(
-      rowSums(data_sd[, -c(1:3)]) == n_individuals
+      rowSums(
+    data_sd[, -c(
+    1:3)]) == n_individuals
     )
   )
 })
 
-test_that("standardise_community_data returns data.frame with valid data", {
-  n_individuals <- 150
+test_that(
+  "standardise_community_data returns data.frame with valid data", {
+  n_individuals <-
+    150
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -869,7 +884,6 @@ test_that("standardise_community_data returns data.frame with valid data", {
     )
 
   # standardisation
-
   set.seed(123)
   data_sd <-
     standardise_community_data(
@@ -882,8 +896,10 @@ test_that("standardise_community_data returns data.frame with valid data", {
   )
 })
 
-test_that("standardise_community_data returns colnames correctly with valid data", {
-  n_individuals <- 150
+test_that(
+  "standardise_community_data returns colnames correctly with valid data", {
+  n_individuals <-
+    150
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -943,7 +959,6 @@ test_that("standardise_community_data returns colnames correctly with valid data
     )
 
   # standardisation
-
   set.seed(123)
   data_sd <-
     standardise_community_data(
@@ -959,8 +974,10 @@ test_that("standardise_community_data returns colnames correctly with valid data
 })
 
 # Reproducibility tests
-test_that("standardise_community_data returns consistent results with set seed", {
-  n_individuals <- 150
+test_that(
+  "standardise_community_data returns consistent results with set seed", {
+  n_individuals <-
+    150
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1040,8 +1057,10 @@ test_that("standardise_community_data returns consistent results with set seed",
 })
 
 # Different seed produces different results
-test_that("standardise_community_data produces different results with different seeds", {
-  n_individuals <- 150
+test_that(
+  "standardise_community_data produces different results with different seeds", {
+  n_individuals <-
+    150
   data_to_run_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1100,13 +1119,15 @@ test_that("standardise_community_data produces different results with different 
       data_source_reduce = data_subset
     )
   set.seed(123)
-  result1 <- standardise_community_data(
+  result1 <-
+    standardise_community_data(
     data_subset,
     n_individuals
   )
 
   set.seed(456)
-  result2 <- standardise_community_data(
+  result2 <-
+    standardise_community_data(
     data_subset,
     n_individuals
   )

--- a/tests/testthat/test-standardise_community_data.R
+++ b/tests/testthat/test-standardise_community_data.R
@@ -1,6 +1,5 @@
 # False input validation
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       n_individuals = 150
@@ -9,8 +8,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = NULL,
@@ -20,8 +18,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = 123,
@@ -31,8 +28,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = "my_data",
@@ -42,8 +38,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = NA,
@@ -53,8 +48,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = list(),
@@ -64,8 +58,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = data.frame(),
@@ -75,8 +68,7 @@ test_that(
   )
 })
 
-test_that(
-  "standardise_community_data throws error if wrong input data is supploed", {
+test_that("standardise_community_data throws error if wrong input data is supploed", {
   expect_error(
     standardise_community_data(
       data_source_standard = matrix(),
@@ -89,8 +81,7 @@ test_that(
 # workflow within run_iteration:
 ## Wrong n_individuals input
 ### NULL
-test_that(
-  "standardise_community_data throws warning with n_individuals = NULL", {
+test_that("standardise_community_data throws warning with n_individuals = NULL", {
   n_individuals <-
     NULL
   data_to_run_bins <-
@@ -161,14 +152,13 @@ test_that(
       ),
     # none programmed into function yet
     # e.g.,
-    # "Warning: n_individuals = NULL will use default 
+    # "Warning: n_individuals = NULL will use default
     # (min number of observations from the data) for standardisation."
   )
 })
 
 ### Character
-test_that(
-  "standardise_community_data returns identical results with character or numeric n_individuals", {
+test_that("standardise_community_data returns identical results with character or numeric n_individuals", {
   n_individuals_char <-
     "10"
 
@@ -244,15 +234,20 @@ test_that(
   expect_true(
     all(
       rowSums(
-    data_sd_char[, -c(
-    1:3)]) == 10
+        data_sd_char[,
+          -c(
+            1:3
+          )
+        ]
+      ) ==
+        10
     )
   )
 
   # Control:
   n_individuals_num <-
     10
-  
+
   # adjust the value to a minimal of presented values
   n_individuals_num <-
     min(
@@ -292,8 +287,7 @@ test_that(
 
 
 ### high n_individuals
-test_that(
-  "standardise_community_data returns min n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
+test_that("standardise_community_data returns min n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
   n_individuals <-
     100000
   data_to_run_bins <-
@@ -375,8 +369,7 @@ test_that(
 })
 
 ### high
-test_that(
-  "standardise_community_data returns standardised data with high n_individuals (within run_iteration workflow)", {
+test_that("standardise_community_data returns standardised data with high n_individuals (within run_iteration workflow)", {
   n_individuals <-
     100000
   data_to_run_bins <-
@@ -453,242 +446,243 @@ test_that(
   )
 })
 
-### negative 
-test_that(
-  "standardise_community_data fails with negative n_individuals", {
-    n_individuals <-
-      -150
-    data_to_run_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      ) %>%
-      prepare_data(
-        data_source_prep = .,
-        working_units = "bins",
-        bin_size = 500,
-        rand = 1
-      ) %>%
-      RUtilpol::flatten_list_by_one() %>%
-      .[[1]]
-    
-    data_source_subset <-
-      data_to_run_bins$data
-    data_source_bins <-
-      data_to_run_bins$bins
-    
-    data_subset <-
-      subset_samples(
-        data_source_subset = data_source_subset,
-        data_source_bins = data_source_bins,
-        bin_selection = "first"
-      ) %>%
-      reduce_data_simple()
-    
-    com_data_sums <-
-      rowSums(
-        subset_community(
-          data_source = data_subset
-        ),
-        na.rm = TRUE
-      )
-    
-    # adjust the value to a minimal of presented values
-    n_individuals <-
-      min(
-        c(
-          com_data_sums,
-          n_individuals
-        )
-      )
-    
-    # check if all samples has n_individuals of individuals
-    data_subset <-
-      data_subset[com_data_sums >= n_individuals, ]
-    
-    data_subset <-
-      reduce_data_simple(
-        data_source_reduce = data_subset
-      )
-    
-    # standardisation
-    set.seed(123)
-    expect_error(
-      data_sd <-
-        standardise_community_data(
-          data_source_standard = data_subset,
-          n_individuals = n_individuals
-        ),
-      "invalid 'size' argument"
-    )
-  })
+### negative
+test_that("standardise_community_data fails with negative n_individuals", {
+  n_individuals <-
+    -150
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
 
-### n_individuals = 1
-test_that(
-  "standardise_community_data works with n_individuals = 1", {
-    n_individuals <-
-      1
-    data_to_run_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      ) %>%
-      prepare_data(
-        data_source_prep = .,
-        working_units = "bins",
-        bin_size = 500,
-        rand = 1
-      ) %>%
-      RUtilpol::flatten_list_by_one() %>%
-      .[[1]]
-    
-    data_source_subset <-
-      data_to_run_bins$data
-    data_source_bins <-
-      data_to_run_bins$bins
-    
-    data_subset <-
-      subset_samples(
-        data_source_subset = data_source_subset,
-        data_source_bins = data_source_bins,
-        bin_selection = "first"
-      ) %>%
-      reduce_data_simple()
-    
-    com_data_sums <-
-      rowSums(
-        subset_community(
-          data_source = data_subset
-        ),
-        na.rm = TRUE
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
       )
-    
-    # adjust the value to a minimal of presented values
-    n_individuals <-
-      min(
-        c(
-          com_data_sums,
-          n_individuals
-        )
-      )
-    
-    # check if all samples has n_individuals of individuals
-    data_subset <-
-      data_subset[com_data_sums >= n_individuals, ]
-    
-    data_subset <-
-      reduce_data_simple(
-        data_source_reduce = data_subset
-      )
-    
-    # standardisation
-    set.seed(123)
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+  set.seed(123)
+  expect_error(
     data_sd <-
       standardise_community_data(
         data_source_standard = data_subset,
         n_individuals = n_individuals
-      )
-    
-    expect_true(
-      all(
-        rowSums(
-          data_sd[, -c(
-            1:3)]) == n_individuals
+      ),
+    "invalid 'size' argument"
+  )
+})
+
+### n_individuals = 1
+test_that("standardise_community_data works with n_individuals = 1", {
+  n_individuals <-
+    1
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
       )
     )
-  })
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+  set.seed(123)
+  data_sd <-
+    standardise_community_data(
+      data_source_standard = data_subset,
+      n_individuals = n_individuals
+    )
+
+  expect_true(
+    all(
+      rowSums(
+        data_sd[,
+          -c(
+            1:3
+          )
+        ]
+      ) ==
+        n_individuals
+    )
+  )
+})
 
 # n_individuals = 0
-test_that(
-  "standardise_community_data fails with zero n_individuals", {
-    n_individuals <-
-      0
-    data_to_run_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      ) %>%
-      prepare_data(
-        data_source_prep = .,
-        working_units = "bins",
-        bin_size = 500,
-        rand = 1
-      ) %>%
-      RUtilpol::flatten_list_by_one() %>%
-      .[[1]]
-    
-    data_source_subset <-
-      data_to_run_bins$data
-    data_source_bins <-
-      data_to_run_bins$bins
-    
-    data_subset <-
-      subset_samples(
-        data_source_subset = data_source_subset,
-        data_source_bins = data_source_bins,
-        bin_selection = "first"
-      ) %>%
-      reduce_data_simple()
-    
-    com_data_sums <-
-      rowSums(
-        subset_community(
-          data_source = data_subset
-        ),
-        na.rm = TRUE
-      )
-    
-    # adjust the value to a minimal of presented values
-    n_individuals <-
-      min(
-        c(
-          com_data_sums,
-          n_individuals
-        )
-      )
-    
-    # check if all samples has n_individuals of individuals
-    data_subset <-
-      data_subset[com_data_sums >= n_individuals, ]
-    
-    data_subset <-
-      reduce_data_simple(
-        data_source_reduce = data_subset
-      )
-    
-    # standardisation
-    set.seed(123)
-    expect_error(
-      data_sd <-
-        standardise_community_data(
-          data_source_standard = data_subset,
-          n_individuals = n_individuals
-        ),
-      # none programmed into the function yet.
-      # e.g.,
-      # "Error: n_individuals must be > 0"
+test_that("standardise_community_data fails with zero n_individuals", {
+  n_individuals <-
+    0
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
     )
-  })
+
+  # adjust the value to a minimal of presented values
+  n_individuals <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals
+      )
+    )
+
+  # check if all samples has n_individuals of individuals
+  data_subset <-
+    data_subset[com_data_sums >= n_individuals, ]
+
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  # standardisation
+  set.seed(123)
+  expect_error(
+    data_sd <-
+      standardise_community_data(
+        data_source_standard = data_subset,
+        n_individuals = n_individuals
+      ),
+    # none programmed into the function yet.
+    # e.g.,
+    # "Error: n_individuals must be > 0"
+  )
+})
 
 # without run_iteration workflow:
 ### high
-test_that(
-  "standardise_community_data fails if n_individuals >> than n observations in sample (outside of run_iteration workflow)", {
+test_that("standardise_community_data fails if n_individuals >> than n observations in sample (outside of run_iteration workflow)", {
   n_individuals <-
     100000
   data_to_run_bins <-
@@ -737,8 +731,7 @@ test_that(
 
 # Output validation
 # Valid data:
-test_that(
-  "standardise_community_data functions correctly (rowSums = n_individuals) with valid/default data", {
+test_that("standardise_community_data functions correctly (rowSums = n_individuals) with valid/default data", {
   n_individuals <-
     150
   data_to_run_bins <-
@@ -816,14 +809,18 @@ test_that(
   expect_true(
     all(
       rowSums(
-    data_sd[, -c(
-    1:3)]) == n_individuals
+        data_sd[,
+          -c(
+            1:3
+          )
+        ]
+      ) ==
+        n_individuals
     )
   )
 })
 
-test_that(
-  "standardise_community_data returns data.frame with valid data", {
+test_that("standardise_community_data returns data.frame with valid data", {
   n_individuals <-
     150
   data_to_run_bins <-
@@ -893,12 +890,12 @@ test_that(
     )
 
   expect_s3_class(
-    data_sd, "data.frame"
+    data_sd,
+    "data.frame"
   )
 })
 
-test_that(
-  "standardise_community_data returns colnames correctly with valid data", {
+test_that("standardise_community_data returns colnames correctly with valid data", {
   n_individuals <-
     150
   data_to_run_bins <-
@@ -975,8 +972,7 @@ test_that(
 })
 
 # Reproducibility tests
-test_that(
-  "standardise_community_data returns consistent results with set seed", {
+test_that("standardise_community_data returns consistent results with set seed", {
   n_individuals <-
     150
   data_to_run_bins <-
@@ -1058,8 +1054,7 @@ test_that(
 })
 
 # Different seed produces different results
-test_that(
-  "standardise_community_data produces different results with different seeds", {
+test_that("standardise_community_data produces different results with different seeds", {
   n_individuals <-
     150
   data_to_run_bins <-
@@ -1122,16 +1117,16 @@ test_that(
   set.seed(123)
   result1 <-
     standardise_community_data(
-    data_subset,
-    n_individuals
-  )
+      data_subset,
+      n_individuals
+    )
 
   set.seed(456)
   result2 <-
     standardise_community_data(
-    data_subset,
-    n_individuals
-  )
+      data_subset,
+      n_individuals
+    )
 
   expect_false(identical(result1, result2))
 })

--- a/tests/testthat/test-standardise_community_data.R
+++ b/tests/testthat/test-standardise_community_data.R
@@ -236,17 +236,93 @@ test_that("standardise_community_data throws error with character n_individuals"
         data_source_standard = data_subset_char,
         n_individuals = n_individuals_char
       ),
+    # none programmed into the function yet
+  )
+})
+
+test_that("standardise_community_data works with character n_individuals", {
+  n_individuals_char <- "10"
+  
+  data_to_run_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    ) %>%
+    prepare_data(
+      data_source_prep = .,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    ) %>%
+    RUtilpol::flatten_list_by_one() %>%
+    .[[1]]
+  
+  data_source_subset <-
+    data_to_run_bins$data
+  data_source_bins <-
+    data_to_run_bins$bins
+  
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_subset,
+      data_source_bins = data_source_bins,
+      bin_selection = "first"
+    ) %>%
+    reduce_data_simple()
+  
+  com_data_sums <-
+    rowSums(
+      subset_community(
+        data_source = data_subset
+      ),
+      na.rm = TRUE
+    )
+  
+  # adjust the value to a minimal of presented values
+  n_individuals_char <-
+    min(
+      c(
+        com_data_sums,
+        n_individuals_char
+      )
+    )
+  
+  # check if all samples has n_individuals of individuals:
+  # -> will not work as intended if n_individuals_char is a character,
+  # leading to incorrect or empty results.
+  
+  data_subset_char <-
+    data_subset[com_data_sums >= n_individuals_char, ]
+  
+  data_subset_char <-
+    reduce_data_simple(
+      data_source_reduce = data_subset_char
+    )
+  
+  # standardisation
+  set.seed(123)
+  expect_no_error(
+    data_sd_char <-
+      standardise_community_data(
+        data_source_standard = data_subset_char,
+        n_individuals = n_individuals_char
+      )
     #
   )
-
+  
   # Control:
   n_individuals_num <- 10
   # adjust the value to a minimal of presented values
-
+  
   # -> will coerce all values to character,
   # which can cause unexpected behavior in
   # subsequent numeric comparisons and subsetting.
-
+  
   n_individuals_num <-
     min(
       c(
@@ -254,27 +330,28 @@ test_that("standardise_community_data throws error with character n_individuals"
         n_individuals_num
       )
     )
-
+  
   # check if all samples has n_individuals of individuals
   data_subset_num <-
     data_subset[com_data_sums >= n_individuals_num, ]
-
+  
   data_subset_num <-
     reduce_data_simple(
       data_source_reduce = data_subset_num
     )
-
+  
   data_sd_num <-
     standardise_community_data(
       data_source_standard = data_subset_num,
       n_individuals = n_individuals_num
     )
-
-  # expect_identical(
-  #   data_sd_char,
-  #   data_sd_num
-  #   )
+  
+  expect_identical(
+    data_sd_char,
+    data_sd_num
+    )
 })
+
 
 # high n_individuals
 test_that("standardise_community_data works with high n_individuals (within run_iteration workflow)", {

--- a/tests/testthat/test-standardise_community_data.R
+++ b/tests/testthat/test-standardise_community_data.R
@@ -161,7 +161,8 @@ test_that(
       ),
     # none programmed into function yet
     # e.g.,
-    # "Warning: n_individuals = NULL will use min number of observations from the data for standardisation."
+    # "Warning: n_individuals = NULL will use default 
+    # (min number of observations from the data) for standardisation."
   )
 })
 
@@ -292,7 +293,7 @@ test_that(
 
 ### high n_individuals
 test_that(
-  "standardise_community_data returns n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
+  "standardise_community_data returns min n_individuals observations in samples with high n_individuals (within run_iteration workflow)", {
   n_individuals <-
     100000
   data_to_run_bins <-


### PR DESCRIPTION
Test suite for `standardise_community_data()`, including the following tests:
### 1. Input Validation Tests
#### Invalid `data_source_standard` Parameter
- **Missing parameter**: Tests error when no `data_source_standard` is provided
  - Expected error: `"data_source_standard" is missing, with no default`
- **NULL input**: Tests behavior with `NULL` value
  - Expected error: `no applicable method for 'select' applied`
- **Numeric input**: Tests with numeric value `123`
  - Expected error: `no applicable method for 'select' applied`
- **Character input**: Tests with string `"my_data"`
  - Expected error: `no applicable method for 'select' applied`
- **NA input**: Tests with `NA` value
  - Expected error: `no applicable method for 'select' applied`
- **List input**: Tests with empty list `list()`
  - Expected error: `doesn't handle lists.`
- **Empty data.frame**: Tests with `data.frame()`
  - Expected error: `undefined columns selected`
- **Matrix input**: Tests with `matrix()`
  - Expected error: `no applicable method for 'select' applied`

### 2. Parameter Validation Tests
#### `n_individuals` Parameter Edge Cases
- **NULL value**: Tests with `n_individuals = NULL`
  - *Note: Warning message not yet implemented*
- **Character input**: Tests character `"10"` vs numeric `10`
  - Validates identical results between character and numeric inputs
- **High value (within workflow)**: Tests `n_individuals = 100000`
  - Validates proper adjustment to minimum available count
- **Negative value**: Tests `n_individuals = -150`
  - Expected error: `invalid 'size' argument`
- **Edge case**: Tests `n_individuals = 1`
  - Validates function works with minimum valid input
- **Zero value**: Tests `n_individuals = 0`
  - *Note: Error handling not yet implemented*

### 3. Workflow Context Tests
#### Within `run_iteration` Workflow
- **High `n_individuals`**: Validates proper handling when `n_individuals` exceeds available data
- **Outside workflow**: Tests failure when high `n_individuals` used without preprocessing
  - Expected error: `cannot take a sample larger than the population when 'replace = FALSE'`

### 4. Output Validation Tests
#### Valid Data Processing
- **Row sum validation**: Confirms all row sums equal `n_individuals` after standardization
- **Return type**: Validates function returns `data.frame` object
- **Column preservation**: Checks required columns (`"label"`, `"res_age"`, `"age_diff"`) are present
- **Data transformation**: Confirms output differs from input (standardization occurred)

### 5. Reproducibility Tests
#### Seed Consistency
- **Same seed**: Validates identical results with `set.seed(123)`
- **Different seeds**: Confirms different results with different seeds (`123` vs `456`)