### PR TITLE
`prepare_data()` & `make_bins()`: Test suite

### DIFF
--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -7,916 +7,999 @@
 # ---------------------------------------------------------- #
 
 test_that(
-  "make_bins rejects missing age data in data_source_bins", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects missing age data in data_source_bins",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age <-
+      NULL
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "`names` must be a character vector"
     )
-
-  data_source_bins$age <-
-    NULL
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "`names` must be a character vector"
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins validates data input class == list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins validates data input class == list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    class(
+      data_source_bins
+    ) <-
+      "data.frame"
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'data_source_bins' must be one of the following: 'list'"
     )
-
-  class(
-    data_source_bins) <-
-    "data.frame"
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'data_source_bins' must be one of the following: 'list'"
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins rejects data input class == character", {
-  expect_error(
-    make_bins(
-      "data",
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'data_source_bins' must be one of the following: 'list'"
-  )
-})
+  "make_bins rejects data input class == character",
+  {
+    expect_error(
+      make_bins(
+        "data",
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'data_source_bins' must be one of the following: 'list'"
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data input class == numeric", {
-  expect_error(
-    make_bins(
-      123,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'data_source_bins' must be one of the following: 'list'"
-  )
-})
+  "make_bins rejects data input class == numeric",
+  {
+    expect_error(
+      make_bins(
+        123,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'data_source_bins' must be one of the following: 'list'"
+    )
+  }
+)
 
 # Additional tests:
 
 test_that(
-  "make_bins rejects empty data_source_bins", {
-  expect_error(
-    make_bins(
-      list(),
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "argument of length 0"
-  )
-})
-
-
-test_that(
-  "make_bins rejects NA data_source_bins", {
-  expect_error(
-    make_bins(
-      NA,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'data_source_bins' must be one of the following: 'list'"
-  )
-})
-
-test_that(
-  "make_bins rejects matrix data_source_bins", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects empty data_source_bins",
+  {
+    expect_error(
+      make_bins(
+        list(),
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "argument of length 0"
     )
+  }
+)
 
-  data_source_bins <-
-    as.matrix(data_source_bins)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'data_source_bins' must be one of the following: 'list'"
-  )
-})
 
 test_that(
-  "make_bins rejects 0 data_source_bins", {
-  expect_error(
-    make_bins(
-      0,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'data_source_bins' must be one of the following: 'list'"
-  )
-})
+  "make_bins rejects NA data_source_bins",
+  {
+    expect_error(
+      make_bins(
+        NA,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'data_source_bins' must be one of the following: 'list'"
+    )
+  }
+)
 
 test_that(
-  "make_bins works with default parameters", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins rejects matrix data_source_bins",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
+    data_source_bins <-
+      as.matrix(data_source_bins)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'data_source_bins' must be one of the following: 'list'"
     )
-  )
-})
+  }
+)
+
+test_that(
+  "make_bins rejects 0 data_source_bins",
+  {
+    expect_error(
+      make_bins(
+        0,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'data_source_bins' must be one of the following: 'list'"
+    )
+  }
+)
+
+test_that(
+  "make_bins works with default parameters",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      )
+    )
+  }
+)
 
 # Data specific validation:
 test_that(
-  "make_bins rejects data_source_bins with all empty elements in the list", {
-  data_source_bins <-
-    list(
-      community = data.frame(),
-      age = data.frame(
-    age = numeric(
-    )),
-      age_un = data.frame()
-    )
+  "make_bins rejects data_source_bins with all empty elements in the list",
+  {
+    data_source_bins <-
+      list(
+        community = data.frame(),
+        age = data.frame(
+          age = numeric()
+        ),
+        age_un = data.frame()
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "`age_diff` must be size 1, not 2."
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "`age_diff` must be size 1, not 2."
+    )
+  }
+)
 
 
 ## A suite of tests that fail because
 ## the function does not handle the community part of the data at all
 
 test_that(
-  "make_bins rejects data_source_bins without community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community <-
-    NULL
+  "make_bins rejects data_source_bins without community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community <-
+      NULL
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 
 test_that(
-  "make_bins rejects data_source_bins list community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community <-
-    list(data_source_bins$community)
+  "make_bins rejects data_source_bins list community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community <-
+      list(data_source_bins$community)
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data_source_bins matrix community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community <-
-    as.matrix(data_source_bins$community)
+  "make_bins rejects data_source_bins matrix community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community <-
+      as.matrix(data_source_bins$community)
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 
 test_that(
-  "make_bins rejects data_source_bins character community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community <-
-    "my_community"
+  "make_bins rejects data_source_bins character community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community <-
+      "my_community"
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data_source_bins numeric community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community <-
-    123
+  "make_bins rejects data_source_bins numeric community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community <-
+      123
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data_source_bins NA community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community[, ] <-
-    NA
+  "make_bins rejects data_source_bins NA community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community[, ] <-
+      NA
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data_source_bins 0 community in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$community[, ] <-
-    0
+  "make_bins rejects data_source_bins 0 community in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$community[, ] <-
+      0
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data_source_bins with community without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  rownames(data_source_bins$community) <-
-    NULL
+  "make_bins rejects data_source_bins with community without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    rownames(data_source_bins$community) <-
+      NULL
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 
 ## Age:
 test_that(
-  "make_bins rejects data_source_bins without age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age <-
-    NULL
+  "make_bins rejects data_source_bins without age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age <-
+      NULL
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "`names` must be a character vector"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "`names` must be a character vector"
+    )
+  }
+)
 
 
 test_that(
-  "make_bins rejects data_source_bins list age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age <-
-    list(data_source_bins$age)
+  "make_bins rejects data_source_bins list age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age <-
+      list(data_source_bins$age)
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "argument of length 0"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "argument of length 0"
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects data_source_bins matrix age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects data_source_bins matrix age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age <-
+      as.matrix(data_source_bins$age)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "Argument 1 must be a data frame or a named atomic vector"
     )
-  data_source_bins$age <-
-    as.matrix(data_source_bins$age)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "Argument 1 must be a data frame or a named atomic vector"
-  )
-})
-
-
-test_that(
-  "make_bins rejects data_source_bins character age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age <-
-    "my_age"
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "Argument 1 must be a data frame or a named atomic vector"
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins numeric age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age <-
-    123
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "Argument 1 must be a data frame or a named atomic vector"
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins NA age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age[, ] <-
-    NA
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels",
-    ),
-    # no error programmed into the function yet
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins NA age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age[, ] <-
-    NA
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    ),
-    "'from' must be a finite number"
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins NA age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age[, ] <-
-    NA
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'from' must be a finite number"
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins 0 age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age[, ] <-
-    0
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels"
-    ),
-    # no error programmed into the function yet
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins 0 age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age[, ] <-
-    0
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    ),
-    # no error programmed into the function yet
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins 0 age in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age[, ] <-
-    0
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  rownames(data_source_bins$age) <-
-    NULL
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels"
-    ),
-    # no error programmed into the function yet
-  )
-})
+  }
+)
 
 
 test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  rownames(data_source_bins$age) <-
-    NULL
+  "make_bins rejects data_source_bins character age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age <-
+      "my_age"
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "Argument 1 must be a data frame or a named atomic vector"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins numeric age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age <-
+      123
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "Argument 1 must be a data frame or a named atomic vector"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins NA age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age[, ] <-
+      NA
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "levels",
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins NA age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age[, ] <-
+      NA
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      ),
+      "'from' must be a finite number"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins NA age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age[, ] <-
+      NA
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'from' must be a finite number"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins 0 age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age[, ] <-
+      0
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "levels"
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins 0 age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age[, ] <-
+      0
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins 0 age in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age[, ] <-
+      0
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    rownames(data_source_bins$age) <-
+      NULL
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "levels"
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 
 test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  rownames(data_source_bins$age) <-
-    NULL
+  "make_bins rejects data_source_bins with age without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    rownames(data_source_bins$age) <-
+      NULL
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    # no error programmed into the function yet
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
+
+
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    rownames(data_source_bins$age) <-
+      NULL
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      # no error programmed into the function yet
+    )
+  }
+)
 
 
 # character values inside age
 test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age$age <-
-    as.character(data_source_bins$age$age)
+  "make_bins rejects data_source_bins with age without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age$age <-
+      as.character(data_source_bins$age$age)
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels"
-    ),
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age$age <-
-    as.character(data_source_bins$age$age)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    ),
-    "non-numeric argument to mathematical function"
-  )
-})
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  data_source_bins$age$age <-
-    as.character(data_source_bins$age$age)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts =
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "levels"
       ),
-    "non-numeric argument to mathematical function"
-  )
-})
+    )
+  }
+)
 
 test_that(
-  "make_bins accepts minimal age data (1 row)", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects data_source_bins with age without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age$age <-
+      as.character(data_source_bins$age$age)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      ),
+      "non-numeric argument to mathematical function"
     )
-
-  data_source_bins$community <-
-    data_source_bins$community[1, , drop = FALSE]
-  data_source_bins$age <-
-    data_source_bins$age[1, , drop = FALSE]
-  data_source_bins$age_un <-
-    data_source_bins$age_un[, 1, drop = FALSE]
-
-
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels"
-    )
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins accepts minimal age data (1 row)", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects data_source_bins with age without rownames in the list",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    data_source_bins$age$age <-
+      as.character(data_source_bins$age$age)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts =
+        ),
+      "non-numeric argument to mathematical function"
     )
-
-  data_source_bins$community <-
-    data_source_bins$community[1, , drop = FALSE]
-  data_source_bins$age <-
-    data_source_bins$age[1, , drop = FALSE]
-  data_source_bins$age_un <-
-    data_source_bins$age_un[, 1, drop = FALSE]
-
-
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    )
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins accepts minimal age data (1 row)", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins accepts minimal age data (1 row)",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$community <-
+      data_source_bins$community[1, , drop = FALSE]
+    data_source_bins$age <-
+      data_source_bins$age[1, , drop = FALSE]
+    data_source_bins$age_un <-
+      data_source_bins$age_un[, 1, drop = FALSE]
+
+
+    expect_no_error(
+      make_bins(
+        data_source_bins,
+        working_units = "levels"
+      )
     )
+  }
+)
 
-  data_source_bins$community <-
-    data_source_bins$community[1, , drop = FALSE]
-  data_source_bins$age <-
-    data_source_bins$age[1, , drop = FALSE]
-  data_source_bins$age_un <-
-    data_source_bins$age_un[, 1, drop = FALSE]
+test_that(
+  "make_bins accepts minimal age data (1 row)",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$community <-
+      data_source_bins$community[1, , drop = FALSE]
+    data_source_bins$age <-
+      data_source_bins$age[1, , drop = FALSE]
+    data_source_bins$age_un <-
+      data_source_bins$age_un[, 1, drop = FALSE]
 
 
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
+    expect_no_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      )
     )
-  )
-})
+  }
+)
+
+test_that(
+  "make_bins accepts minimal age data (1 row)",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$community <-
+      data_source_bins$community[1, , drop = FALSE]
+    data_source_bins$age <-
+      data_source_bins$age[1, , drop = FALSE]
+    data_source_bins$age_un <-
+      data_source_bins$age_un[, 1, drop = FALSE]
+
+
+    expect_no_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      )
+    )
+  }
+)
 
 
 # age with character strings instead of numeric
 test_that(
-  "make_bins rejects age with character strings instead of numeric", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects age with character strings instead of numeric",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age <-
+      as.character(data_source_bins$age$age)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "levels"
+      ), #
+      "Can't combine"
     )
-
-  data_source_bins$age$age <-
-    as.character(data_source_bins$age$age)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels"
-    ), #
-    "Can't combine"
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins rejects age with character strings instead of numeric", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects age with character strings instead of numeric",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age <-
+      as.character(data_source_bins$age$age)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      ), #
+      "non-numeric argument to mathematical function"
     )
-
-  data_source_bins$age$age <-
-    as.character(data_source_bins$age$age)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    ), #
-    "non-numeric argument to mathematical function"
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins rejects age with character strings instead of numeric", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins rejects age with character strings instead of numeric",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age <-
+      as.character(data_source_bins$age$age)
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      ), #
+      "non-numeric argument to mathematical function"
     )
-
-  data_source_bins$age$age <-
-    as.character(data_source_bins$age$age)
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    ), #
-    "non-numeric argument to mathematical function"
-  )
-})
+  }
+)
 
 
 # ---------------------------------------------------------- #
@@ -924,174 +1007,192 @@ test_that(
 # ---------------------------------------------------------- #
 
 test_that(
-  "make_bins validates that there is a working_unit as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins validates that there is a working_unit as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = NULL
-    ), "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = NULL
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 ## (fails - it silently uses "bins" and default bin_size = 500
 test_that(
-  "make_bins rejects no working_unit as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins rejects no working_unit as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-    ), "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 test_that(
-  "make_bins validates that working_unit is not NULL", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins validates that working_unit is not NULL",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = NULL
-    ), "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = NULL
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 test_that(
-  "make_bins validates correct working_unit value as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins validates correct working_unit value as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = 123
-    ), "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = 123
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 test_that(
-  "make_bins validates correct working_unit value as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins validates correct working_unit value as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "invalid input"
-    ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "invalid input"
+      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+    )
+  }
+)
 
 test_that(
-  "make_bins validates correct working_unit value as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins validates correct working_unit value as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins")
-    ), "'arg' must be of length 1"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins")
+      ), "'arg' must be of length 1"
+    )
+  }
+)
 
 test_that(
-  "make_bins validates correct working_unit value as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins validates correct working_unit value as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = c("levels", "bins"),
-      bin_size = 500,
-      number_of_shifts = 5
-    ), "'arg' must be of length 1"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins"),
+        bin_size = 500,
+        number_of_shifts = 5
+      ), "'arg' must be of length 1"
+    )
+  }
+)
 
 ## (fails right now - it will take always the first method in the vector without error or warning)
 test_that(
-  "make_bins rejects multiple working_units as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+  "make_bins rejects multiple working_units as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
       )
-    # no error/warning programmed into the function yet
-  )
-})
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = c("levels", "bins", "MW"),
+          bin_size = 500,
+          number_of_shifts = 5
+        )
+      # no error/warning programmed into the function yet
+    )
+  }
+)
 
 test_that(
-  "make_bins rejects NULL values for all parameters (but data_source_bins)", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
+  "make_bins rejects NULL values for all parameters (but data_source_bins)",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins = data_source_bins,
-      working_units = NULL,
-      bin_size = NULL,
-      number_of_shifts = NULL
-    ),
-    "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      make_bins(
+        data_source_bins = data_source_bins,
+        working_units = NULL,
+        bin_size = NULL,
+        number_of_shifts = NULL
+      ),
+      "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 
 
@@ -1102,123 +1203,134 @@ test_that(
 # ---------------------------------------------------------- #
 
 test_that(
-  "make_bins with working_units='levels' accepts data without age uncertainty", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "levels",
-      bin_size = NULL,
-      number_of_shifts = NULL
-    )
-  )
-})
-
-test_that(
-  "make_bins with working_units='levels' works if there are 0s in age data", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  data_source_bins$age$age[1:3] <-
-    0
-
-  expect_no_error(
-    bins <-
+  "make_bins with working_units='levels' accepts data without age uncertainty",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+    expect_no_error(
       make_bins(
         data_source_bins,
-        working_units = "levels"
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL
       )
-  )
-})
+    )
+  }
+)
+
+test_that(
+  "make_bins with working_units='levels' works if there are 0s in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age[1:3] <-
+      0
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "levels"
+        )
+    )
+  }
+)
 
 ## (test fails - function works and produces invalid output)
 test_that(
-  "make_bins with working_units='levels' fails if there are no rownames in age data", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins with working_units='levels' fails if there are no rownames in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    rownames(data_source_bins$age) <-
+      NULL
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "levels",
+          bin_size = NULL,
+          number_of_shifts = NULL
+        ),
+      # no error/warning programmed into the function yet
     )
 
-  rownames(data_source_bins$age) <-
-    NULL
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL
-      ),
-    # no error/warning programmed into the function yet
-  )
-
-  expect_false(bins$label[1] == "...1-...2")
-})
+    expect_false(bins$label[1] == "...1-...2")
+  }
+)
 
 test_that(
-  "make_bins with working_units='levels' works if rownames in age are not numeric", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  length_levels <-
-    length(rownames(data_source_bins$age))
-  rownames(
-    data_source_bins$age) <-
-    paste0("ABC", 1:length_levels)
-
-  expect_no_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL
+  "make_bins with working_units='levels' works if rownames in age are not numeric",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
       )
-  )
-})
+
+    length_levels <-
+      length(rownames(data_source_bins$age))
+    rownames(
+      data_source_bins$age
+    ) <-
+      paste0("ABC", 1:length_levels)
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "levels",
+          bin_size = NULL,
+          number_of_shifts = NULL
+        )
+    )
+  }
+)
 
 test_that(
-  "make_bins with working_units='levels' ignores NAs in age data", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  data_source_bins$age$age[1:3] <-
-    NA
-
-  expect_no_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL
+  "make_bins with working_units='levels' ignores NAs in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
       )
-  )
-})
+
+    data_source_bins$age$age[1:3] <-
+      NA
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "levels",
+          bin_size = NULL,
+          number_of_shifts = NULL
+        )
+    )
+  }
+)
 
 
 # ---------------------------------------------------------- #
@@ -1226,270 +1338,295 @@ test_that(
 # ---------------------------------------------------------- #
 
 test_that(
-  "make_bins with working_units='bins' accepts data without age uncertainty", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 500,
-      number_of_shifts = NULL
-    )
-  )
-})
-
-test_that(
-  "make_bins with working_units='bins' works if there are 0s in age data", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  data_source_bins$age$age[1:3] <-
-    0
-
-  expect_no_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500,
+  "make_bins with working_units='bins' accepts data without age uncertainty",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
       )
-  )
-})
-
-test_that(
-  "make_bins fails with working_units='bins' and no bin_size", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = NULL,
-        number_of_shifts = NULL
-      ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-test_that(
-  "make_bins rejects non-numeric bin_size if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = NA,
-        number_of_shifts = NULL
-      ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-
-
-test_that(
-  "make_bins works with minimum valid bin_size if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_no_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 1,
-        number_of_shifts = NULL
-      )
-  )
-})
-
-
-test_that(
-  "make_bins works with maximum valid bin_size if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_no_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 2000000,
-        number_of_shifts = NULL
-      )
-  )
-})
-
-
-test_that(
-  "make_bins rejects Inf bin_size if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = Inf,
-        number_of_shifts = NULL
-      ),
-    "'to' must be a finite number"
-  )
-})
-
-test_that(
-  "make_bins rejects negative bin_size if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = -500,
-        number_of_shifts = NULL
-      ),
-    "wrong sign in 'by' argument"
-  )
-})
-
-test_that(
-  "make_bins rejects non-integer bin_size if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500.5,
-        number_of_shifts = NULL
-      ),
-    "' bin_size ' must be a an integer"
-  )
-})
-
-
-test_that(
-  "make_bins rejects vector of multiple bin_sizes if working_units='bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = c(
-    100:500),
-        number_of_shifts = NULL
-      ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-test_that(
-  "make_bins throws error if 'bins' and there are NAs in age data", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  data_source_bins$age$age[1:3] <-
-    NA
-
-  expect_error(
-    bins <-
+    expect_no_error(
       make_bins(
         data_source_bins,
         working_units = "bins",
         bin_size = 500,
         number_of_shifts = NULL
-      ),
-    "'from' must be a finite number"
-  )
-})
+      )
+    )
+  }
+)
 
 test_that(
-  "make_bins throws error if working_units='bins' and bin_size < 1", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "make_bins with working_units='bins' works if there are 0s in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "bins",
-      bin_size = 0,
-    ),
-    "invalid" # invalid '(to - from)/by'
-  )
-})
+    data_source_bins$age$age[1:3] <-
+      0
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = 500,
+        )
+    )
+  }
+)
+
+test_that(
+  "make_bins fails with working_units='bins' and no bin_size",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = NULL,
+          number_of_shifts = NULL
+        ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects non-numeric bin_size if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = NA,
+          number_of_shifts = NULL
+        ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+
+
+test_that(
+  "make_bins works with minimum valid bin_size if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = 1,
+          number_of_shifts = NULL
+        )
+    )
+  }
+)
+
+
+test_that(
+  "make_bins works with maximum valid bin_size if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = 2000000,
+          number_of_shifts = NULL
+        )
+    )
+  }
+)
+
+
+test_that(
+  "make_bins rejects Inf bin_size if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = Inf,
+          number_of_shifts = NULL
+        ),
+      "'to' must be a finite number"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects negative bin_size if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = -500,
+          number_of_shifts = NULL
+        ),
+      "wrong sign in 'by' argument"
+    )
+  }
+)
+
+test_that(
+  "make_bins rejects non-integer bin_size if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = 500.5,
+          number_of_shifts = NULL
+        ),
+      "' bin_size ' must be a an integer"
+    )
+  }
+)
+
+
+test_that(
+  "make_bins rejects vector of multiple bin_sizes if working_units='bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = c(
+            100:500
+          ),
+          number_of_shifts = NULL
+        ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if 'bins' and there are NAs in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age[1:3] <-
+      NA
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "bins",
+          bin_size = 500,
+          number_of_shifts = NULL
+        ),
+      "'from' must be a finite number"
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='bins' and bin_size < 1",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 0,
+      ),
+      "invalid" # invalid '(to - from)/by'
+    )
+  }
+)
 
 
 # ---------------------------------------------------------- #
@@ -1497,52 +1634,967 @@ test_that(
 # ---------------------------------------------------------- #
 
 test_that(
-  "make_bins with working_units='MW' accepts data without age uncertainty", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
+  "make_bins with working_units='MW' accepts data without age uncertainty",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
 
-  expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 1
+    expect_no_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 1
+      )
     )
-  )
-})
+  }
+)
 
 test_that(
-  "make_bins with working_units='MW' throws error if there are NAs in age data", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "make_bins with working_units='MW' throws error if there are NAs in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age[1:3] <-
+      NA
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "MW",
+          bin_size = 500,
+          number_of_shifts = 5
+        ),
+      "'from' must be a finite number"
     )
+  }
+)
 
-  data_source_bins$age$age[1:3] <-
-    NA
+test_that(
+  "make_bins with working_units='MW' works if there are 0s in age data",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    bins <-
+    data_source_bins$age$age[1:3] <-
+      0
+
+    expect_no_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "MW",
+          bin_size = 500,
+          number_of_shifts = 5
+        )
+    )
+  }
+)
+
+
+test_that(
+  "make_bins throws error if working_units='MW' and bin_size is missing",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "MW",
+          bin_size = NULL,
+          number_of_shifts = NULL
+        ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts is missing",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "MW",
+          bin_size = 500,
+          number_of_shifts = NULL
+        ),
+      "'number_of_shifts' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='MW' and bin_size is NA",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+
+    expect_error(
+      bins <-
+        make_bins(
+          data_source_bins,
+          working_units = "MW",
+          bin_size = NA,
+          number_of_shifts = 1
+        ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+test_that(
+  "make_bins uses default parameters if working_units='MW' and no input bin_size and number_of_shifts",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    bins_res <-
+      make_bins(
+        data_source_bins,
+        working_units = "MW"
+      )
+
+    bins_default <-
       make_bins(
         data_source_bins,
         working_units = "MW",
         bin_size = 500,
         number_of_shifts = 5
-      ),
-    "'from' must be a finite number"
-  )
-})
+      )
+
+    expect_identical(bins_default, bins_res)
+  }
+)
 
 test_that(
-  "make_bins with working_units='MW' works if there are 0s in age data", {
-  data_source_bins <-
+  "make_bins throws error if working_units='MW' and non-integer bin_size",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500.5,
+        number_of_shifts = 5
+      ),
+      "' bin_size ' must be a an integer"
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='MW' and bin_size < 1",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 0,
+        number_of_shifts = 5
+      ),
+      "invalid" # invalid '(to - from)/by'
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts < 1",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 0
+      ),
+      "arguments imply differing number of rows: 0, 36" # arguments imply differing number of rows: 0, 36
+    )
+  }
+)
+
+test_that(
+  "make_bins throws no error if working_units='MW' and number_of_shifts = 1",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 1
+      )
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = Inf",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = Inf
+      ),
+      "result would be too long a vector"
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = negative",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = -5
+      ),
+      "invalid 'times' argument"
+    )
+  }
+)
+
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = NA",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = NA
+      ),
+      "'number_of_shifts' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = non-numeric",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = "5"
+      ),
+      "'number_of_shifts' must be one of the following: 'numeric'"
+    )
+  }
+)
+
+# ---------------------------------------------------------- #
+# 2. Output validation
+# ---------------------------------------------------------- #
+
+test_that(
+  "make_bins returns the correct output",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    bins <-
+      make_bins(data_source_bins = data_source_bins)
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_identical(
+      bins$name,
+      rownames(data_source_bins$age)
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+
+
+
+test_that(
+  "make_bins returns the correct output without age_uncertainty",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
+    bins <-
+      make_bins(data_source_bins = data_source_bins)
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_identical(
+      bins$name,
+      rownames(data_source_bins$age)
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+
+test_that(
+  "make_bins returns the correct output with default parameters for 'levels'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    bins <-
+      make_bins(
+        data_source_bins = data_source_bins,
+        working_units = "levels"
+      )
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_identical(
+      bins$name,
+      rownames(data_source_bins$age)
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+test_that(
+  "make_bins with working_units='levels' ignores NAs in age data and returns valid output",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    data_source_bins$age$age[1:3] <-
+      NA
+
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      )
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_identical(
+      bins$name,
+      rownames(data_source_bins$age)
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+
+
+test_that(
+  "make_bins returns the correct output with default parameters for 'bins'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    bins <-
+      make_bins(
+        data_source_bins = data_source_bins,
+        working_units = "bins",
+        bin_size = 500
+      )
+
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+test_that(
+  "make_bins returns the correct output with default parameters for 'MW'",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    bins <-
+      make_bins(
+        data_source_bins = data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      )
+
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "integer"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+
+## (test fails as long as function accepts invalid input without rownames)
+test_that(
+  "make_bins with working_units='levels' and no rownames in age data returns valid output",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    rownames(data_source_bins$age) <-
+      NULL
+
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      )
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_identical(
+      bins$name,
+      rownames(data_source_bins$age)
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+
+test_that(
+  "make_bins with no working_units as input returns valid output",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+
+    bins <-
+      make_bins(
+        data_source_bins,
+      )
+
+    # General output structure tests:
+    expect_s3_class(
+      bins, "data.frame"
+    )
+
+    expect_identical(
+      bins$name,
+      rownames(data_source_bins$age)
+    )
+
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(bins)
+      )
+    )
+
+    expect_true(
+      class(
+        bins$name
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$shift
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$age_diff
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$start
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$end
+      ) == "character"
+    )
+    expect_true(
+      class(
+        bins$res_age
+      ) == "numeric"
+    )
+    expect_true(
+      class(
+        bins$label
+      ) == "character"
+    )
+  }
+)
+
+
+# Test full functionality workflow within estimate_roc()
+test_that("make_bins and 'levels' works within the workflow of estimate_roc()", {
+  data_extract <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -1550,13 +2602,56 @@ test_that(
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <-
-    0
+  data_smooth <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smooth
+    )
+
+  data_source_prep <-
+    data_work
 
   expect_no_error(
-    bins <-
+    bin_levels <-
       make_bins(
-        data_source_bins,
+        data_source_bins = data_source_prep,
+        working_units = "levels"
+      )
+  )
+})
+
+test_that("make_bins and 'MW' works within the workflow of estimate_roc()", {
+  data_extract <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_smooth <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smooth
+    )
+
+  data_source_prep <-
+    data_work
+
+  expect_no_error(
+    bin_WM <-
+      make_bins(
+        data_source_bins = data_source_prep,
         working_units = "MW",
         bin_size = 500,
         number_of_shifts = 5
@@ -1564,10 +2659,8 @@ test_that(
   )
 })
 
-
-test_that(
-  "make_bins throws error if working_units='MW' and bin_size is missing", {
-  data_source_bins <-
+test_that("make_bins and 'bins' works within the workflow of estimate_roc()", {
+  data_extract <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
@@ -1575,779 +2668,26 @@ test_that(
       verbose = FALSE
     )
 
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = NULL,
-        number_of_shifts = NULL
-      ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-
-test_that(
-  "make_bins throws error if working_units='MW' and number_of_shifts is missing", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  data_smooth <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
     )
 
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = NULL
-      ),
-    "'number_of_shifts' must be one of the following: 'numeric'"
-  )
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and bin_size is NA", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  data_work <-
+    reduce_data(
+      data_smooth
     )
 
-
-  expect_error(
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = NA,
-        number_of_shifts = 1
-      ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-test_that(
-  "make_bins uses default parameters if working_units='MW' and no input bin_size and number_of_shifts", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  bins_res <-
-    make_bins(
-      data_source_bins,
-      working_units = "MW"
-    )
-
-  bins_default <-
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    )
-
-  expect_identical(bins_default, bins_res)
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and non-integer bin_size", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500.5,
-      number_of_shifts = 5
-    ),
-    "' bin_size ' must be a an integer"
-  )
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and bin_size < 1", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 0,
-      number_of_shifts = 5
-    ),
-    "invalid" # invalid '(to - from)/by'
-  )
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and number_of_shifts < 1", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 0
-    ),
-    "arguments imply differing number of rows: 0, 36" # arguments imply differing number of rows: 0, 36
-  )
-})
-
-test_that(
-  "make_bins throws no error if working_units='MW' and number_of_shifts = 1", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  data_source_prep <-
+    data_work
 
   expect_no_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 1
-    )
-  )
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and number_of_shifts = Inf", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = Inf
-    ),
-    "result would be too long a vector"
-  )
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and number_of_shifts = negative", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = -5
-    ),
-    "invalid 'times' argument"
-  )
-})
-
-test_that(
-  "make_bins throws error if working_units='MW' and number_of_shifts = NA", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = NA
-    ),
-    "'number_of_shifts' must be one of the following: 'numeric'"
-  )
-})
-
-
-test_that(
-  "make_bins throws error if working_units='MW' and number_of_shifts = non-numeric", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    make_bins(
-      data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = "5"
-    ),
-    "'number_of_shifts' must be one of the following: 'numeric'"
-  )
-})
-
-# ---------------------------------------------------------- #
-# 2. Output validation
-# ---------------------------------------------------------- #
-
-test_that(
-  "make_bins returns the correct output", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  bins <-
-    make_bins(data_source_bins = data_source_bins)
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_identical(
-    bins$name,
-    rownames(data_source_bins$age)
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "character"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "character"
-  )
-  expect_true(
-    class(
-    bins$end) == "character"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-
-
-
-test_that(
-  "make_bins returns the correct output without age_uncertainty", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-
-  bins <-
-    make_bins(data_source_bins = data_source_bins)
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_identical(
-    bins$name,
-    rownames(data_source_bins$age)
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "character"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "character"
-  )
-  expect_true(
-    class(
-    bins$end) == "character"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-
-test_that(
-  "make_bins returns the correct output with default parameters for 'levels'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  bins <-
-    make_bins(
-      data_source_bins = data_source_bins,
-      working_units = "levels"
-    )
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_identical(
-    bins$name,
-    rownames(data_source_bins$age)
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "character"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "character"
-  )
-  expect_true(
-    class(
-    bins$end) == "character"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-test_that(
-  "make_bins with working_units='levels' ignores NAs in age data and returns valid output", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  data_source_bins$age$age[1:3] <-
-    NA
-
-  bins <-
-    make_bins(
-      data_source_bins,
-      working_units = "levels",
-      bin_size = NULL,
-      number_of_shifts = NULL
-    )
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_identical(
-    bins$name,
-    rownames(data_source_bins$age)
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "character"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "character"
-  )
-  expect_true(
-    class(
-    bins$end) == "character"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-
-
-test_that(
-  "make_bins returns the correct output with default parameters for 'bins'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  bins <-
-    make_bins(
-      data_source_bins = data_source_bins,
-      working_units = "bins",
-      bin_size = 500
-    )
-
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$end) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-test_that(
-  "make_bins returns the correct output with default parameters for 'MW'", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  bins <-
-    make_bins(
-      data_source_bins = data_source_bins,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    )
-
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$shift) == "integer"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$end) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-
-## (test fails as long as function accepts invalid input without rownames)
-test_that(
-  "make_bins with working_units='levels' and no rownames in age data returns valid output", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  rownames(data_source_bins$age) <-
-    NULL
-
-  bins <-
-    make_bins(
-      data_source_bins,
-      working_units = "levels",
-      bin_size = NULL,
-      number_of_shifts = NULL
-    )
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_identical(
-    bins$name,
-    rownames(data_source_bins$age)
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "character"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "character"
-  )
-  expect_true(
-    class(
-    bins$end) == "character"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
-  )
-})
-
-
-test_that(
-  "make_bins with no working_units as input returns valid output", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-
-  bins <-
-    make_bins(
-    data_source_bins,
-  )
-
-  # General output structure tests:
-  expect_s3_class(
-    bins, "data.frame"
-  )
-
-  expect_identical(
-    bins$name,
-    rownames(data_source_bins$age)
-  )
-
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(bins)
-    )
-  )
-
-  expect_true(
-    class(
-    bins$name) == "character"
-  )
-  expect_true(
-    class(
-    bins$shift) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$age_diff) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$start) == "character"
-  )
-  expect_true(
-    class(
-    bins$end) == "character"
-  )
-  expect_true(
-    class(
-    bins$res_age) == "numeric"
-  )
-  expect_true(
-    class(
-    bins$label) == "character"
+    bin_bins <-
+      make_bins(
+        data_source_bins = data_source_prep,
+        working_units = "bins",
+        bin_size = 500
+      )
   )
 })

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -2691,3 +2691,4 @@ test_that("make_bins and 'bins' works within the workflow of estimate_roc()", {
       )
   )
 })
+

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -23,9 +23,7 @@ test_that(
     expect_error(
       make_bins(
         data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "`names` must be a character vector"
     )
@@ -51,9 +49,7 @@ test_that(
     expect_error(
       make_bins(
         data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "'data_source_bins' must be one of the following: 'list'"
     )
@@ -66,9 +62,7 @@ test_that(
     expect_error(
       make_bins(
         "data",
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "'data_source_bins' must be one of the following: 'list'"
     )
@@ -81,9 +75,7 @@ test_that(
     expect_error(
       make_bins(
         123,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "'data_source_bins' must be one of the following: 'list'"
     )
@@ -98,9 +90,7 @@ test_that(
     expect_error(
       make_bins(
         list(),
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "argument of length 0"
     )
@@ -114,9 +104,7 @@ test_that(
     expect_error(
       make_bins(
         NA,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "'data_source_bins' must be one of the following: 'list'"
     )
@@ -140,9 +128,7 @@ test_that(
     expect_error(
       make_bins(
         data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "'data_source_bins' must be one of the following: 'list'"
     )
@@ -155,9 +141,7 @@ test_that(
     expect_error(
       make_bins(
         0,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "'data_source_bins' must be one of the following: 'list'"
     )
@@ -178,9 +162,7 @@ test_that(
     expect_no_error(
       make_bins(
         data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       )
     )
   }
@@ -202,659 +184,30 @@ test_that(
     expect_error(
       make_bins(
         data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
+        working_units = "levels"
       ),
       "`age_diff` must be size 1, not 2."
     )
   }
 )
 
-
-## A suite of tests that fail because
-## the function does not handle the community part of the data at all
-
-test_that(
-  "make_bins rejects data_source_bins without community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community <-
-      NULL
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-
-test_that(
-  "make_bins rejects data_source_bins list community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community <-
-      list(data_source_bins$community)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins matrix community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community <-
-      as.matrix(data_source_bins$community)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-
-test_that(
-  "make_bins rejects data_source_bins character community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community <-
-      "my_community"
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins numeric community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community <-
-      123
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins NA community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community[, ] <-
-      NA
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins 0 community in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$community[, ] <-
-      0
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins with community without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    rownames(data_source_bins$community) <-
-      NULL
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-
-## Age:
-test_that(
-  "make_bins rejects data_source_bins without age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age <-
-      NULL
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "`names` must be a character vector"
-    )
-  }
-)
-
-
-test_that(
-  "make_bins rejects data_source_bins list age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age <-
-      list(data_source_bins$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "argument of length 0"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins matrix age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age <-
-      as.matrix(data_source_bins$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "Argument 1 must be a data frame or a named atomic vector"
-    )
-  }
-)
-
-
-test_that(
-  "make_bins rejects data_source_bins character age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age <-
-      "my_age"
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "Argument 1 must be a data frame or a named atomic vector"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins numeric age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age <-
-      123
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "Argument 1 must be a data frame or a named atomic vector"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins NA age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age[, ] <-
-      NA
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "levels",
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins NA age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age[, ] <-
-      NA
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500
-      ),
-      "'from' must be a finite number"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins NA age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age[, ] <-
-      NA
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "'from' must be a finite number"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins 0 age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age[, ] <-
-      0
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "levels"
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins 0 age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age[, ] <-
-      0
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins 0 age in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age[, ] <-
-      0
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    rownames(data_source_bins$age) <-
-      NULL
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "levels"
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    rownames(data_source_bins$age) <-
-      NULL
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    rownames(data_source_bins$age) <-
-      NULL
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      # no error programmed into the function yet
-    )
-  }
-)
-
-
-# character values inside age
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age$age <-
-      as.character(data_source_bins$age$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "levels"
-      ),
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age$age <-
-      as.character(data_source_bins$age$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500
-      ),
-      "non-numeric argument to mathematical function"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects data_source_bins with age without rownames in the list",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    data_source_bins$age$age <-
-      as.character(data_source_bins$age$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts =
-        ),
-      "non-numeric argument to mathematical function"
-    )
-  }
-)
-
 test_that(
   "make_bins accepts minimal age data (1 row)",
   {
+    community <-
+      RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE]
+    age <-
+      RRatepol::example_data$sample_age[[1]][1, , drop = FALSE]
+    age_un <-
+      RRatepol::example_data$age_uncertainty[[1]][, 1, drop = FALSE]
+
     data_source_bins <-
       extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_un,
         verbose = FALSE
       )
-
-    data_source_bins$community <-
-      data_source_bins$community[1, , drop = FALSE]
-    data_source_bins$age <-
-      data_source_bins$age[1, , drop = FALSE]
-    data_source_bins$age_un <-
-      data_source_bins$age_un[, 1, drop = FALSE]
-
 
     expect_no_error(
       make_bins(
@@ -868,20 +221,20 @@ test_that(
 test_that(
   "make_bins accepts minimal age data (1 row)",
   {
+    community <-
+      RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE]
+    age <-
+      RRatepol::example_data$sample_age[[1]][1, , drop = FALSE]
+    age_un <-
+      RRatepol::example_data$age_uncertainty[[1]][, 1, drop = FALSE]
+
     data_source_bins <-
       extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_un,
         verbose = FALSE
       )
-
-    data_source_bins$community <-
-      data_source_bins$community[1, , drop = FALSE]
-    data_source_bins$age <-
-      data_source_bins$age[1, , drop = FALSE]
-    data_source_bins$age_un <-
-      data_source_bins$age_un[, 1, drop = FALSE]
 
 
     expect_no_error(
@@ -897,20 +250,20 @@ test_that(
 test_that(
   "make_bins accepts minimal age data (1 row)",
   {
+    community <-
+      RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE]
+    age <-
+      RRatepol::example_data$sample_age[[1]][1, , drop = FALSE]
+    age_un <-
+      RRatepol::example_data$age_uncertainty[[1]][, 1, drop = FALSE]
+
     data_source_bins <-
       extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_un,
         verbose = FALSE
       )
-
-    data_source_bins$community <-
-      data_source_bins$community[1, , drop = FALSE]
-    data_source_bins$age <-
-      data_source_bins$age[1, , drop = FALSE]
-    data_source_bins$age_un <-
-      data_source_bins$age_un[, 1, drop = FALSE]
 
 
     expect_no_error(
@@ -923,84 +276,6 @@ test_that(
     )
   }
 )
-
-
-# age with character strings instead of numeric
-test_that(
-  "make_bins rejects age with character strings instead of numeric",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age <-
-      as.character(data_source_bins$age$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "levels"
-      ), #
-      "Can't combine"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects age with character strings instead of numeric",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age <-
-      as.character(data_source_bins$age$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "bins",
-        bin_size = 500
-      ), #
-      "non-numeric argument to mathematical function"
-    )
-  }
-)
-
-test_that(
-  "make_bins rejects age with character strings instead of numeric",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age <-
-      as.character(data_source_bins$age$age)
-
-    expect_error(
-      make_bins(
-        data_source_bins,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      ), #
-      "non-numeric argument to mathematical function"
-    )
-  }
-)
-
 
 # ---------------------------------------------------------- #
 #               working_unit validation                      #
@@ -1021,26 +296,6 @@ test_that(
       make_bins(
         data_source_bins,
         working_units = NULL
-      ), "'working_units' must be one of the following: 'character'"
-    )
-  }
-)
-
-## (fails - it silently uses "bins" and default bin_size = 500
-test_that(
-  "make_bins rejects no working_unit as input",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      make_bins(
-        data_source_bins,
       ), "'working_units' must be one of the following: 'character'"
     )
   }
@@ -1141,8 +396,7 @@ test_that(
       make_bins(
         data_source_bins,
         working_units = c("levels", "bins"),
-        bin_size = 500,
-        number_of_shifts = 5
+        bin_size = 500
       ), "'arg' must be of length 1"
     )
   }
@@ -1194,10 +448,6 @@ test_that(
   }
 )
 
-
-
-
-
 # ---------------------------------------------------------- #
 #               working_units = "levels"                     #
 # ---------------------------------------------------------- #
@@ -1222,117 +472,6 @@ test_that(
   }
 )
 
-test_that(
-  "make_bins with working_units='levels' works if there are 0s in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      0
-
-    expect_no_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "levels"
-        )
-    )
-  }
-)
-
-## (test fails - function works and produces invalid output)
-test_that(
-  "make_bins with working_units='levels' fails if there are no rownames in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    rownames(data_source_bins$age) <-
-      NULL
-
-    expect_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "levels",
-          bin_size = NULL,
-          number_of_shifts = NULL
-        ),
-      # no error/warning programmed into the function yet
-    )
-
-    expect_false(bins$label[1] == "...1-...2")
-  }
-)
-
-test_that(
-  "make_bins with working_units='levels' works if rownames in age are not numeric",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    length_levels <-
-      length(rownames(data_source_bins$age))
-    rownames(
-      data_source_bins$age
-    ) <-
-      paste0("ABC", 1:length_levels)
-
-    expect_no_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "levels",
-          bin_size = NULL,
-          number_of_shifts = NULL
-        )
-    )
-  }
-)
-
-test_that(
-  "make_bins with working_units='levels' ignores NAs in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      NA
-
-    expect_no_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "levels",
-          bin_size = NULL,
-          number_of_shifts = NULL
-        )
-    )
-  }
-)
-
-
 # ---------------------------------------------------------- #
 #               working_units = "bins"                     #
 # ---------------------------------------------------------- #
@@ -1353,31 +492,6 @@ test_that(
         bin_size = 500,
         number_of_shifts = NULL
       )
-    )
-  }
-)
-
-test_that(
-  "make_bins with working_units='bins' works if there are 0s in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      0
-
-    expect_no_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "bins",
-          bin_size = 500,
-        )
     )
   }
 )
@@ -1454,31 +568,6 @@ test_that(
     )
   }
 )
-
-
-test_that(
-  "make_bins works with maximum valid bin_size if working_units='bins'",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_no_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "bins",
-          bin_size = 2000000,
-          number_of_shifts = NULL
-        )
-    )
-  }
-)
-
 
 test_that(
   "make_bins rejects Inf bin_size if working_units='bins'",
@@ -1579,32 +668,6 @@ test_that(
   }
 )
 
-test_that(
-  "make_bins throws error if 'bins' and there are NAs in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      NA
-
-    expect_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "bins",
-          bin_size = 500,
-          number_of_shifts = NULL
-        ),
-      "'from' must be a finite number"
-    )
-  }
-)
 
 test_that(
   "make_bins throws error if working_units='bins' and bin_size < 1",
@@ -1627,7 +690,6 @@ test_that(
     )
   }
 )
-
 
 # ---------------------------------------------------------- #
 #               working_units = "MW"                     #
@@ -1653,60 +715,6 @@ test_that(
     )
   }
 )
-
-test_that(
-  "make_bins with working_units='MW' throws error if there are NAs in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      NA
-
-    expect_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "MW",
-          bin_size = 500,
-          number_of_shifts = 5
-        ),
-      "'from' must be a finite number"
-    )
-  }
-)
-
-test_that(
-  "make_bins with working_units='MW' works if there are 0s in age data",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      0
-
-    expect_no_error(
-      bins <-
-        make_bins(
-          data_source_bins,
-          working_units = "MW",
-          bin_size = 500,
-          number_of_shifts = 5
-        )
-    )
-  }
-)
-
 
 test_that(
   "make_bins throws error if working_units='MW' and bin_size is missing",
@@ -2012,7 +1020,9 @@ test_that(
       )
 
     bins <-
-      make_bins(data_source_bins = data_source_bins)
+      make_bins(
+        data_source_bins = data_source_bins
+      )
 
     # General output structure tests:
     expect_s3_class(
@@ -2069,9 +1079,6 @@ test_that(
     )
   }
 )
-
-
-
 
 test_that(
   "make_bins returns the correct output without age_uncertainty",
@@ -2141,7 +1148,6 @@ test_that(
     )
   }
 )
-
 
 test_that(
   "make_bins returns the correct output with default parameters for 'levels'",
@@ -2215,85 +1221,6 @@ test_that(
     )
   }
 )
-
-test_that(
-  "make_bins with working_units='levels' ignores NAs in age data and returns valid output",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    data_source_bins$age$age[1:3] <-
-      NA
-
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL
-      )
-
-    # General output structure tests:
-    expect_s3_class(
-      bins, "data.frame"
-    )
-
-    expect_identical(
-      bins$name,
-      rownames(data_source_bins$age)
-    )
-
-    expect_true(
-      all(
-        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-        %in%
-          colnames(bins)
-      )
-    )
-
-    expect_true(
-      class(
-        bins$name
-      ) == "character"
-    )
-    expect_true(
-      class(
-        bins$shift
-      ) == "numeric"
-    )
-    expect_true(
-      class(
-        bins$age_diff
-      ) == "numeric"
-    )
-    expect_true(
-      class(
-        bins$start
-      ) == "character"
-    )
-    expect_true(
-      class(
-        bins$end
-      ) == "character"
-    )
-    expect_true(
-      class(
-        bins$res_age
-      ) == "numeric"
-    )
-    expect_true(
-      class(
-        bins$label
-      ) == "character"
-    )
-  }
-)
-
 
 
 test_that(
@@ -2438,84 +1365,6 @@ test_that(
 )
 
 
-## (test fails as long as function accepts invalid input without rownames)
-test_that(
-  "make_bins with working_units='levels' and no rownames in age data returns valid output",
-  {
-    data_source_bins <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    rownames(data_source_bins$age) <-
-      NULL
-
-    bins <-
-      make_bins(
-        data_source_bins,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL
-      )
-
-    # General output structure tests:
-    expect_s3_class(
-      bins, "data.frame"
-    )
-
-    expect_identical(
-      bins$name,
-      rownames(data_source_bins$age)
-    )
-
-    expect_true(
-      all(
-        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-        %in%
-          colnames(bins)
-      )
-    )
-
-    expect_true(
-      class(
-        bins$name
-      ) == "character"
-    )
-    expect_true(
-      class(
-        bins$shift
-      ) == "numeric"
-    )
-    expect_true(
-      class(
-        bins$age_diff
-      ) == "numeric"
-    )
-    expect_true(
-      class(
-        bins$start
-      ) == "character"
-    )
-    expect_true(
-      class(
-        bins$end
-      ) == "character"
-    )
-    expect_true(
-      class(
-        bins$res_age
-      ) == "numeric"
-    )
-    expect_true(
-      class(
-        bins$label
-      ) == "character"
-    )
-  }
-)
 
 
 test_that(
@@ -2590,7 +1439,6 @@ test_that(
     )
   }
 )
-
 
 # Test full functionality workflow within estimate_roc()
 test_that("make_bins and 'levels' works within the workflow of estimate_roc()", {
@@ -2691,4 +1539,3 @@ test_that("make_bins and 'bins' works within the workflow of estimate_roc()", {
       )
   )
 })
-

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -1,0 +1,958 @@
+# Requirements for parameters:
+## levels  - requires nothing
+## MW - requires bin_size and number of shifts (> 0)
+## bins - requires bin_size
+
+
+# Example usage
+data_source_bins <-
+  extract_data(
+    data_community_extract = RRatepol::example_data$pollen_data[[1]],
+    data_age_extract = RRatepol::example_data$sample_age[[1]],
+    age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+    verbose = FALSE
+  )
+bins <-
+  make_bins(
+    data_source_bins,
+    working_units = c("levels", "bins", "MW"),
+    bin_size = 500,
+    number_of_shifts = 5
+  )
+
+
+
+# Input validation (Errors)
+
+# ---------------------------------------------------------- #
+#               data_source_bins validation                  #
+# ---------------------------------------------------------- #
+
+## 1
+test_that("make_bins rejects missing age data in data_source_bins", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age <-
+    NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "`names` must be a character vector"
+  )
+})
+## 2
+test_that("make_bins validates data input class == list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  class(data_source_bins) <-
+    "data.frame"
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'data_source_bins' must be one of the following: 'list'"
+  )
+})
+
+# ---------------------------------------------------------- #
+#               working_unit validation                      #
+# ---------------------------------------------------------- #
+
+## 3
+test_that("make_bins validates that there is a working_unit as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = NULL
+    ), "'working_units' must be one of the following: 'character'"
+  )
+})
+
+## 4 (fails - it silently uses "bins" and default bin_size = 500
+test_that("make_bins rejects no working_unit as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+    ), "'working_units' must be one of the following: 'character'"
+  )
+})
+
+## 5
+test_that("make_bins validates that working_unit is not NULL", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = NULL
+    ), "'working_units' must be one of the following: 'character'"
+  )
+})
+
+## 6
+test_that("make_bins validates correct working_unit value as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = 123
+    ), "'working_units' must be one of the following: 'character'"
+  )
+})
+
+
+## 7
+test_that("make_bins validates correct working_unit value as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "invalid input"
+    ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
+
+## 8
+test_that("make_bins validates correct working_unit value as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins")
+    ), "'arg' must be of length 1"
+  )
+})
+
+## 9
+test_that("make_bins validates correct working_unit value as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ), "'arg' must be of length 1"
+  )
+})
+
+## 10 (fails right now - it will take always the first method in the vector without error or warning)
+test_that("make_bins rejects multiple working_units as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5
+      )
+    # no error/warning programmed into the function yet
+  )
+})
+
+## 11
+test_that("make_bins rejects NULL values for all parameters (but data_source_bins)", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins = data_source_bins,
+      working_units = NULL,
+      bin_size = NULL,
+      number_of_shifts = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
+
+
+
+
+
+# ---------------------------------------------------------- #
+#               working_units = "levels"                     #
+# ---------------------------------------------------------- #
+
+## 12
+test_that("make_bins with working_units='levels' accepts data without age uncertainty", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels",
+      bin_size = NULL,
+      number_of_shifts = NULL
+    )
+  )
+})
+
+test_that("make_bins with working_units='levels' works if there are 0s in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- 0
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "levels"
+      )
+  )
+})
+
+## 13 (test fails - function works and produces invalid output)
+test_that("make_bins with working_units='levels' fails if there are no rownames in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  rownames(data_source_bins$age) <- NULL
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      ),
+    # no error/warning programmed into the function yet
+  )
+
+  expect_false(bins$label[1] == "...1-...2")
+})
+
+## 14
+test_that("make_bins with working_units='levels' works if rownames in age are not numeric", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  length_levels <-
+    length(rownames(data_source_bins$age))
+  rownames(data_source_bins$age) <-
+    paste0("ABC", 1:length_levels)
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      )
+  )
+})
+
+test_that("make_bins with working_units='levels' ignores NAs in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- NA
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      )
+  )
+})
+
+
+# ---------------------------------------------------------- #
+#               working_units = "bins"                     #
+# ---------------------------------------------------------- #
+
+test_that("make_bins with working_units='bins' accepts data without age uncertainty", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500,
+      number_of_shifts = NULL
+    )
+  )
+})
+
+test_that("make_bins with working_units='bins' works if there are 0s in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- 0
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500,
+      )
+  )
+})
+
+## 15
+test_that("make_bins fails with working_units='bins' and no bin_size", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+
+## 16
+test_that("make_bins rejects non-numeric bin_size if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = NA,
+        number_of_shifts = NULL
+      ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+
+## 17
+test_that("make_bins works with minimum valid bin_size if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 1,
+        number_of_shifts = NULL
+      )
+  )
+})
+
+
+## 18
+test_that("make_bins works with maximum valid bin_size if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 2000000,
+        number_of_shifts = NULL
+      )
+  )
+})
+
+
+## 18
+test_that("make_bins rejects Inf bin_size if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = Inf,
+        number_of_shifts = NULL
+      ),
+    "'to' must be a finite number"
+  )
+})
+
+test_that("make_bins rejects negative bin_size if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = -500,
+        number_of_shifts = NULL
+      ),
+    "wrong sign in 'by' argument"
+  )
+})
+
+test_that("make_bins rejects non-integer bin_size if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500.5,
+        number_of_shifts = NULL
+      ),
+    "' bin_size ' must be a an integer"
+  )
+})
+
+
+test_that("make_bins rejects vector of multiple bin_sizes if working_units='bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = c(100:500),
+        number_of_shifts = NULL
+      ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("make_bins throws error if 'bins' and there are NAs in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- NA
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "bins",
+        bin_size = 500,
+        number_of_shifts = NULL
+      ),
+    "'from' must be a finite number"
+  )
+})
+
+test_that("make_bins throws error if working_units='bins' and bin_size < 1", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 0,
+    ),
+    "invalid" # invalid '(to - from)/by'
+  )
+})
+
+
+# ---------------------------------------------------------- #
+#               working_units = "MW"                     #
+# ---------------------------------------------------------- #
+
+test_that("make_bins with working_units='MW' accepts data without age uncertainty", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 1
+    )
+  )
+})
+
+test_that("make_bins with working_units='MW' throws error if there are NAs in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- NA
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+    "'from' must be a finite number"
+  )
+})
+
+test_that("make_bins with working_units='MW' works if there are 0s in age data", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- 0
+
+  expect_no_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      )
+  )
+})
+
+
+test_that("make_bins throws error if working_units='MW' and bin_size is missing", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = NULL,
+        number_of_shifts = NULL
+      ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+
+test_that("make_bins throws error if working_units='MW' and number_of_shifts is missing", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = NULL
+      ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("make_bins throws error if working_units='MW' and bin_size is NA", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+
+  expect_error(
+    bins <-
+      make_bins(
+        data_source_bins,
+        working_units = "MW",
+        bin_size = NA,
+        number_of_shifts = 1
+      ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("make_bins uses default parameters if working_units='MW' and no input bin_size and number_of_shifts", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  bins_res <-
+    make_bins(
+      data_source_bins,
+      working_units = "MW"
+    )
+
+  bins_default <-
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+
+  expect_identical(bins_default, bins_res)
+})
+
+test_that("make_bins throws error if working_units='MW' and non-integer bin_size", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500.5,
+      number_of_shifts = 5
+    ),
+    "' bin_size ' must be a an integer"
+  )
+})
+
+test_that("make_bins throws error if working_units='MW' and bin_size < 1", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 0,
+      number_of_shifts = 5
+    ),
+    "invalid" # invalid '(to - from)/by'
+  )
+})
+
+
+test_that("make_bins throws error if working_units='MW' and number_of_shifts < 1", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 0
+    ),
+    "arguments imply differing number of rows: 0, 36" # arguments imply differing number of rows: 0, 36
+  )
+})
+
+test_that("make_bins throws no error if working_units='MW' and number_of_shifts = 1", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 1
+    )
+  )
+})
+
+test_that("make_bins throws error if working_units='MW' and number_of_shifts = Inf", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = Inf
+    ),
+    "result would be too long a vector"
+  )
+})
+
+test_that("make_bins throws error if working_units='MW' and number_of_shifts = negative", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = -5
+    ),
+    "invalid 'times' argument"
+  )
+})
+
+test_that("make_bins throws error if working_units='MW' and number_of_shifts = NA", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = NA
+    ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+
+test_that("make_bins throws error if working_units='MW' and number_of_shifts = non-numeric", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = "5"
+    ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+
+
+
+
+# 2. Output validation

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -1348,10 +1348,10 @@ test_that("make_bins with no working_units as input returns valid output", {
 
 
   bins <- make_bins(
-      data_source_bins,
+    data_source_bins,
   )
 
-    # General output structure tests:
+  # General output structure tests:
   expect_s3_class(
     bins, "data.frame"
   )
@@ -1390,6 +1390,4 @@ test_that("make_bins with no working_units as input returns valid output", {
   expect_true(
     class(bins$label) == "character"
   )
-
-
 })

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -75,6 +75,30 @@ test_that("make_bins validates data input class == list", {
   )
 })
 
+test_that("make_bins rejects data input class == character", {
+  expect_error(
+    make_bins(
+      "data",
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'data_source_bins' must be one of the following: 'list'"
+  )
+})
+
+test_that("make_bins rejects data input class == numeric", {
+  expect_error(
+    make_bins(
+      123,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'data_source_bins' must be one of the following: 'list'"
+  )
+})
+
 # ---------------------------------------------------------- #
 #               working_unit validation                      #
 # ---------------------------------------------------------- #
@@ -830,7 +854,6 @@ test_that("make_bins throws error if working_units='MW' and bin_size < 1", {
   )
 })
 
-
 test_that("make_bins throws error if working_units='MW' and number_of_shifts < 1", {
   data_source_bins <-
     extract_data(
@@ -952,7 +975,337 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts = n
 })
 
 
-
-
-
 # 2. Output validation
+test_that("make_bins returns the correct output", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  bins <-
+    make_bins(data_source_bins = data_source_bins)
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_identical(
+    bins$name,
+    rownames(data_source_bins$age)
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "character"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "character"
+  )
+  expect_true(
+    class(bins$end) == "character"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})
+
+
+
+
+test_that("make_bins returns the correct output without age_uncertainty", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+
+  bins <-
+    make_bins(data_source_bins = data_source_bins)
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_identical(
+    bins$name,
+    rownames(data_source_bins$age)
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "character"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "character"
+  )
+  expect_true(
+    class(bins$end) == "character"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})
+
+
+test_that("make_bins returns the correct output with default parameters for 'levels'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  bins <-
+    make_bins(
+      data_source_bins = data_source_bins,
+      working_units = "levels"
+    )
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_identical(
+    bins$name,
+    rownames(data_source_bins$age)
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "character"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "character"
+  )
+  expect_true(
+    class(bins$end) == "character"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})
+
+test_that("make_bins with working_units='levels' ignores NAs in age data and returns valid output", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age[1:3] <- NA
+
+  bins <-
+    make_bins(
+      data_source_bins,
+      working_units = "levels",
+      bin_size = NULL,
+      number_of_shifts = NULL
+    )
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_identical(
+    bins$name,
+    rownames(data_source_bins$age)
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "character"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "character"
+  )
+  expect_true(
+    class(bins$end) == "character"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})
+
+
+
+test_that("make_bins returns the correct output with default parameters for 'bins'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  bins <-
+    make_bins(
+      data_source_bins = data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    )
+
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "numeric"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "numeric"
+  )
+  expect_true(
+    class(bins$end) == "numeric"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})
+
+test_that("make_bins returns the correct output with default parameters for 'MW'", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  bins <-
+    make_bins(
+      data_source_bins = data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "numeric"
+  )
+  expect_true(
+    class(bins$shift) == "integer"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "numeric"
+  )
+  expect_true(
+    class(bins$end) == "numeric"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -1,34 +1,11 @@
-# Requirements for parameters:
-## levels  - requires nothing
-## MW - requires bin_size and number of shifts (> 0)
-## bins - requires bin_size
-
-
-# Example usage
-data_source_bins <-
-  extract_data(
-    data_community_extract = RRatepol::example_data$pollen_data[[1]],
-    data_age_extract = RRatepol::example_data$sample_age[[1]],
-    age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-    verbose = FALSE
-  )
-bins <-
-  make_bins(
-    data_source_bins,
-    working_units = c("levels", "bins", "MW"),
-    bin_size = 500,
-    number_of_shifts = 5
-  )
-
-
-
-# Input validation (Errors)
+# ---------------------------------------------------------- #
+#  1. Input validation (Errors)
+# ---------------------------------------------------------- #
 
 # ---------------------------------------------------------- #
 #               data_source_bins validation                  #
 # ---------------------------------------------------------- #
 
-## 1
 test_that("make_bins rejects missing age data in data_source_bins", {
   data_source_bins <-
     extract_data(
@@ -51,7 +28,7 @@ test_that("make_bins rejects missing age data in data_source_bins", {
     "`names` must be a character vector"
   )
 })
-## 2
+
 test_that("make_bins validates data input class == list", {
   data_source_bins <-
     extract_data(
@@ -103,7 +80,6 @@ test_that("make_bins rejects data input class == numeric", {
 #               working_unit validation                      #
 # ---------------------------------------------------------- #
 
-## 3
 test_that("make_bins validates that there is a working_unit as input", {
   data_source_bins <-
     extract_data(
@@ -121,7 +97,7 @@ test_that("make_bins validates that there is a working_unit as input", {
   )
 })
 
-## 4 (fails - it silently uses "bins" and default bin_size = 500
+## (fails - it silently uses "bins" and default bin_size = 500
 test_that("make_bins rejects no working_unit as input", {
   data_source_bins <-
     extract_data(
@@ -138,7 +114,6 @@ test_that("make_bins rejects no working_unit as input", {
   )
 })
 
-## 5
 test_that("make_bins validates that working_unit is not NULL", {
   data_source_bins <-
     extract_data(
@@ -156,7 +131,6 @@ test_that("make_bins validates that working_unit is not NULL", {
   )
 })
 
-## 6
 test_that("make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
@@ -174,8 +148,6 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-
-## 7
 test_that("make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
@@ -193,7 +165,6 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-## 8
 test_that("make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
@@ -211,7 +182,6 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-## 9
 test_that("make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
@@ -231,7 +201,7 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-## 10 (fails right now - it will take always the first method in the vector without error or warning)
+## (fails right now - it will take always the first method in the vector without error or warning)
 test_that("make_bins rejects multiple working_units as input", {
   data_source_bins <-
     extract_data(
@@ -252,7 +222,6 @@ test_that("make_bins rejects multiple working_units as input", {
   )
 })
 
-## 11
 test_that("make_bins rejects NULL values for all parameters (but data_source_bins)", {
   data_source_bins <-
     extract_data(
@@ -280,7 +249,6 @@ test_that("make_bins rejects NULL values for all parameters (but data_source_bin
 #               working_units = "levels"                     #
 # ---------------------------------------------------------- #
 
-## 12
 test_that("make_bins with working_units='levels' accepts data without age uncertainty", {
   data_source_bins <-
     extract_data(
@@ -318,7 +286,7 @@ test_that("make_bins with working_units='levels' works if there are 0s in age da
   )
 })
 
-## 13 (test fails - function works and produces invalid output)
+## (test fails - function works and produces invalid output)
 test_that("make_bins with working_units='levels' fails if there are no rownames in age data", {
   data_source_bins <-
     extract_data(
@@ -344,7 +312,6 @@ test_that("make_bins with working_units='levels' fails if there are no rownames 
   expect_false(bins$label[1] == "...1-...2")
 })
 
-## 14
 test_that("make_bins with working_units='levels' works if rownames in age are not numeric", {
   data_source_bins <-
     extract_data(
@@ -435,7 +402,6 @@ test_that("make_bins with working_units='bins' works if there are 0s in age data
   )
 })
 
-## 15
 test_that("make_bins fails with working_units='bins' and no bin_size", {
   data_source_bins <-
     extract_data(
@@ -457,8 +423,6 @@ test_that("make_bins fails with working_units='bins' and no bin_size", {
   )
 })
 
-
-## 16
 test_that("make_bins rejects non-numeric bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
@@ -481,7 +445,7 @@ test_that("make_bins rejects non-numeric bin_size if working_units='bins'", {
 })
 
 
-## 17
+
 test_that("make_bins works with minimum valid bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
@@ -503,7 +467,6 @@ test_that("make_bins works with minimum valid bin_size if working_units='bins'",
 })
 
 
-## 18
 test_that("make_bins works with maximum valid bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
@@ -525,7 +488,6 @@ test_that("make_bins works with maximum valid bin_size if working_units='bins'",
 })
 
 
-## 18
 test_that("make_bins rejects Inf bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
@@ -974,8 +936,10 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts = n
   )
 })
 
-
+# ---------------------------------------------------------- #
 # 2. Output validation
+# ---------------------------------------------------------- #
+
 test_that("make_bins returns the correct output", {
   data_source_bins <-
     extract_data(

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -76,6 +76,767 @@ test_that("make_bins rejects data input class == numeric", {
   )
 })
 
+# Additional tests:
+
+test_that("make_bins rejects empty data_source_bins", {
+  expect_error(
+    make_bins(
+      list(),
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "argument of length 0"
+  )
+})
+
+
+test_that("make_bins rejects NA data_source_bins", {
+  expect_error(
+    make_bins(
+      NA,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'data_source_bins' must be one of the following: 'list'"
+  )
+})
+
+test_that("make_bins rejects matrix data_source_bins", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins <- as.matrix(data_source_bins)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'data_source_bins' must be one of the following: 'list'"
+  )
+})
+
+test_that("make_bins rejects 0 data_source_bins", {
+  expect_error(
+    make_bins(
+      0,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'data_source_bins' must be one of the following: 'list'"
+  )
+})
+
+test_that("make_bins works with default parameters", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+  )
+})
+
+# Data specific validation:
+test_that("make_bins rejects data_source_bins with all empty elements in the list", {
+  data_source_bins <-
+    list(
+      community = data.frame(),
+      age = data.frame(age = numeric()),
+      age_un = data.frame()
+    )
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "`age_diff` must be size 1, not 2."
+  )
+})
+
+
+## A suite of tests that fail because
+## the function does not handle the community part of the data at all
+
+test_that("make_bins rejects data_source_bins without community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community <- NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+
+test_that("make_bins rejects data_source_bins list community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community <- list(data_source_bins$community)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins matrix community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community <- as.matrix(data_source_bins$community)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+
+test_that("make_bins rejects data_source_bins character community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community <- "my_community"
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins numeric community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community <- 123
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins NA community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community[, ] <- NA
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins 0 community in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$community[, ] <- 0
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins with community without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  rownames(data_source_bins$community) <- NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+
+## Age:
+test_that("make_bins rejects data_source_bins without age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age <- NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "`names` must be a character vector"
+  )
+})
+
+
+test_that("make_bins rejects data_source_bins list age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age <- list(data_source_bins$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "argument of length 0"
+  )
+})
+
+test_that("make_bins rejects data_source_bins matrix age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age <- as.matrix(data_source_bins$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "Argument 1 must be a data frame or a named atomic vector"
+  )
+})
+
+
+test_that("make_bins rejects data_source_bins character age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age <- "my_age"
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "Argument 1 must be a data frame or a named atomic vector"
+  )
+})
+
+test_that("make_bins rejects data_source_bins numeric age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age <- 123
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "Argument 1 must be a data frame or a named atomic vector"
+  )
+})
+
+test_that("make_bins rejects data_source_bins NA age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age[, ] <- NA
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels",
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins NA age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age[, ] <- NA
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    ),
+    "'from' must be a finite number"
+  )
+})
+
+test_that("make_bins rejects data_source_bins NA age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age[, ] <- NA
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'from' must be a finite number"
+  )
+})
+
+test_that("make_bins rejects data_source_bins 0 age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age[, ] <- 0
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels"
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins 0 age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age[, ] <- 0
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins 0 age in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age[, ] <- 0
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  rownames(data_source_bins$age) <- NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels"
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+
+test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  rownames(data_source_bins$age) <- NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+
+test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  rownames(data_source_bins$age) <- NULL
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    # no error programmed into the function yet
+  )
+})
+
+
+# character values inside age
+test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels"
+    ),
+  )
+})
+
+test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    ),
+    "non-numeric argument to mathematical function"
+  )
+})
+
+test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts =
+      ),
+    "non-numeric argument to mathematical function"
+  )
+})
+
+test_that("make_bins accepts minimal age data (1 row)", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$community <- data_source_bins$community[1, , drop = FALSE]
+  data_source_bins$age <- data_source_bins$age[1, , drop = FALSE]
+  data_source_bins$age_un <- data_source_bins$age_un[, 1, drop = FALSE]
+
+
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels"
+    )
+  )
+})
+
+test_that("make_bins accepts minimal age data (1 row)", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$community <- data_source_bins$community[1, , drop = FALSE]
+  data_source_bins$age <- data_source_bins$age[1, , drop = FALSE]
+  data_source_bins$age_un <- data_source_bins$age_un[, 1, drop = FALSE]
+
+
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    )
+  )
+})
+
+test_that("make_bins accepts minimal age data (1 row)", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$community <- data_source_bins$community[1, , drop = FALSE]
+  data_source_bins$age <- data_source_bins$age[1, , drop = FALSE]
+  data_source_bins$age_un <- data_source_bins$age_un[, 1, drop = FALSE]
+
+
+  expect_no_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+  )
+})
+
+
+# age with character strings instead of numeric
+test_that("make_bins rejects age with character strings instead of numeric", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "levels"
+    ), #
+    "Can't combine"
+  )
+})
+
+test_that("make_bins rejects age with character strings instead of numeric", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "bins",
+      bin_size = 500
+    ), #
+    "non-numeric argument to mathematical function"
+  )
+})
+
+test_that("make_bins rejects age with character strings instead of numeric", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+
+  expect_error(
+    make_bins(
+      data_source_bins,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    ), #
+    "non-numeric argument to mathematical function"
+  )
+})
+
+
 # ---------------------------------------------------------- #
 #               working_unit validation                      #
 # ---------------------------------------------------------- #

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -6,7 +6,8 @@
 #               data_source_bins validation                  #
 # ---------------------------------------------------------- #
 
-test_that("make_bins rejects missing age data in data_source_bins", {
+test_that(
+  "make_bins rejects missing age data in data_source_bins", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -29,7 +30,8 @@ test_that("make_bins rejects missing age data in data_source_bins", {
   )
 })
 
-test_that("make_bins validates data input class == list", {
+test_that(
+  "make_bins validates data input class == list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -38,7 +40,8 @@ test_that("make_bins validates data input class == list", {
       verbose = FALSE
     )
 
-  class(data_source_bins) <-
+  class(
+    data_source_bins) <-
     "data.frame"
 
   expect_error(
@@ -52,7 +55,8 @@ test_that("make_bins validates data input class == list", {
   )
 })
 
-test_that("make_bins rejects data input class == character", {
+test_that(
+  "make_bins rejects data input class == character", {
   expect_error(
     make_bins(
       "data",
@@ -64,7 +68,8 @@ test_that("make_bins rejects data input class == character", {
   )
 })
 
-test_that("make_bins rejects data input class == numeric", {
+test_that(
+  "make_bins rejects data input class == numeric", {
   expect_error(
     make_bins(
       123,
@@ -78,7 +83,8 @@ test_that("make_bins rejects data input class == numeric", {
 
 # Additional tests:
 
-test_that("make_bins rejects empty data_source_bins", {
+test_that(
+  "make_bins rejects empty data_source_bins", {
   expect_error(
     make_bins(
       list(),
@@ -91,7 +97,8 @@ test_that("make_bins rejects empty data_source_bins", {
 })
 
 
-test_that("make_bins rejects NA data_source_bins", {
+test_that(
+  "make_bins rejects NA data_source_bins", {
   expect_error(
     make_bins(
       NA,
@@ -103,7 +110,8 @@ test_that("make_bins rejects NA data_source_bins", {
   )
 })
 
-test_that("make_bins rejects matrix data_source_bins", {
+test_that(
+  "make_bins rejects matrix data_source_bins", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -112,7 +120,8 @@ test_that("make_bins rejects matrix data_source_bins", {
       verbose = FALSE
     )
 
-  data_source_bins <- as.matrix(data_source_bins)
+  data_source_bins <-
+    as.matrix(data_source_bins)
 
   expect_error(
     make_bins(
@@ -125,7 +134,8 @@ test_that("make_bins rejects matrix data_source_bins", {
   )
 })
 
-test_that("make_bins rejects 0 data_source_bins", {
+test_that(
+  "make_bins rejects 0 data_source_bins", {
   expect_error(
     make_bins(
       0,
@@ -137,7 +147,8 @@ test_that("make_bins rejects 0 data_source_bins", {
   )
 })
 
-test_that("make_bins works with default parameters", {
+test_that(
+  "make_bins works with default parameters", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -157,11 +168,14 @@ test_that("make_bins works with default parameters", {
 })
 
 # Data specific validation:
-test_that("make_bins rejects data_source_bins with all empty elements in the list", {
+test_that(
+  "make_bins rejects data_source_bins with all empty elements in the list", {
   data_source_bins <-
     list(
       community = data.frame(),
-      age = data.frame(age = numeric()),
+      age = data.frame(
+    age = numeric(
+    )),
       age_un = data.frame()
     )
 
@@ -180,7 +194,8 @@ test_that("make_bins rejects data_source_bins with all empty elements in the lis
 ## A suite of tests that fail because
 ## the function does not handle the community part of the data at all
 
-test_that("make_bins rejects data_source_bins without community in the list", {
+test_that(
+  "make_bins rejects data_source_bins without community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -188,7 +203,8 @@ test_that("make_bins rejects data_source_bins without community in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community <- NULL
+  data_source_bins$community <-
+    NULL
 
   expect_error(
     make_bins(
@@ -202,7 +218,8 @@ test_that("make_bins rejects data_source_bins without community in the list", {
 })
 
 
-test_that("make_bins rejects data_source_bins list community in the list", {
+test_that(
+  "make_bins rejects data_source_bins list community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -210,7 +227,8 @@ test_that("make_bins rejects data_source_bins list community in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community <- list(data_source_bins$community)
+  data_source_bins$community <-
+    list(data_source_bins$community)
 
   expect_error(
     make_bins(
@@ -223,7 +241,8 @@ test_that("make_bins rejects data_source_bins list community in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins matrix community in the list", {
+test_that(
+  "make_bins rejects data_source_bins matrix community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -231,7 +250,8 @@ test_that("make_bins rejects data_source_bins matrix community in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community <- as.matrix(data_source_bins$community)
+  data_source_bins$community <-
+    as.matrix(data_source_bins$community)
 
   expect_error(
     make_bins(
@@ -245,7 +265,8 @@ test_that("make_bins rejects data_source_bins matrix community in the list", {
 })
 
 
-test_that("make_bins rejects data_source_bins character community in the list", {
+test_that(
+  "make_bins rejects data_source_bins character community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -253,7 +274,8 @@ test_that("make_bins rejects data_source_bins character community in the list", 
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community <- "my_community"
+  data_source_bins$community <-
+    "my_community"
 
   expect_error(
     make_bins(
@@ -266,7 +288,8 @@ test_that("make_bins rejects data_source_bins character community in the list", 
   )
 })
 
-test_that("make_bins rejects data_source_bins numeric community in the list", {
+test_that(
+  "make_bins rejects data_source_bins numeric community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -274,7 +297,8 @@ test_that("make_bins rejects data_source_bins numeric community in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community <- 123
+  data_source_bins$community <-
+    123
 
   expect_error(
     make_bins(
@@ -287,7 +311,8 @@ test_that("make_bins rejects data_source_bins numeric community in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins NA community in the list", {
+test_that(
+  "make_bins rejects data_source_bins NA community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -295,7 +320,8 @@ test_that("make_bins rejects data_source_bins NA community in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community[, ] <- NA
+  data_source_bins$community[, ] <-
+    NA
 
   expect_error(
     make_bins(
@@ -308,7 +334,8 @@ test_that("make_bins rejects data_source_bins NA community in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins 0 community in the list", {
+test_that(
+  "make_bins rejects data_source_bins 0 community in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -316,7 +343,8 @@ test_that("make_bins rejects data_source_bins 0 community in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$community[, ] <- 0
+  data_source_bins$community[, ] <-
+    0
 
   expect_error(
     make_bins(
@@ -329,7 +357,8 @@ test_that("make_bins rejects data_source_bins 0 community in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins with community without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with community without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -337,7 +366,8 @@ test_that("make_bins rejects data_source_bins with community without rownames in
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  rownames(data_source_bins$community) <- NULL
+  rownames(data_source_bins$community) <-
+    NULL
 
   expect_error(
     make_bins(
@@ -352,7 +382,8 @@ test_that("make_bins rejects data_source_bins with community without rownames in
 
 
 ## Age:
-test_that("make_bins rejects data_source_bins without age in the list", {
+test_that(
+  "make_bins rejects data_source_bins without age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -360,7 +391,8 @@ test_that("make_bins rejects data_source_bins without age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age <- NULL
+  data_source_bins$age <-
+    NULL
 
   expect_error(
     make_bins(
@@ -374,7 +406,8 @@ test_that("make_bins rejects data_source_bins without age in the list", {
 })
 
 
-test_that("make_bins rejects data_source_bins list age in the list", {
+test_that(
+  "make_bins rejects data_source_bins list age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -382,7 +415,8 @@ test_that("make_bins rejects data_source_bins list age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age <- list(data_source_bins$age)
+  data_source_bins$age <-
+    list(data_source_bins$age)
 
   expect_error(
     make_bins(
@@ -395,7 +429,8 @@ test_that("make_bins rejects data_source_bins list age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins matrix age in the list", {
+test_that(
+  "make_bins rejects data_source_bins matrix age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -403,7 +438,8 @@ test_that("make_bins rejects data_source_bins matrix age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age <- as.matrix(data_source_bins$age)
+  data_source_bins$age <-
+    as.matrix(data_source_bins$age)
 
   expect_error(
     make_bins(
@@ -417,7 +453,8 @@ test_that("make_bins rejects data_source_bins matrix age in the list", {
 })
 
 
-test_that("make_bins rejects data_source_bins character age in the list", {
+test_that(
+  "make_bins rejects data_source_bins character age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -425,7 +462,8 @@ test_that("make_bins rejects data_source_bins character age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age <- "my_age"
+  data_source_bins$age <-
+    "my_age"
 
   expect_error(
     make_bins(
@@ -438,7 +476,8 @@ test_that("make_bins rejects data_source_bins character age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins numeric age in the list", {
+test_that(
+  "make_bins rejects data_source_bins numeric age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -446,7 +485,8 @@ test_that("make_bins rejects data_source_bins numeric age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age <- 123
+  data_source_bins$age <-
+    123
 
   expect_error(
     make_bins(
@@ -459,7 +499,8 @@ test_that("make_bins rejects data_source_bins numeric age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins NA age in the list", {
+test_that(
+  "make_bins rejects data_source_bins NA age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -467,7 +508,8 @@ test_that("make_bins rejects data_source_bins NA age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age[, ] <- NA
+  data_source_bins$age[, ] <-
+    NA
 
   expect_error(
     make_bins(
@@ -478,7 +520,8 @@ test_that("make_bins rejects data_source_bins NA age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins NA age in the list", {
+test_that(
+  "make_bins rejects data_source_bins NA age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -486,7 +529,8 @@ test_that("make_bins rejects data_source_bins NA age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age[, ] <- NA
+  data_source_bins$age[, ] <-
+    NA
 
   expect_error(
     make_bins(
@@ -498,7 +542,8 @@ test_that("make_bins rejects data_source_bins NA age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins NA age in the list", {
+test_that(
+  "make_bins rejects data_source_bins NA age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -506,7 +551,8 @@ test_that("make_bins rejects data_source_bins NA age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age[, ] <- NA
+  data_source_bins$age[, ] <-
+    NA
 
   expect_error(
     make_bins(
@@ -519,7 +565,8 @@ test_that("make_bins rejects data_source_bins NA age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins 0 age in the list", {
+test_that(
+  "make_bins rejects data_source_bins 0 age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -527,7 +574,8 @@ test_that("make_bins rejects data_source_bins 0 age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age[, ] <- 0
+  data_source_bins$age[, ] <-
+    0
 
   expect_error(
     make_bins(
@@ -538,7 +586,8 @@ test_that("make_bins rejects data_source_bins 0 age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins 0 age in the list", {
+test_that(
+  "make_bins rejects data_source_bins 0 age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -546,7 +595,8 @@ test_that("make_bins rejects data_source_bins 0 age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age[, ] <- 0
+  data_source_bins$age[, ] <-
+    0
 
   expect_error(
     make_bins(
@@ -558,7 +608,8 @@ test_that("make_bins rejects data_source_bins 0 age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins 0 age in the list", {
+test_that(
+  "make_bins rejects data_source_bins 0 age in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -566,7 +617,8 @@ test_that("make_bins rejects data_source_bins 0 age in the list", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age[, ] <- 0
+  data_source_bins$age[, ] <-
+    0
 
   expect_error(
     make_bins(
@@ -579,7 +631,8 @@ test_that("make_bins rejects data_source_bins 0 age in the list", {
   )
 })
 
-test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -587,7 +640,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  rownames(data_source_bins$age) <- NULL
+  rownames(data_source_bins$age) <-
+    NULL
 
   expect_error(
     make_bins(
@@ -599,7 +653,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
 })
 
 
-test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -607,7 +662,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  rownames(data_source_bins$age) <- NULL
+  rownames(data_source_bins$age) <-
+    NULL
 
   expect_error(
     make_bins(
@@ -620,7 +676,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
 })
 
 
-test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -628,7 +685,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  rownames(data_source_bins$age) <- NULL
+  rownames(data_source_bins$age) <-
+    NULL
 
   expect_error(
     make_bins(
@@ -643,7 +701,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
 
 
 # character values inside age
-test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -651,7 +710,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+  data_source_bins$age$age <-
+    as.character(data_source_bins$age$age)
 
   expect_error(
     make_bins(
@@ -661,7 +721,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
   )
 })
 
-test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -669,7 +730,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+  data_source_bins$age$age <-
+    as.character(data_source_bins$age$age)
 
   expect_error(
     make_bins(
@@ -681,7 +743,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
   )
 })
 
-test_that("make_bins rejects data_source_bins with age without rownames in the list", {
+test_that(
+  "make_bins rejects data_source_bins with age without rownames in the list", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -689,7 +752,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+  data_source_bins$age$age <-
+    as.character(data_source_bins$age$age)
 
   expect_error(
     make_bins(
@@ -702,7 +766,8 @@ test_that("make_bins rejects data_source_bins with age without rownames in the l
   )
 })
 
-test_that("make_bins accepts minimal age data (1 row)", {
+test_that(
+  "make_bins accepts minimal age data (1 row)", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -711,9 +776,12 @@ test_that("make_bins accepts minimal age data (1 row)", {
       verbose = FALSE
     )
 
-  data_source_bins$community <- data_source_bins$community[1, , drop = FALSE]
-  data_source_bins$age <- data_source_bins$age[1, , drop = FALSE]
-  data_source_bins$age_un <- data_source_bins$age_un[, 1, drop = FALSE]
+  data_source_bins$community <-
+    data_source_bins$community[1, , drop = FALSE]
+  data_source_bins$age <-
+    data_source_bins$age[1, , drop = FALSE]
+  data_source_bins$age_un <-
+    data_source_bins$age_un[, 1, drop = FALSE]
 
 
   expect_no_error(
@@ -724,7 +792,8 @@ test_that("make_bins accepts minimal age data (1 row)", {
   )
 })
 
-test_that("make_bins accepts minimal age data (1 row)", {
+test_that(
+  "make_bins accepts minimal age data (1 row)", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -733,9 +802,12 @@ test_that("make_bins accepts minimal age data (1 row)", {
       verbose = FALSE
     )
 
-  data_source_bins$community <- data_source_bins$community[1, , drop = FALSE]
-  data_source_bins$age <- data_source_bins$age[1, , drop = FALSE]
-  data_source_bins$age_un <- data_source_bins$age_un[, 1, drop = FALSE]
+  data_source_bins$community <-
+    data_source_bins$community[1, , drop = FALSE]
+  data_source_bins$age <-
+    data_source_bins$age[1, , drop = FALSE]
+  data_source_bins$age_un <-
+    data_source_bins$age_un[, 1, drop = FALSE]
 
 
   expect_no_error(
@@ -747,7 +819,8 @@ test_that("make_bins accepts minimal age data (1 row)", {
   )
 })
 
-test_that("make_bins accepts minimal age data (1 row)", {
+test_that(
+  "make_bins accepts minimal age data (1 row)", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -756,9 +829,12 @@ test_that("make_bins accepts minimal age data (1 row)", {
       verbose = FALSE
     )
 
-  data_source_bins$community <- data_source_bins$community[1, , drop = FALSE]
-  data_source_bins$age <- data_source_bins$age[1, , drop = FALSE]
-  data_source_bins$age_un <- data_source_bins$age_un[, 1, drop = FALSE]
+  data_source_bins$community <-
+    data_source_bins$community[1, , drop = FALSE]
+  data_source_bins$age <-
+    data_source_bins$age[1, , drop = FALSE]
+  data_source_bins$age_un <-
+    data_source_bins$age_un[, 1, drop = FALSE]
 
 
   expect_no_error(
@@ -773,7 +849,8 @@ test_that("make_bins accepts minimal age data (1 row)", {
 
 
 # age with character strings instead of numeric
-test_that("make_bins rejects age with character strings instead of numeric", {
+test_that(
+  "make_bins rejects age with character strings instead of numeric", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -782,7 +859,8 @@ test_that("make_bins rejects age with character strings instead of numeric", {
       verbose = FALSE
     )
 
-  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+  data_source_bins$age$age <-
+    as.character(data_source_bins$age$age)
 
   expect_error(
     make_bins(
@@ -793,7 +871,8 @@ test_that("make_bins rejects age with character strings instead of numeric", {
   )
 })
 
-test_that("make_bins rejects age with character strings instead of numeric", {
+test_that(
+  "make_bins rejects age with character strings instead of numeric", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -802,7 +881,8 @@ test_that("make_bins rejects age with character strings instead of numeric", {
       verbose = FALSE
     )
 
-  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+  data_source_bins$age$age <-
+    as.character(data_source_bins$age$age)
 
   expect_error(
     make_bins(
@@ -814,7 +894,8 @@ test_that("make_bins rejects age with character strings instead of numeric", {
   )
 })
 
-test_that("make_bins rejects age with character strings instead of numeric", {
+test_that(
+  "make_bins rejects age with character strings instead of numeric", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -823,7 +904,8 @@ test_that("make_bins rejects age with character strings instead of numeric", {
       verbose = FALSE
     )
 
-  data_source_bins$age$age <- as.character(data_source_bins$age$age)
+  data_source_bins$age$age <-
+    as.character(data_source_bins$age$age)
 
   expect_error(
     make_bins(
@@ -841,7 +923,8 @@ test_that("make_bins rejects age with character strings instead of numeric", {
 #               working_unit validation                      #
 # ---------------------------------------------------------- #
 
-test_that("make_bins validates that there is a working_unit as input", {
+test_that(
+  "make_bins validates that there is a working_unit as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -859,7 +942,8 @@ test_that("make_bins validates that there is a working_unit as input", {
 })
 
 ## (fails - it silently uses "bins" and default bin_size = 500
-test_that("make_bins rejects no working_unit as input", {
+test_that(
+  "make_bins rejects no working_unit as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -875,7 +959,8 @@ test_that("make_bins rejects no working_unit as input", {
   )
 })
 
-test_that("make_bins validates that working_unit is not NULL", {
+test_that(
+  "make_bins validates that working_unit is not NULL", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -892,7 +977,8 @@ test_that("make_bins validates that working_unit is not NULL", {
   )
 })
 
-test_that("make_bins validates correct working_unit value as input", {
+test_that(
+  "make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -909,7 +995,8 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-test_that("make_bins validates correct working_unit value as input", {
+test_that(
+  "make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -926,7 +1013,8 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-test_that("make_bins validates correct working_unit value as input", {
+test_that(
+  "make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -943,7 +1031,8 @@ test_that("make_bins validates correct working_unit value as input", {
   )
 })
 
-test_that("make_bins validates correct working_unit value as input", {
+test_that(
+  "make_bins validates correct working_unit value as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -963,7 +1052,8 @@ test_that("make_bins validates correct working_unit value as input", {
 })
 
 ## (fails right now - it will take always the first method in the vector without error or warning)
-test_that("make_bins rejects multiple working_units as input", {
+test_that(
+  "make_bins rejects multiple working_units as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -983,7 +1073,8 @@ test_that("make_bins rejects multiple working_units as input", {
   )
 })
 
-test_that("make_bins rejects NULL values for all parameters (but data_source_bins)", {
+test_that(
+  "make_bins rejects NULL values for all parameters (but data_source_bins)", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1010,7 +1101,8 @@ test_that("make_bins rejects NULL values for all parameters (but data_source_bin
 #               working_units = "levels"                     #
 # ---------------------------------------------------------- #
 
-test_that("make_bins with working_units='levels' accepts data without age uncertainty", {
+test_that(
+  "make_bins with working_units='levels' accepts data without age uncertainty", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1027,7 +1119,8 @@ test_that("make_bins with working_units='levels' accepts data without age uncert
   )
 })
 
-test_that("make_bins with working_units='levels' works if there are 0s in age data", {
+test_that(
+  "make_bins with working_units='levels' works if there are 0s in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1036,7 +1129,8 @@ test_that("make_bins with working_units='levels' works if there are 0s in age da
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- 0
+  data_source_bins$age$age[1:3] <-
+    0
 
   expect_no_error(
     bins <-
@@ -1048,7 +1142,8 @@ test_that("make_bins with working_units='levels' works if there are 0s in age da
 })
 
 ## (test fails - function works and produces invalid output)
-test_that("make_bins with working_units='levels' fails if there are no rownames in age data", {
+test_that(
+  "make_bins with working_units='levels' fails if there are no rownames in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1057,7 +1152,8 @@ test_that("make_bins with working_units='levels' fails if there are no rownames 
       verbose = FALSE
     )
 
-  rownames(data_source_bins$age) <- NULL
+  rownames(data_source_bins$age) <-
+    NULL
 
   expect_error(
     bins <-
@@ -1073,7 +1169,8 @@ test_that("make_bins with working_units='levels' fails if there are no rownames 
   expect_false(bins$label[1] == "...1-...2")
 })
 
-test_that("make_bins with working_units='levels' works if rownames in age are not numeric", {
+test_that(
+  "make_bins with working_units='levels' works if rownames in age are not numeric", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1084,7 +1181,8 @@ test_that("make_bins with working_units='levels' works if rownames in age are no
 
   length_levels <-
     length(rownames(data_source_bins$age))
-  rownames(data_source_bins$age) <-
+  rownames(
+    data_source_bins$age) <-
     paste0("ABC", 1:length_levels)
 
   expect_no_error(
@@ -1098,7 +1196,8 @@ test_that("make_bins with working_units='levels' works if rownames in age are no
   )
 })
 
-test_that("make_bins with working_units='levels' ignores NAs in age data", {
+test_that(
+  "make_bins with working_units='levels' ignores NAs in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1107,7 +1206,8 @@ test_that("make_bins with working_units='levels' ignores NAs in age data", {
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- NA
+  data_source_bins$age$age[1:3] <-
+    NA
 
   expect_no_error(
     bins <-
@@ -1125,7 +1225,8 @@ test_that("make_bins with working_units='levels' ignores NAs in age data", {
 #               working_units = "bins"                     #
 # ---------------------------------------------------------- #
 
-test_that("make_bins with working_units='bins' accepts data without age uncertainty", {
+test_that(
+  "make_bins with working_units='bins' accepts data without age uncertainty", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1142,7 +1243,8 @@ test_that("make_bins with working_units='bins' accepts data without age uncertai
   )
 })
 
-test_that("make_bins with working_units='bins' works if there are 0s in age data", {
+test_that(
+  "make_bins with working_units='bins' works if there are 0s in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1151,7 +1253,8 @@ test_that("make_bins with working_units='bins' works if there are 0s in age data
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- 0
+  data_source_bins$age$age[1:3] <-
+    0
 
   expect_no_error(
     bins <-
@@ -1163,7 +1266,8 @@ test_that("make_bins with working_units='bins' works if there are 0s in age data
   )
 })
 
-test_that("make_bins fails with working_units='bins' and no bin_size", {
+test_that(
+  "make_bins fails with working_units='bins' and no bin_size", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1184,7 +1288,8 @@ test_that("make_bins fails with working_units='bins' and no bin_size", {
   )
 })
 
-test_that("make_bins rejects non-numeric bin_size if working_units='bins'", {
+test_that(
+  "make_bins rejects non-numeric bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1207,7 +1312,8 @@ test_that("make_bins rejects non-numeric bin_size if working_units='bins'", {
 
 
 
-test_that("make_bins works with minimum valid bin_size if working_units='bins'", {
+test_that(
+  "make_bins works with minimum valid bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1228,7 +1334,8 @@ test_that("make_bins works with minimum valid bin_size if working_units='bins'",
 })
 
 
-test_that("make_bins works with maximum valid bin_size if working_units='bins'", {
+test_that(
+  "make_bins works with maximum valid bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1249,7 +1356,8 @@ test_that("make_bins works with maximum valid bin_size if working_units='bins'",
 })
 
 
-test_that("make_bins rejects Inf bin_size if working_units='bins'", {
+test_that(
+  "make_bins rejects Inf bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1270,7 +1378,8 @@ test_that("make_bins rejects Inf bin_size if working_units='bins'", {
   )
 })
 
-test_that("make_bins rejects negative bin_size if working_units='bins'", {
+test_that(
+  "make_bins rejects negative bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1291,7 +1400,8 @@ test_that("make_bins rejects negative bin_size if working_units='bins'", {
   )
 })
 
-test_that("make_bins rejects non-integer bin_size if working_units='bins'", {
+test_that(
+  "make_bins rejects non-integer bin_size if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1313,7 +1423,8 @@ test_that("make_bins rejects non-integer bin_size if working_units='bins'", {
 })
 
 
-test_that("make_bins rejects vector of multiple bin_sizes if working_units='bins'", {
+test_that(
+  "make_bins rejects vector of multiple bin_sizes if working_units='bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1327,14 +1438,16 @@ test_that("make_bins rejects vector of multiple bin_sizes if working_units='bins
       make_bins(
         data_source_bins,
         working_units = "bins",
-        bin_size = c(100:500),
+        bin_size = c(
+    100:500),
         number_of_shifts = NULL
       ),
     "'bin_size' must be one of the following: 'numeric'"
   )
 })
 
-test_that("make_bins throws error if 'bins' and there are NAs in age data", {
+test_that(
+  "make_bins throws error if 'bins' and there are NAs in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1343,7 +1456,8 @@ test_that("make_bins throws error if 'bins' and there are NAs in age data", {
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- NA
+  data_source_bins$age$age[1:3] <-
+    NA
 
   expect_error(
     bins <-
@@ -1357,7 +1471,8 @@ test_that("make_bins throws error if 'bins' and there are NAs in age data", {
   )
 })
 
-test_that("make_bins throws error if working_units='bins' and bin_size < 1", {
+test_that(
+  "make_bins throws error if working_units='bins' and bin_size < 1", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1381,7 +1496,8 @@ test_that("make_bins throws error if working_units='bins' and bin_size < 1", {
 #               working_units = "MW"                     #
 # ---------------------------------------------------------- #
 
-test_that("make_bins with working_units='MW' accepts data without age uncertainty", {
+test_that(
+  "make_bins with working_units='MW' accepts data without age uncertainty", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1399,7 +1515,8 @@ test_that("make_bins with working_units='MW' accepts data without age uncertaint
   )
 })
 
-test_that("make_bins with working_units='MW' throws error if there are NAs in age data", {
+test_that(
+  "make_bins with working_units='MW' throws error if there are NAs in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1408,7 +1525,8 @@ test_that("make_bins with working_units='MW' throws error if there are NAs in ag
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- NA
+  data_source_bins$age$age[1:3] <-
+    NA
 
   expect_error(
     bins <-
@@ -1422,7 +1540,8 @@ test_that("make_bins with working_units='MW' throws error if there are NAs in ag
   )
 })
 
-test_that("make_bins with working_units='MW' works if there are 0s in age data", {
+test_that(
+  "make_bins with working_units='MW' works if there are 0s in age data", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1431,7 +1550,8 @@ test_that("make_bins with working_units='MW' works if there are 0s in age data",
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- 0
+  data_source_bins$age$age[1:3] <-
+    0
 
   expect_no_error(
     bins <-
@@ -1445,7 +1565,8 @@ test_that("make_bins with working_units='MW' works if there are 0s in age data",
 })
 
 
-test_that("make_bins throws error if working_units='MW' and bin_size is missing", {
+test_that(
+  "make_bins throws error if working_units='MW' and bin_size is missing", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1468,7 +1589,8 @@ test_that("make_bins throws error if working_units='MW' and bin_size is missing"
 })
 
 
-test_that("make_bins throws error if working_units='MW' and number_of_shifts is missing", {
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts is missing", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1489,7 +1611,8 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts is 
   )
 })
 
-test_that("make_bins throws error if working_units='MW' and bin_size is NA", {
+test_that(
+  "make_bins throws error if working_units='MW' and bin_size is NA", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1511,7 +1634,8 @@ test_that("make_bins throws error if working_units='MW' and bin_size is NA", {
   )
 })
 
-test_that("make_bins uses default parameters if working_units='MW' and no input bin_size and number_of_shifts", {
+test_that(
+  "make_bins uses default parameters if working_units='MW' and no input bin_size and number_of_shifts", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1537,7 +1661,8 @@ test_that("make_bins uses default parameters if working_units='MW' and no input 
   expect_identical(bins_default, bins_res)
 })
 
-test_that("make_bins throws error if working_units='MW' and non-integer bin_size", {
+test_that(
+  "make_bins throws error if working_units='MW' and non-integer bin_size", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1557,7 +1682,8 @@ test_that("make_bins throws error if working_units='MW' and non-integer bin_size
   )
 })
 
-test_that("make_bins throws error if working_units='MW' and bin_size < 1", {
+test_that(
+  "make_bins throws error if working_units='MW' and bin_size < 1", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1577,7 +1703,8 @@ test_that("make_bins throws error if working_units='MW' and bin_size < 1", {
   )
 })
 
-test_that("make_bins throws error if working_units='MW' and number_of_shifts < 1", {
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts < 1", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1597,7 +1724,8 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts < 1
   )
 })
 
-test_that("make_bins throws no error if working_units='MW' and number_of_shifts = 1", {
+test_that(
+  "make_bins throws no error if working_units='MW' and number_of_shifts = 1", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1616,7 +1744,8 @@ test_that("make_bins throws no error if working_units='MW' and number_of_shifts 
   )
 })
 
-test_that("make_bins throws error if working_units='MW' and number_of_shifts = Inf", {
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = Inf", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1636,7 +1765,8 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts = I
   )
 })
 
-test_that("make_bins throws error if working_units='MW' and number_of_shifts = negative", {
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = negative", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1656,7 +1786,8 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts = n
   )
 })
 
-test_that("make_bins throws error if working_units='MW' and number_of_shifts = NA", {
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = NA", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1677,7 +1808,8 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts = N
 })
 
 
-test_that("make_bins throws error if working_units='MW' and number_of_shifts = non-numeric", {
+test_that(
+  "make_bins throws error if working_units='MW' and number_of_shifts = non-numeric", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1701,7 +1833,8 @@ test_that("make_bins throws error if working_units='MW' and number_of_shifts = n
 # 2. Output validation
 # ---------------------------------------------------------- #
 
-test_that("make_bins returns the correct output", {
+test_that(
+  "make_bins returns the correct output", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1732,32 +1865,40 @@ test_that("make_bins returns the correct output", {
   )
 
   expect_true(
-    class(bins$name) == "character"
+    class(
+    bins$name) == "character"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "character"
+    class(
+    bins$start) == "character"
   )
   expect_true(
-    class(bins$end) == "character"
+    class(
+    bins$end) == "character"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
 
 
 
-test_that("make_bins returns the correct output without age_uncertainty", {
+test_that(
+  "make_bins returns the correct output without age_uncertainty", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1787,30 +1928,38 @@ test_that("make_bins returns the correct output without age_uncertainty", {
   )
 
   expect_true(
-    class(bins$name) == "character"
+    class(
+    bins$name) == "character"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "character"
+    class(
+    bins$start) == "character"
   )
   expect_true(
-    class(bins$end) == "character"
+    class(
+    bins$end) == "character"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
 
-test_that("make_bins returns the correct output with default parameters for 'levels'", {
+test_that(
+  "make_bins returns the correct output with default parameters for 'levels'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1844,29 +1993,37 @@ test_that("make_bins returns the correct output with default parameters for 'lev
   )
 
   expect_true(
-    class(bins$name) == "character"
+    class(
+    bins$name) == "character"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "character"
+    class(
+    bins$start) == "character"
   )
   expect_true(
-    class(bins$end) == "character"
+    class(
+    bins$end) == "character"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
-test_that("make_bins with working_units='levels' ignores NAs in age data and returns valid output", {
+test_that(
+  "make_bins with working_units='levels' ignores NAs in age data and returns valid output", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1875,7 +2032,8 @@ test_that("make_bins with working_units='levels' ignores NAs in age data and ret
       verbose = FALSE
     )
 
-  data_source_bins$age$age[1:3] <- NA
+  data_source_bins$age$age[1:3] <-
+    NA
 
   bins <-
     make_bins(
@@ -1904,31 +2062,39 @@ test_that("make_bins with working_units='levels' ignores NAs in age data and ret
   )
 
   expect_true(
-    class(bins$name) == "character"
+    class(
+    bins$name) == "character"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "character"
+    class(
+    bins$start) == "character"
   )
   expect_true(
-    class(bins$end) == "character"
+    class(
+    bins$end) == "character"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
 
 
-test_that("make_bins returns the correct output with default parameters for 'bins'", {
+test_that(
+  "make_bins returns the correct output with default parameters for 'bins'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1959,29 +2125,37 @@ test_that("make_bins returns the correct output with default parameters for 'bin
   )
 
   expect_true(
-    class(bins$name) == "numeric"
+    class(
+    bins$name) == "numeric"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "numeric"
+    class(
+    bins$start) == "numeric"
   )
   expect_true(
-    class(bins$end) == "numeric"
+    class(
+    bins$end) == "numeric"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
-test_that("make_bins returns the correct output with default parameters for 'MW'", {
+test_that(
+  "make_bins returns the correct output with default parameters for 'MW'", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -2013,31 +2187,39 @@ test_that("make_bins returns the correct output with default parameters for 'MW'
   )
 
   expect_true(
-    class(bins$name) == "numeric"
+    class(
+    bins$name) == "numeric"
   )
   expect_true(
-    class(bins$shift) == "integer"
+    class(
+    bins$shift) == "integer"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "numeric"
+    class(
+    bins$start) == "numeric"
   )
   expect_true(
-    class(bins$end) == "numeric"
+    class(
+    bins$end) == "numeric"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
 
 ## (test fails as long as function accepts invalid input without rownames)
-test_that("make_bins with working_units='levels' and no rownames in age data returns valid output", {
+test_that(
+  "make_bins with working_units='levels' and no rownames in age data returns valid output", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -2046,7 +2228,8 @@ test_that("make_bins with working_units='levels' and no rownames in age data ret
       verbose = FALSE
     )
 
-  rownames(data_source_bins$age) <- NULL
+  rownames(data_source_bins$age) <-
+    NULL
 
   bins <-
     make_bins(
@@ -2075,30 +2258,38 @@ test_that("make_bins with working_units='levels' and no rownames in age data ret
   )
 
   expect_true(
-    class(bins$name) == "character"
+    class(
+    bins$name) == "character"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "character"
+    class(
+    bins$start) == "character"
   )
   expect_true(
-    class(bins$end) == "character"
+    class(
+    bins$end) == "character"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })
 
 
-test_that("make_bins with no working_units as input returns valid output", {
+test_that(
+  "make_bins with no working_units as input returns valid output", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -2108,7 +2299,8 @@ test_that("make_bins with no working_units as input returns valid output", {
     )
 
 
-  bins <- make_bins(
+  bins <-
+    make_bins(
     data_source_bins,
   )
 
@@ -2131,24 +2323,31 @@ test_that("make_bins with no working_units as input returns valid output", {
   )
 
   expect_true(
-    class(bins$name) == "character"
+    class(
+    bins$name) == "character"
   )
   expect_true(
-    class(bins$shift) == "numeric"
+    class(
+    bins$shift) == "numeric"
   )
   expect_true(
-    class(bins$age_diff) == "numeric"
+    class(
+    bins$age_diff) == "numeric"
   )
   expect_true(
-    class(bins$start) == "character"
+    class(
+    bins$start) == "character"
   )
   expect_true(
-    class(bins$end) == "character"
+    class(
+    bins$end) == "character"
   )
   expect_true(
-    class(bins$res_age) == "numeric"
+    class(
+    bins$res_age) == "numeric"
   )
   expect_true(
-    class(bins$label) == "character"
+    class(
+    bins$label) == "character"
   )
 })

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -1497,7 +1497,7 @@ test_that("make_bins and 'MW' works within the workflow of estimate_roc()", {
     data_work
 
   expect_no_error(
-    bin_WM <-
+    bin_MW <-
       make_bins(
         data_source_bins = data_source_prep,
         working_units = "MW",

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -1273,3 +1273,123 @@ test_that("make_bins returns the correct output with default parameters for 'MW'
     class(bins$label) == "character"
   )
 })
+
+
+## (test fails as long as function accepts invalid input without rownames)
+test_that("make_bins with working_units='levels' and no rownames in age data returns valid output", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  rownames(data_source_bins$age) <- NULL
+
+  bins <-
+    make_bins(
+      data_source_bins,
+      working_units = "levels",
+      bin_size = NULL,
+      number_of_shifts = NULL
+    )
+
+  # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_identical(
+    bins$name,
+    rownames(data_source_bins$age)
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "character"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "character"
+  )
+  expect_true(
+    class(bins$end) == "character"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+})
+
+
+test_that("make_bins with no working_units as input returns valid output", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+
+  bins <- make_bins(
+      data_source_bins,
+  )
+
+    # General output structure tests:
+  expect_s3_class(
+    bins, "data.frame"
+  )
+
+  expect_identical(
+    bins$name,
+    rownames(data_source_bins$age)
+  )
+
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(bins)
+    )
+  )
+
+  expect_true(
+    class(bins$name) == "character"
+  )
+  expect_true(
+    class(bins$shift) == "numeric"
+  )
+  expect_true(
+    class(bins$age_diff) == "numeric"
+  )
+  expect_true(
+    class(bins$start) == "character"
+  )
+  expect_true(
+    class(bins$end) == "character"
+  )
+  expect_true(
+    class(bins$res_age) == "numeric"
+  )
+  expect_true(
+    class(bins$label) == "character"
+  )
+
+
+})

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -1,0 +1,1348 @@
+# takes result from reduce_data() as input
+# parameters: working_units, bin_size, number_of_shifts, rand
+# returns: a list?
+
+
+# steps:
+## 1. checks input classes
+## 2. if a shift is present,
+## check N of shifts as well and set it = 1 if it is NULL
+## 3. if working_units is "levels", call make_bins() with "levels"
+## check if shifts are present, if so make bins with MW
+## of make bins with "bins" and bin_size
+## 4. check for age_un, if it is present, sample from it (SEED??)
+
+example_data <-
+  extract_data(
+    data_community_extract = RRatepol::example_data$pollen_data[[1]],
+    data_age_extract = RRatepol::example_data$sample_age[[1]],
+    age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+    verbose = FALSE
+  )
+
+prepare_data(example_data,
+  working_units = c("levels", "bins", "MW"),
+  bin_size = 500,
+  number_of_shifts = 5,
+  rand = NULL
+)
+
+
+
+# ---------------------------------------------------------- #
+#               Data_source_prep Input Tests                 #
+# ---------------------------------------------------------- #
+
+test_that("prepare_data rejects NULL data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = NULL,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ), "'data_source_prep' must be one of the following: 'list'"
+  )
+})
+
+test_that("prepare_data rejects incomplete list(data.frame) in data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = RRatepol::example_data$pollen_data[[1]],
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ), "'data_source_prep' must be one of the following: 'list'"
+  )
+})
+
+test_that("prepare_data fails if no community in data_source", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  example_data$community <- NULL
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ), "is not TRUE"
+  )
+})
+
+
+test_that("prepare_data fails if no age in data_source", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  example_data$age <- NULL
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ), "`names` must be a character vector"
+  )
+})
+
+test_that("prepare_data works if no age_uncertainty in data_source", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  example_data$age_un <- NULL
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+  )
+})
+
+
+
+
+# to do: test with 0 and NAs in age/community data
+## Community data
+# Zeros
+test_that("prepare_data with working_units='levels' works if there are 0s in community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$community[1:3] <- 0
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "levels"
+    )
+  )
+})
+
+test_that("prepare_data with working_units='bins' works if there are 0s in community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$community[1:3] <- 0
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500
+    )
+  )
+})
+
+
+test_that("prepare_data with working_units='MW' works if there are 0s in community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$community[1:3] <- 0
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+  )
+})
+
+# NAs in Age
+test_that("prepare_data with working_units='levels' works if there are NAs in community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$community[1:3] <- NA
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "levels"
+    )
+  )
+})
+
+test_that("prepare_data with working_units='bins' works if there are NAs in community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$community[1:3] <- NA
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500
+    )
+  )
+})
+
+
+test_that("prepare_data with working_units='MW' works if there are NAs in community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$community[1:3] <- NA
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+  )
+})
+
+
+## Age data
+# Zeros
+test_that("prepare_data with working_units='levels' works if there are 0s in age data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age$age[1:3] <- 0
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "levels"
+    )
+  )
+})
+
+test_that("prepare_data with working_units='bins' works if there are 0s in age data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age$age[1:3] <- 0
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500
+    )
+  )
+})
+
+
+test_that("prepare_data with working_units='MW' works if there are 0s in age data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age$age[1:3] <- 0
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
+  )
+})
+
+# NAs in Age
+test_that("prepare_data with working_units='levels' works if there are NAs in age data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age$age[1:3] <- NA
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "levels"
+    )
+  )
+})
+
+test_that("prepare_data with working_units='bins' fails if there are NAs in age data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age$age[1:3] <- NA
+
+  expect_error(
+    prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500
+    ),
+    "'from' must be a finite number"
+  )
+})
+
+
+test_that("prepare_data with working_units='MW' fails if there are NAs in age data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age$age[1:3] <- NA
+
+  expect_error(
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    ),
+    "'from' must be a finite number"
+  )
+})
+
+
+## Age_uncertainty data
+# Zeros
+test_that("prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age_un[1:3] <- 0
+
+  expect_no_error(
+    res <- prepare_data(
+      example_data,
+      working_units = "levels",
+      rand = 1
+    )
+  )
+
+  expect_false(
+    identical(
+      res[[1]][[1]]$data$age,
+      example_data$age$age
+    )
+  )
+})
+
+test_that("prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age_un[1:3] <- 0
+
+  expect_no_error(
+    res <- prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    )
+  )
+
+  expect_false(
+    identical(
+      res[[1]][[1]]$data$age,
+      example_data$age$age
+    )
+  )
+})
+
+
+test_that("prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age_un[1:3] <- 0
+
+  expect_no_error(
+    res <- prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 1
+    )
+  )
+
+  expect_false(
+    identical(
+      res[[1]][[1]]$data$age,
+      example_data$age$age
+    )
+  )
+})
+
+
+# NAs in Age_uncertainty
+test_that("prepare_data with working_units='levels' works if there are NAs in age_un data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age_un[1:3] <- NA
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "levels",
+      rand = 1
+    )
+  )
+})
+
+test_that("prepare_data with working_units='bins' works if there are NAs in age_un data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age_un[1:3] <- NA
+
+  expect_no_error(
+    prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    )
+  )
+})
+
+
+test_that("prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  example_data$age_un[1:3] <- NA
+
+  expect_no_error(
+    res <-  
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 1
+    )
+  )
+
+  # returns NA in output$age
+  expect_true(any(is.na(res[[1]][[1]]$data$age)))
+})
+
+# ---------------------------------------------------------- #
+#                  Working Units Input Tests                 #
+# ---------------------------------------------------------- #
+
+test_that("prepare_data validates working_units is one of the three valid options", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "invalid",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
+
+test_that("prepare_data validates working_units parameter is not numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = 123,
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
+
+test_that("prepare_data validates working_units parameter is not numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = NA,
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
+
+
+test_that("prepare_data validates working_units parameter is not a vector of parameters", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("MW", "bins", "levels"),
+      rand = NULL
+    ),
+    "'arg' must be of length 1"
+  )
+})
+
+test_that("prepare_data validates working_units parameter is not a vector of parameters", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("MW", "bins")
+    ),
+    "'arg' must be of length 1"
+  )
+})
+
+
+# test fails because function silently uses the default parameters
+test_that("prepare_data rejects no working_unit as input", {
+  data_source_bins <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_bins
+    )
+    # no error programmed into function yet
+  )
+})
+
+test_that("prepare_data validates working_units parameter is not 0", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = 0
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
+
+
+test_that("prepare_data validates working_units parameter is not NULL", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
+
+
+
+### Bin Size ###
+
+# ---------------------------------------------------------- #
+#                   Bin_size Input Tests                     #
+# ---------------------------------------------------------- #
+
+# 1.1 "bins"
+
+test_that("prepare_data validates bin_size is numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = "500",
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates bin_size is not Inf", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = Inf,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'to' must be a finite number"
+  )
+})
+
+
+test_that("prepare_data validates bin_size is not negative", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = -500,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "wrong sign in 'by' argument"
+  )
+})
+
+test_that("prepare_data validates bin_size is not NA", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = NA,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates bin_size is integer", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 500.5,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "' bin_size ' must be a an integer"
+  )
+})
+
+test_that("prepare_data validates bin_size is not 0", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 0,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "invalid"
+  )
+})
+
+
+test_that("prepare_data works with minimum bin_size (1)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 1,
+      number_of_shifts = NULL,
+      rand = NULL
+    )
+  )
+})
+
+
+test_that("prepare_data works with minimum bin_size (1) and bins", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 100,
+      number_of_shifts = NULL,
+      rand = NULL
+    )
+  )
+})
+
+# 1.2 "MW"
+
+test_that("prepare_data validates bin_size is numeric (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = "500",
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates bin_size is not Inf (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = Inf,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'to' must be a finite number"
+  )
+})
+
+
+test_that("prepare_data validates bin_size is not negative (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = -500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "wrong sign in 'by' argument"
+  )
+})
+
+test_that("prepare_data validates bin_size is not NA (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = NA,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+
+test_that("prepare_data validates bin_size is integer (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500.5,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "' bin_size ' must be a an integer"
+  )
+})
+
+
+test_that("prepare_data validates bin_size is not 0 (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 0,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "invalid"
+  )
+})
+
+
+test_that("prepare_data works with minimum bin_size (1) and MW", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 1,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+  )
+})
+
+
+
+# ---------------------------------------------------------- #
+#                Number of shifts Input Tests                #
+# ---------------------------------------------------------- #
+
+test_that("prepare_data validates number_of_shifts is present (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates number_of_shifts is not Inf (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = Inf,
+      rand = NULL
+    ),
+    "result would be too long a vector"
+  )
+})
+
+
+test_that("prepare_data validates number_of_shifts is not negative (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = -5,
+      rand = NULL
+    ),
+    "invalid 'times' argument"
+  )
+})
+
+test_that("prepare_data validates number_of_shifts is not NA (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = NA,
+      rand = NULL
+    ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+
+test_that("prepare_data validates number_of_shifts is integer (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5.5,
+      rand = NULL
+    ),
+    "' number_of_shifts ' must be a an integer"
+  )
+})
+
+
+test_that("prepare_data works with number_of_shifts = 0 (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 0,
+      rand = NULL
+    ),
+  )
+})
+
+
+# ---------------------------------------------------------- #
+#                 Rand Input Tests                           #
+# ---------------------------------------------------------- #
+
+test_that("prepare_data validates rand parameter when provided", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = "invalid"
+    ),
+    "'rand' must be one of the following: 'NULL', 'numeric'"
+  )
+})
+
+test_that("prepare_data validates rand is integer when numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5.5
+    ),
+    "' rand ' must be a an integer"
+  )
+})
+
+test_that("prepare_data produces N = rand random samples", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_no_error(
+    dat_5 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 5
+      )
+  )
+
+  dat_3 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 3
+    )
+
+  expect_equal(length(dat_3), 3)
+  expect_equal(length(dat_5), 5)
+})
+
+test_that("prepare_data produces _randomized_ samples with every trial", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  dat_5 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5
+    )
+
+  dat_3 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 3
+    )
+  expect_false(identical(dat_3, dat_5[1:3]))
+})
+
+
+test_that("prepare_data samples reproducibly if rand > 1 and seed set manually", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  set.seed(123)
+  res1 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5
+    )
+
+  set.seed(123)
+  res2 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5
+    )
+
+  expect_identical(res1, res2)
+})
+
+test_that("prepare_data samples reproducibly if rand > 1 and no seed set manually", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  res1 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 1
+    )
+
+  res2 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 1
+    )
+
+  expect_identical(res1, res2)
+})
+
+test_that("prepare_data does not change age if no age_uncertainty in data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = NULL,
+      verbose = FALSE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 1,
+      rand = 1
+    )
+
+  expect_identical(
+    res[[1]][[1]]$bins$res_age,
+    example_data$age$age
+  )
+})
+

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -1,6 +1,138 @@
 # ---------------------------------------------------------- #
 #               Data_source_prep Input Tests                 #
+#                            Errors                          #
 # ---------------------------------------------------------- #
+# 1.1 data_source_prep = NULL
+# i) levels
+test_that(
+  "prepare_data, working_units = 'levels' throws error for NULL input for data_source",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = NULL,
+        working_units = "levels",
+        rand = NULL
+      ), "'data_source_prep' must be one of the following: 'list'"
+    )
+  }
+)
+
+# ii) bins
+test_that(
+  "prepare_data, working_units = 'bins' throws error for NULL input for data_source",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = NULL,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      ), "'data_source_prep' must be one of the following: 'list'"
+    )
+  }
+)
+
+# iii) MW
+test_that(
+  "prepare_data, working_units = 'MW' throws error for NULL input for data_source",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = NULL,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ), "'data_source_prep' must be one of the following: 'list'"
+    )
+  }
+)
+
+# --------------------------------------------------- #
+
+# 1.2 data_source_prep = empty list with data = zero
+# (these fail because there is no error programmed into the function yet)
+# i) levels
+test_that(
+  "prepare_data, working_units = 'levels' throws error for data_source_prep = empty named list",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep =
+          list(
+            community = data.frame(
+              0
+            ),
+            age = data.frame(
+              age = 0
+            ),
+            age_un = data.frame(0)
+          ),
+        working_units = "levels",
+        rand = NULL
+      ),
+      # none programmed into the function yet.
+      # e.g., "'data_source_prep' must be non-empty"
+    )
+  }
+)
+
+# ii) bins
+test_that(
+  "prepare_data, working_units = 'bins' throws error for data_source_prep = empty named list",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep =
+          list(
+            community = data.frame(
+              0
+            ),
+            age = data.frame(
+              age = 0
+            ),
+            age_un = data.frame(0)
+          ),
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      ),
+      # none programmed into the function yet.
+      # e.g., "'data_source_prep' must be non-empty"
+    )
+  }
+)
+
+# iii) MW
+test_that(
+  "prepare_data, working_units = 'MW' throws error for data_source_prep = empty named list",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep =
+          list(
+            community = data.frame(
+              0
+            ),
+            age = data.frame(
+              age = 0
+            ),
+            age_un = data.frame(0)
+          ),
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      # none programmed into the function yet.
+      # e.g., "'data_source_prep' must be non-empty"
+    )
+  }
+)
+
+# ----------------------------------------------------------------- #
+# ----------------------------------------------------------------- #
+
 
 test_that(
   "prepare_data rejects NULL data_source",
@@ -34,6 +166,44 @@ test_that(
 )
 
 test_that(
+  "prepare_data throws error with empty data_source_prep list",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = list(),
+        working_units = "levels"
+      ),
+      "argument of length 0"
+    )
+  }
+)
+
+test_that(
+  "prepare_data  throws error with data_source_prep with wrong structure",
+  {
+    wrong_structure <-
+      list(
+        wrong_name = data.frame(
+          x = 1:5
+        ),
+        another_wrong = data.frame(y = 1:5)
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = wrong_structure,
+        working_units = "levels"
+      ),
+      "argument of length 0"
+    )
+  }
+)
+
+# ----------------------------------------------------------------- #
+#                 input data internal structure validation
+# ----------------------------------------------------------------- #
+
+test_that(
   "prepare_data fails if no community in data_source",
   {
     example_data <-
@@ -56,7 +226,6 @@ test_that(
     )
   }
 )
-
 
 test_that(
   "prepare_data fails if no age in data_source",
@@ -82,6 +251,7 @@ test_that(
   }
 )
 
+# no error without age_uncertainty
 test_that(
   "prepare_data works if no age_uncertainty in data_source",
   {
@@ -106,10 +276,63 @@ test_that(
   }
 )
 
-
-
+# ----------------------------------------------------------------- #
+#   More specific tests for 1) community 2) age and 3) age_un       #
+# ----------------------------------------------------------------- #
 
 ## Community data
+test_that(
+  "prepare_data handles single-row community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE],
+        data_age_extract = RRatepol::example_data$sample_age[[1]][1, , drop = FALSE],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]][, 1, drop = FALSE],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      result <-
+        prepare_data(
+          data_source_prep = example_data,
+          working_units = "levels"
+        )
+    )
+
+    expect_equal(nrow(result[[1]][[1]]$bins), 1)
+  }
+)
+
+test_that(
+  "prepare_data handles single-column community data",
+  {
+    community_single <-
+      RRatepol::example_data$pollen_data[[1]][, 1:2] # sample_id + 1 species
+
+    example_data <-
+      extract_data(
+        data_community_extract = community_single,
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      result <-
+        prepare_data(
+          data_source_prep = example_data,
+          working_units = "levels"
+        )
+    )
+
+    expect_equal(
+      ncol(
+        result[[1]][[1]]$data
+      ) - 1, 1
+    ) # -1 for age column
+  }
+)
+
 # Zeros
 test_that(
   "prepare_data with working_units='levels' works if there are 0s in community data",
@@ -158,7 +381,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data with working_units='MW' works if there are 0s in community data",
   {
@@ -184,7 +406,7 @@ test_that(
   }
 )
 
-# NAs in Age
+# NAs in Community
 test_that(
   "prepare_data with working_units='levels' works if there are NAs in community data",
   {
@@ -232,7 +454,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data with working_units='MW' works if there are NAs in community data",
   {
@@ -257,7 +478,6 @@ test_that(
     )
   }
 )
-
 
 ## Age data
 # Zeros
@@ -299,15 +519,15 @@ test_that(
       0
 
     expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "bins",
-        bin_size = 500
-      )
+      res <-
+        prepare_data(
+          example_data,
+          working_units = "bins",
+          bin_size = 500
+        )
     )
   }
 )
-
 
 test_that(
   "prepare_data with working_units='MW' works if there are 0s in age data",
@@ -331,267 +551,6 @@ test_that(
         number_of_shifts = 5
       )
     )
-  }
-)
-
-# NAs in Age
-test_that(
-  "prepare_data with working_units='levels' works if there are NAs in age data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age$age[1:3] <-
-      NA
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "levels"
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='bins' fails if there are NAs in age data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age$age[1:3] <-
-      NA
-
-    expect_error(
-      prepare_data(
-        example_data,
-        working_units = "bins",
-        bin_size = 500
-      ),
-      "'from' must be a finite number"
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data with working_units='MW' fails if there are NAs in age data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age$age[1:3] <-
-      NA
-
-    expect_error(
-      prepare_data(
-        example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      ),
-      "'from' must be a finite number"
-    )
-  }
-)
-
-
-## Age_uncertainty data
-# Zeros
-test_that(
-  "prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age_un[1:3] <-
-      0
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          example_data,
-          working_units = "levels",
-          rand = 1
-        )
-    )
-
-    expect_false(
-      identical(
-        res[[1]][[1]]$data$age,
-        example_data$age$age
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age_un[1:3] <-
-      0
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          example_data,
-          working_units = "bins",
-          bin_size = 500,
-          rand = 1
-        )
-    )
-
-    expect_false(
-      identical(
-        res[[1]][[1]]$data$age,
-        example_data$age$age
-      )
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age_un[1:3] <-
-      0
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          example_data,
-          working_units = "MW",
-          bin_size = 500,
-          number_of_shifts = 5,
-          rand = 1
-        )
-    )
-
-    expect_false(
-      identical(
-        res[[1]][[1]]$data$age,
-        example_data$age$age
-      )
-    )
-  }
-)
-
-
-# NAs in Age_uncertainty
-test_that(
-  "prepare_data with working_units='levels' works if there are NAs in age_un data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age_un[1:3] <-
-      NA
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "levels",
-        rand = 1
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='bins' works if there are NAs in age_un data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age_un[1:3] <-
-      NA
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "bins",
-        bin_size = 500,
-        rand = 1
-      )
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age_un[1:3] <-
-      NA
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          example_data,
-          working_units = "MW",
-          bin_size = 500,
-          number_of_shifts = 5,
-          rand = 1
-        )
-    )
-
-    # returns NA in output$age
-    expect_true(any(is.na(res[[1]][[1]]$data$age)))
   }
 )
 
@@ -671,7 +630,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data validates working_units parameter is not a vector of parameters",
   {
@@ -715,24 +673,446 @@ test_that(
   }
 )
 
+# --------------------------------------------------- #
 
-# test fails because function silently uses the default parameters
+# 1.3 working_units = NULL
+# 1.3.1 m.avg
 test_that(
-  "prepare_data rejects no working_unit as input",
+  "prepare_data, smooth_method = 'm.avg' throws error for working_units = NULL",
   {
-    data_source_bins <-
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_mavg <-
       extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data()
 
     expect_error(
       prepare_data(
-        data_source_bins
-      )
-      # no error programmed into function yet
+        data_source_prep = data_work_mavg,
+        working_units = NULL,
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
+
+# 1.3.2. shep
+test_that(
+  "prepare_data, smooth_method = 'shep' throws error for working_units = NULL",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep"
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = NULL,
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
+
+# 1.3.3. age.w
+test_that(
+  "prepare_data, smooth_method = 'age.w' throws error for working_units = NULL",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data()
+
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = NULL,
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
+
+# 1.3.4. grim
+test_that(
+  "prepare_data, smooth_method = 'grim' throws error for working_units = NULL",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = NULL,
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
+
+# --------------------------------------------------- #
+# 1.4 working_units = invalid character
+# 1.4.1 m.avg
+test_that(
+  "prepare_data, smooth_method = 'm.avg' throws error for working_units = invalid character",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "invalid_unit",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+    )
+  }
+)
+
+# 1.4.2. shep
+test_that(
+  "prepare_data, smooth_method = 'shep' throws error for working_units = invalid character",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep"
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "invalid_unit",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+    )
+  }
+)
+
+# 1.4.3. age.w
+test_that(
+  "prepare_data, smooth_method = 'age.w' throws error for working_units = invalid character",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data()
+
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "invalid_unit",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+    )
+  }
+)
+
+# 1.4.4. grim
+test_that(
+  "prepare_data, smooth_method = 'grim' throws error for working_units = invalid character",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "invalid_unit",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+    )
+  }
+)
+
+# --------------------------------------------------- #
+# 1.5 working_units = multiple
+# 1.5.1 m.avg
+test_that(
+  "prepare_data, smooth_method = 'm.avg' throws error for working_units = multiple values",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = c("levels", "bins"),
+        bin_size = 500,
+        rand = NULL
+      ), "'arg' must be of length 1"
+    )
+  }
+)
+
+# 1.4.2. shep
+test_that(
+  "prepare_data, smooth_method = 'shep' throws error for working_units = multiple values",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep"
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = c("levels", "bins"),
+        bin_size = 500,
+        rand = NULL
+      ), "'arg' must be of length 1"
+    )
+  }
+)
+
+# 1.4.3. age.w
+test_that(
+  "prepare_data, smooth_method = 'age.w' throws error for working_units = multiple values",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data()
+
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = c("levels", "bins"),
+        bin_size = 500,
+        rand = NULL
+      ), "'arg' must be of length 1"
+    )
+  }
+)
+
+# 1.4.4. grim
+test_that(
+  "prepare_data, smooth_method = 'grim' throws error for working_units = multiple values",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data()
+
+    expect_error(
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = c("levels", "bins"),
+        bin_size = 500,
+        rand = NULL
+      ), "'arg' must be of length 1"
     )
   }
 )
@@ -758,7 +1138,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data validates working_units parameter is not NULL",
   {
@@ -780,6 +1159,211 @@ test_that(
   }
 )
 
+# 1.5 no user-defined input for working_units
+## (these tests fail because function will use defaults silently)
+test_that(
+  "prepare_data throws warning if no user-defined input for working_units is supplied",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data() %>%
+      reduce_data()
+
+    expect_warning(
+      res <-
+        prepare_data(
+          data_source_prep = data_work_mavg,
+          rand = NULL
+        ),
+      # none programmed into the function yet.
+      # e.g., "No user-defined input for working_units. Defaulting to 'levels'."
+    )
+  }
+)
+
+# 1.5.1  m.avg
+test_that(
+  "prepare_data, smooth_method = 'm.avg' uses 'levels' if no user-defined input for working_units",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data()
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          data_source_prep = data_work_mavg,
+          rand = NULL
+        )
+    )
+
+    # Control: if nothing is user-supplied, uses working_units = "levels"
+    res_levels <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "levels"
+      )
+
+    expect_identical(res, res_levels)
+  }
+)
+
+# 1.5.2. shep
+test_that(
+  "prepare_data, smooth_method = 'shep' uses 'levels' if no user-defined input for working_units",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep"
+      ) %>%
+      reduce_data()
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          data_source_prep = data_work_shep,
+          rand = NULL
+        )
+    )
+    # Control: if nothing is user-supplied, uses working_units = "levels"
+    res_levels <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "levels"
+      )
+
+    expect_identical(res, res_levels)
+  }
+)
+# 1.5.3. age.w
+test_that(
+  "prepare_data, smooth_method = 'age.w' uses 'levels' if no user-defined input for working_units",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data()
+
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          data_source_prep = data_work_agew,
+          rand = NULL
+        )
+    )
+
+    # Control: if nothing is user-supplied, uses working_units = "levels"
+    res_levels <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "levels"
+      )
+
+    expect_identical(res, res_levels)
+  }
+)
+# 1.5.4. grim
+test_that(
+  "prepare_data, smooth_method = 'grim' uses 'levels' if no user-defined input for working_units",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data()
+
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          data_source_prep = data_work_grim,
+          rand = NULL
+        )
+    )
+
+    # Control: if nothing is user-supplied, uses working_units = "levels"
+    res_levels <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "levels"
+      )
+
+    expect_identical(res, res_levels)
+  }
+)
 
 
 ### Bin Size ###
@@ -789,175 +1373,8 @@ test_that(
 # ---------------------------------------------------------- #
 
 # 1.1 "levels"
-
-test_that(
-  "prepare_data validates bin_size is not NULL with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'bin_size' must be one of the following: 'numeric'"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates bin_size is not Inf with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = Inf,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'to' must be a finite number"
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data validates bin_size is not negative with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = -500,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "wrong sign in 'by' argument"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates bin_size is not NA with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = NA,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'bin_size' must be one of the following: 'numeric'"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates bin_size is integer with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500.5,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "' bin_size ' must be a an integer"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates bin_size is not 0 with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 0,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "invalid"
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data works with minimum bin_size (1) with working_unit='levels'",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_no_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 1,
-        number_of_shifts = NULL,
-        rand = NULL
-      )
-    )
-  }
-)
-
+## skipped because bin_size is not required for 'levels'
 # 1.2 "bins"
-
 test_that(
   "prepare_data validates bin_size is numeric",
   {
@@ -1005,7 +1422,6 @@ test_that(
     )
   }
 )
-
 
 test_that(
   "prepare_data validates bin_size is not negative",
@@ -1101,7 +1517,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data works with minimum bin_size (1)",
   {
@@ -1124,9 +1539,7 @@ test_that(
   }
 )
 
-
 # 1.3 "MW"
-
 test_that(
   "prepare_data validates bin_size is numeric (working_units=WM)",
   {
@@ -1174,7 +1587,6 @@ test_that(
     )
   }
 )
-
 
 test_that(
   "prepare_data validates bin_size is not negative (working_units=WM)",
@@ -1224,7 +1636,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data validates bin_size is integer (working_units=WM)",
   {
@@ -1247,7 +1658,6 @@ test_that(
     )
   }
 )
-
 
 test_that(
   "prepare_data validates bin_size is not 0 (working_units=WM)",
@@ -1272,7 +1682,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data works with minimum bin_size (1) and MW",
   {
@@ -1296,6 +1705,56 @@ test_that(
 )
 
 
+test_that(
+  "prepare_data handles extremely large bin_size",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
+    age_range <-
+      max(example_data$age$age) - min(example_data$age$age)
+    huge_bin_size <-
+      age_range * 10
+
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = huge_bin_size
+      )
+    )
+  }
+)
+
+test_that(
+  "prepare_data handles small bin_size efficiently",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
+    # This will create many bins
+    expect_no_error(
+      result <-
+        prepare_data(
+          data_source_prep = example_data,
+          working_units = "bins",
+          bin_size = 1
+        )
+    )
+
+    # Should still return valid structure
+    expect_type(result, "list")
+    expect_true(length(result) >= 1)
+  }
+)
 
 # ---------------------------------------------------------- #
 #                Number of shifts Input Tests                #
@@ -1348,7 +1807,6 @@ test_that(
     )
   }
 )
-
 
 test_that(
   "prepare_data validates number_of_shifts is not negative (working_units=WM)",
@@ -1422,7 +1880,6 @@ test_that(
   }
 )
 
-
 test_that(
   "prepare_data works with number_of_shifts = 0 (working_units=WM)",
   {
@@ -1445,6 +1902,30 @@ test_that(
   }
 )
 
+test_that(
+  "prepare_data handles very large number_of_shifts",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      result <-
+        prepare_data(
+          data_source_prep = example_data,
+          working_units = "MW",
+          bin_size = 500,
+          number_of_shifts = 100
+        )
+    )
+
+    # Should create 100 different shifts
+    expect_equal(length(result[[1]]), 100)
+  }
+)
 
 # ---------------------------------------------------------- #
 #                 Rand Input Tests                           #
@@ -1535,7 +2016,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data produces _randomized_ samples with every trial",
+  "prepare_data produces randomized samples with every trial",
   {
     example_data <-
       extract_data(
@@ -1566,6 +2047,92 @@ test_that(
   }
 )
 
+test_that(
+  "prepare_data throws error with rand = 0",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        rand = 0
+      ),
+      "subscript out of bounds"
+    )
+  }
+)
+
+
+test_that(
+  "prepare_data throws error with negative rand",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        rand = -5
+      ),
+      "invalid 'size' argument"
+    )
+  }
+)
+
+test_that(
+  "prepare_data handles age_uncertainty with all identical values (returns identical age across randomizations)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    # Make all age uncertainty values identical
+    example_data$age_un[] <-
+      1000
+
+    expect_no_error(
+      result <-
+        prepare_data(
+          data_source_prep = example_data,
+          working_units = "levels",
+          rand = 10
+        )
+    )
+
+    # All randomizations should be identical
+    expect_true(
+      all(
+        sapply(
+          result[-1], function(x) {
+            identical(x[[1]]$data$age, result[[1]][[1]]$data$age)
+          }
+        )
+      )
+    )
+  }
+)
+
+
+# ------------------------------------------ #
+#         Reproducibility tests              #
+# ------------------------------------------ #
 
 test_that(
   "prepare_data samples reproducibly if rand > 1 and seed set manually",
@@ -1604,7 +2171,7 @@ test_that(
 
 # fails currently
 test_that(
-  "prepare_data samples reproducibly if age_un is supplied, rand > 1 and no seed set manually",
+  "prepare_data samples reproducibly if age_un is supplied, rand = 1 and no seed set manually",
   {
     example_data <-
       extract_data(
@@ -1635,7 +2202,6 @@ test_that(
     expect_identical(res1, res2)
   }
 )
-
 
 test_that(
   "prepare_data samples reproducibly if age_un = NULL and rand > 1 and no seed set manually",
@@ -1669,7 +2235,6 @@ test_that(
     expect_identical(res1, res2)
   }
 )
-
 
 test_that(
   "prepare_data does not change age if no age_uncertainty in data",
@@ -1727,295 +2292,128 @@ test_that(
   }
 )
 
-# ---------------------------------------------------------- #
-#                Additional Edge Case Tests                  #
-# ---------------------------------------------------------- #
-
 test_that(
-  "prepare_data  throws error with empty data_source_prep list",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = list(),
-        working_units = "levels"
-      ),
-      "argument of length 0"
-    )
-  }
-)
-
-test_that(
-  "prepare_data  throws error with data_source_prep with wrong structure",
-  {
-    wrong_structure <-
-      list(
-      wrong_name = data.frame(
-    x = 1:5),
-      another_wrong = data.frame(y = 1:5)
-    )
-    
-    expect_error(
-      prepare_data(
-        data_source_prep = wrong_structure,
-        working_units = "levels"
-      ),
-      "argument of length 0"
-    )
-  }
-)
-
-#fails
-test_that(
-  "prepare_data  throws error with mismatched rownames between community and age",
+  "prepare_data changes age if age_uncertainty is in data",
   {
     example_data <-
       extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
-    # Change rownames to create mismatch
-    rownames(example_data$community)[1:5] <-
-      paste0("wrong_", 1:5)
-    
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels"
-      ),
-      # none programmed into the function yet
-    )
-  }
-)
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-test_that(
-  "prepare_data  throws error with age_uncertainty with wrong dimensions",
-  {
-    example_data <-
-      extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
-    # Add age_uncertainty with wrong number of columns
-    example_data$age_un <-
-      matrix(1:100, nrow = 10, ncol = 10)
-    
-    expect_error(
+    res <-
       prepare_data(
         data_source_prep = example_data,
         working_units = "levels",
-        rand = 5
-      ),
-      "`age` must be size 63 or 1, not 10."
+        rand = 1
+      )
+
+    expect_false(
+      identical(
+        res[[1]][[1]]$data$age,
+        example_data$age$age
+      )
     )
   }
 )
 
 test_that(
-  "prepare_data handles extremely large bin_size",
+  "prepare_data changes age if age_uncertainty is in data",
   {
     example_data <-
       extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
-    age_range <-
-      max(example_data$age$age) - min(example_data$age$age)
-    huge_bin_size <-
-      age_range * 10
-    
-    expect_no_error(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    res <-
       prepare_data(
         data_source_prep = example_data,
         working_units = "bins",
-        bin_size = huge_bin_size
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data handles extremely small bin_size efficiently",
-  {
-    example_data <-
-      extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
-    # This will create many bins
-    expect_no_error(
-      result <-
-        prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = 1
-      )
-    )
-    
-    # Should still return valid structure
-    expect_type(result, "list")
-    expect_true(length(result) >= 1)
-  }
-)
-
-test_that(
-  "prepare_data handles very large number_of_shifts",
-  {
-    example_data <-
-      extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
-    expect_no_error(
-      result <-
-        prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
         bin_size = 500,
-        number_of_shifts = 100
+        rand = 1
       )
-    )
-    
-    # Should create 100 different shifts
-    expect_equal(length(result[[1]]), 100)
-  }
-)
 
-test_that(
-  "prepare_data throws error with rand = 0",
-  {
-    example_data <-
-      extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-    
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        rand = 0
-      ),
-      "subscript out of bounds"
-    )
-  }
-)
-
-test_that(
-  "prepare_data throws error with negative rand",
-  {
-    example_data <-
-      extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-    
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        rand = -5
-      ),
-      "invalid 'size' argument"
-    )
-  }
-)
-
-# ---------------------------------------------------------- #
-#                Age Uncertainty Edge Cases                  #
-# ---------------------------------------------------------- #
-
-test_that(
-  "prepare_data handles age_uncertainty with all identical values",
-  {
-    example_data <-
-      extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-    
-    # Make all age uncertainty values identical
-    example_data$age_un[] <-
-      1000
-    
-    expect_no_error(
-      result <-
-        prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        rand = 10
-      )
-    )
-    
-    # All randomizations should be identical
-    expect_true(
-      all(
-        sapply(
-    result[-1], function(
-    x) 
-          identical(x[[1]]$data$age, result[[1]][[1]]$data$age)
-        )
+    expect_false(
+      identical(
+        res[[1]][[1]]$data$age,
+        example_data$age$age
       )
     )
   }
 )
 
 
-
-
-# WIP:
 # ---------------------------------------------------------- #
 #                  Output structure Tests                    #
 # ---------------------------------------------------------- #
 
 # with valid input:
-
 test_that(
   "prepare_data returns consistent structure across different working_units",
   {
     example_data <-
       extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
     result_levels <-
-      prepare_data(example_data, working_units = "levels")
+      prepare_data(
+        example_data,
+        working_units = "levels"
+      )
     result_bins <-
-      prepare_data(example_data, working_units = "bins", bin_size = 500)
+      prepare_data(
+        example_data,
+        working_units = "bins",
+        bin_size = 500
+      )
     result_mw <-
-      prepare_data(example_data, working_units = "MW", bin_size = 500, number_of_shifts = 3)
-    
+      prepare_data(
+        example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 3
+      )
+
     # All should have same top-level structure
-    expect_identical(names(result_levels), names(result_bins))
-    expect_identical(names(result_levels), names(result_mw))
-    
+    expect_identical(
+      names(result_levels),
+      names(result_bins)
+    )
+    expect_identical(
+      names(result_levels),
+      names(result_mw)
+    )
+
     # All should have same internal structure
-    expect_identical(names(result_levels[[1]][[1]]), names(result_bins[[1]][[1]]))
-    expect_identical(names(result_levels[[1]][[1]]), names(result_mw[[1]][[1]]))
-    
+    expect_identical(
+      names(result_levels[[1]][[1]]),
+      names(result_bins[[1]][[1]])
+    )
+    expect_identical(
+      names(result_levels[[1]][[1]]),
+      names(result_mw[[1]][[1]])
+    )
+
     # Bins should have same column structure
-    expect_identical(names(result_levels[[1]][[1]]$bins), names(result_bins[[1]][[1]]$bins))
-    expect_identical(names(result_levels[[1]][[1]]$bins), names(result_mw[[1]][[1]]$bins))
+    expect_identical(
+      names(result_levels[[1]][[1]]$bins),
+      names(result_bins[[1]][[1]]$bins)
+    )
+    expect_identical(
+      names(result_levels[[1]][[1]]$bins), names(result_mw[[1]][[1]]$bins)
+    )
   }
 )
 
+# Fails because assertion for bin_size is in the wrong position in the function
 test_that(
   "prepare_data returns the correct output structure with default parameters (levels)",
   {
@@ -2067,15 +2465,27 @@ test_that(
     )
 
     # $data is not all 0 or empty
-    expect_false(all(res[[1]][[1]]$data == 0))
-    expect_false(length(res[[1]][[1]]$data) == 0)
+    expect_false(
+      all(
+        res[[1]][[1]]$data == 0
+      )
+    )
+    expect_false(
+      length(
+        res[[1]][[1]]$data
+      ) == 0
+    )
     # $bins is not all 0 or empty
-    expect_false(all(res[[1]][[1]]$bins == 0))
-    expect_false(nrow(res[[1]][[1]]$bins) == 0)
+    expect_false(
+      all(
+        res[[1]][[1]]$bins == 0
+      )
+    )
+    expect_false(
+      nrow(res[[1]][[1]]$bins) == 0
+    )
   }
 )
-
-
 
 test_that(
   "prepare_data returns the correct output structure with default parameters (MW)",
@@ -2146,1340 +2556,73 @@ test_that(
   }
 )
 
-
-# ---------------------------------------------------------- #
-#                Data Structure Validation Tests             #
-# ---------------------------------------------------------- #
-
-
 test_that(
-  "prepare_data handles single-row community data",
+  "prepare_data returns the correct output structure with default parameters (bins)",
   {
     example_data <-
       extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE],
-      data_age_extract = RRatepol::example_data$sample_age[[1]][1, , drop = FALSE],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]][,1 , drop = FALSE],
-      verbose = FALSE
-    )
-    
-    expect_no_error(
-      result <-
-        prepare_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    res <-
+      prepare_data(
         data_source_prep = example_data,
-        working_units = "levels"
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # General output structure tests:
+    expect_type(
+      res, "list"
+    )
+
+    # Named list elements
+    expect_identical(
+      names(
+        res[[1]][[1]]
+      ),
+      c("data", "bins")
+    )
+
+    # Named data object
+    expect_identical(
+      names(
+        res[[1]][[1]]$data
+      ),
+      c("age", names(example_data$community))
+    )
+
+    # Named bins object
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(res[[1]][[1]]$bins)
       )
     )
-    
-    expect_equal(nrow(result[[1]][[1]]$bins), 1)
+
+    # Correct types
+    expect_type(res[[1]][[1]]$bins$name, "double")
+    expect_type(res[[1]][[1]]$bins$shift, "double")
+    expect_type(res[[1]][[1]]$bins$age_diff, "double")
+    expect_type(res[[1]][[1]]$bins$start, "double")
+    expect_type(res[[1]][[1]]$bins$end, "double")
+    expect_type(res[[1]][[1]]$bins$res_age, "double")
+    expect_type(res[[1]][[1]]$bins$label, "character")
+
+    # $data is not all 0 or empty
+    expect_false(all(res[[1]][[1]]$data == 0))
+    expect_false(length(res[[1]][[1]]$data) == 0)
+    # $bins is not all 0 or empty
+    expect_false(all(res[[1]][[1]]$bins == 0))
+    expect_false(nrow(res[[1]][[1]]$bins) == 0)
   }
 )
 
-test_that(
-  "prepare_data handles single-column community data",
-  {
-    community_single <-
-      RRatepol::example_data$pollen_data[[1]][, 1:2] # sample_id + 1 species
-    
-    example_data <-
-      extract_data(
-      data_community_extract = community_single,
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
-    expect_no_error(
-      result <-
-        prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels"
-      )
-    )
-    
-    expect_equal(
-    ncol(
-    result[[1]][[1]]$data) - 1, 1) # -1 for age column
-  }
-)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-# WIP
-
-
-
-# --------------------------------------------------------- #
-# Tests for the full functionality within estimate_roc()
-# --------------------------------------------------------- #
-
-# working_units = levels
-
-# # 1. default with correct data
-# test_that(
-#   "prepare_data works correctly within estimate_roc() workflow", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "shep"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   # empty working_units uses 'levels'
-#   data_prepared <-
-#     prepare_data(
-#       data_work
-#     )
-# })
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "m.avg"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "grim"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-
-# NAs in community
-test_that(
-  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  expect_identical(
-    data_prepared[[1]][[1]]$bins$name,
-    rownames(data_work$community)
-  )
-})
-
-# NAs in community
-test_that(
-  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "m.avg"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  expect_identical(
-    data_prepared[[1]][[1]]$bins$name,
-    rownames(data_work$community)
-  )
-})
-
-# NAs in community
-test_that(
-  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "grim"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  expect_identical(
-    data_prepared[[1]][[1]]$bins$name,
-    rownames(data_work$community)
-  )
-})
-
-# NAs in community
-test_that(
-  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-
-  expect_identical(
-    data_prepared[[1]][[1]]$bins$name,
-    rownames(data_work$community)
-  )
-})
-
-
-
-# working_units = bins
-
-# 1. default with correct data
-# test_that(
-#   "prepare_data works correctly within estimate_roc() workflow", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "shep"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "bins"
-#     )
-# })
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "m.avg"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "grim"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "shep"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "bins"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "m.avg"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "bins"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "grim"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "bins"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "age.w"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "bins"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# 
-# 
-# working_units = MW
-
-# 1. default with correct data
-# test_that(
-#   "prepare_data works correctly within estimate_roc() workflow", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "shep"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "MW"
-#     )
-# })
-# 
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "m.avg"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "grim"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-# NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age$age[1:10] <-
-    NA
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-
-  # expect no more NAs in bins
-  expect_false(
-    isTRUE(
-      any(
-        is.na(
-          data_prepared[[1]][[1]]$bins
-        )
-      )
-    )
-  )
-})
-
-
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "shep"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "MW"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "m.avg"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "MW"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "grim"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "MW"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
-# NAs in community
-# test_that(
-#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-#   community <-
-#     RRatepol::example_data$pollen_data[[1]]
-# 
-#   community[1:10, -1] <-
-#     NA
-# 
-#   age <-
-#     RRatepol::example_data$sample_age[[1]]
-# 
-#   age_uncertainty <-
-#     RRatepol::example_data$age_uncertainty[[1]]
-# 
-#   data_extract <-
-#     extract_data(
-#       community,
-#       age,
-#       age_uncertainty
-#     )
-# 
-#   data_smoothed <-
-#     smooth_community_data(
-#       data_extract,
-#       smooth_method = "age.w"
-#     )
-# 
-#   data_work <-
-#     reduce_data(
-#       data_smoothed
-#     )
-# 
-#   data_prepared <-
-#     prepare_data(
-#       data_work,
-#       working_units = "MW"
-#     )
-# 
-#   # expect_identical(
-#   #   data_prepared[[1]][[1]]$bins$name,
-#   #   rownames(data_work$community)
-#   # )
-# })
-# 
 # ---------------------------------------------------------- #
 #                Integration with make_bins Tests            #
 # ---------------------------------------------------------- #
@@ -3489,11 +2632,11 @@ test_that(
   {
     example_data <-
       extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
-    )
-    
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        verbose = FALSE
+      )
+
     # Test that bins are created correctly for each type
     result_levels <-
       prepare_data(example_data, working_units = "levels")
@@ -3501,14 +2644,14 @@ test_that(
       prepare_data(example_data, working_units = "bins", bin_size = 500)
     result_mw <-
       prepare_data(example_data, working_units = "MW", bin_size = 500, number_of_shifts = 5)
-    
+
     # Levels should have one bin per sample
     expect_equal(nrow(result_levels[[1]][[1]]$bins), nrow(example_data$community))
-    
+
     # MW should have multiple shifts
     expect_true(max(result_mw[[1]][[1]]$bins$shift) <= 5)
     expect_true(length(result_mw[[1]]) == 5)
-    
+
     # Bins should have consistent bin_size
     bins_result <-
       result_bins[[1]][[1]]$bins
@@ -3518,405 +2661,326 @@ test_that(
 
 
 
-# tests for specific parameter combinations:
+
+
+
+
+# ------------------------------------------------- #
+# Tests using internal estimate_roc workflow:       #
+#                   Errors                          #
+# ------------------------------------------------- #
 
 # Invalid parameter combinations:
+test_that(
+  "prepare_data throws message if invalid combinations of parameters are silently overridden",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    expect_message(
+      data_prepared <-
+        prepare_data(
+          data_work,
+          working_units = "levels",
+          number_of_shifts = 5,
+          rand = 1
+        ),
+      # not programmed into the function yet.
+      # e.g.,
+      # "Invalid parameter 'number_of_shifts = 5' to working_units != 'MW'. number_of_shifts is automatically set to = 1"
+    )
+  }
+)
 
 test_that(
-  "prepare_data throws message if invalid combinations of parameters are silently overridden", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
+  "prepare_data sets number_of_shifts =1 with user-supplied: 'MW' and number_of_shifts = 0",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
 
-  age <-
-    RRatepol::example_data$sample_age[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
 
-  data_extract <-
-    extract_data(
-      community,
-      age,
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 0
+      )
+
+    expect_true(
+      unique(
+        data_prepared[[1]][[1]]$bins$shift
+      ) == 1
     )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-expect_message(
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "levels",
-      number_of_shifts = 5,
-      rand = 1
-    ),
-    # not programmed into the function yet.
-    # e.g., 
-    # "Invalid parameter 'number_of_shifts = 5' to working_units = 'levels'. number_of_shifts is automatically set to = 1"
-    )
-})
-
-
-test_that(
-  "prepare_data sets number_of_shifts =1 with user-supplied: 'MW' and number_of_shifts = 0", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 0
-    )
-
-  expect_true(
-    unique(
-      data_prepared[[1]][[1]]$bins$shift
-    ) == 1
-  )
-})
+  }
+)
 
 # Test combinations of rand and age_un.
 # Q: is it the same whether if the user sets rand = 1 or if the function does it if rand = NULL?
 # expect identical results for rand = 1 and rand = NULL.
-
 test_that(
-  "Prepare data returns identical results for rand=NULL and rand=1", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
+  "Prepare data returns identical results for rand=NULL and rand=1",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
 
-  age <-
-    RRatepol::example_data$sample_age[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
 
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
 
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared_rand_1 <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 2,
+        rand = 1
+      )
+
+    data_prepared_rand_null <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 2,
+        rand = NULL
+      )
+
+    expect_identical(
+      data_prepared_rand_1,
+      data_prepared_rand_null
     )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared_rand_1 <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 2,
-      rand = 1
-    )
-
-  data_prepared_rand_null <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 2,
-      rand = NULL
-    )
-
-  expect_identical(
-    data_prepared_rand_1,
-    data_prepared_rand_null
-  )
-})
-
-
-test_that(
-  "Prepare data returns identical results for rand=NULL and rand=1 (without age_un)", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared_rand_1 <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 2,
-      rand = 1
-    )
-
-  data_prepared_rand_null <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 2,
-      rand = NULL
-    )
-
-  expect_identical(
-    data_prepared_rand_1,
-    data_prepared_rand_null
-  )
-})
-
-
-# Is rand ignored if no age_un?
-test_that(
-  "prepare_data ignores rand parameter if no age_un is supplied", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared_rand_1 <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 1,
-      rand = 1
-    )
-
-  data_prepared_rand_100 <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 1,
-      rand = 100
-    )
-
-# Expect that rand is ignored if no age_un is supplied:
-expect_true(
-  length(data_prepared_rand_100) == length(data_prepared_rand_1)
+  }
 )
 
-  # # both results are identical
-  # expect_identical(
-  #   data_prepared_rand_1[[1]][[1]]$bins,
-  #   data_prepared_rand_100[[2]][[1]]$bins
-  # )
+test_that(
+  "Prepare data returns identical results for rand=NULL and rand=1 (without age_un)",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
 
-  # # all "randomized" samples are identical inside the same result
-  # expect_identical(
-  #   data_prepared_rand_100[[1]][[1]]$bins,
-  #   data_prepared_rand_100[[2]][[1]]$bins
-  # )
+    age <-
+      RRatepol::example_data$sample_age[[1]]
 
-  # expect_identical(
-  #   data_prepared_rand_100[[1]][[1]]$bins,
-  #   data_prepared_rand_100[[100]][[1]]$bins
-  # )
-})
+    data_extract <-
+      extract_data(
+        community,
+        age,
+      )
 
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared_rand_1 <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 2,
+        rand = 1
+      )
+
+    data_prepared_rand_null <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 2,
+        rand = NULL
+      )
+
+    expect_identical(
+      data_prepared_rand_1,
+      data_prepared_rand_null
+    )
+  }
+)
+
+# Is rand ignored if no age_un? - no. but results are identical.
+test_that(
+  "prepare_data ignores rand parameter if no age_un is supplied",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared_rand_1 <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 1
+      )
+
+    data_prepared_rand_100 <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
+
+    # Expect that rand is ignored if no age_un is supplied:
+    expect_true(
+      length(data_prepared_rand_100) == length(data_prepared_rand_1)
+    )
+
+    # # both results are identical
+    # expect_identical(
+    #   data_prepared_rand_1[[1]][[1]]$bins,
+    #   data_prepared_rand_100[[2]][[1]]$bins
+    # )
+
+    # # all "randomized" samples are identical inside the same result
+    # expect_identical(
+    #   data_prepared_rand_100[[1]][[1]]$bins,
+    #   data_prepared_rand_100[[2]][[1]]$bins
+    # )
+
+    # expect_identical(
+    #   data_prepared_rand_100[[1]][[1]]$bins,
+    #   data_prepared_rand_100[[100]][[1]]$bins
+    # )
+  }
+)
 
 test_that(
-  "prepare_data returns identical results across randomizations if age_un is not supplied but rand is", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
+  "prepare_data returns identical results across randomizations if age_un is not supplied but rand is",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
 
-  age <-
-    RRatepol::example_data$sample_age[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
 
-  data_extract <-
-    extract_data(
-      community,
-      age
-    )
+    data_extract <-
+      extract_data(
+        community,
+        age
+      )
 
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
 
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
 
-  data_prepared_rand_100 <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 1,
-      rand = 100
-    )
+    data_prepared_rand_100 <-
+      prepare_data(
+        data_work,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
 
     # Test if all elements in data_prepared_rand_100 are identical
     expect_true(
       all(
-      vapply(
-        data_prepared_rand_100[-1],
-        function(
-    x) identical(
-    x, data_prepared_rand_100[[1]]),
-        logical(1)
+        vapply(
+          data_prepared_rand_100[-1],
+          function(
+              x) {
+            identical(
+              x, data_prepared_rand_100[[1]]
+            )
+          },
+          logical(1)
+        )
       )
-      )
     )
-})
+  }
+)
 
-
-# Q: What happens if age_un has only 1 row but rand = 100?
-
-test_that(
-  "prepare_data returns randomized results if age_un has only 2 rows but rand = 100", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_un <-
-    RRatepol::example_data$age_uncertainty[[1]][1:2, 1:63]
-
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_un
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared_rand_100_2rows <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 1,
-      rand = 100
-    )
-
-  expect_false(
-    identical(
-      data_prepared_rand_100_2rows[[100]][[1]]$bins,
-      data_prepared_rand_100_2rows[[7]][[1]]$bins
-    )
-  )
-
-
-  # Control:
-  age_un <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_un
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared_rand_100_full <-
-    prepare_data(
-      data_work,
-      working_units = "MW",
-      number_of_shifts = 1,
-      rand = 100
-    )
-  
-
-  expect_identical(
-    data_prepared_rand_100_full[[1]],
-    data_prepared_rand_100_2rows[[1]]
-  )
-
-})
-
-
-
-
-
-
-
-### WIP:
 test_that(
   "prepare_data handles only 1 age_uncertainty row with high rand values - expect identical results across randomizations",
   {
@@ -3958,7 +3022,8 @@ test_that(
     # With only 1 row, ALL samples should be identical (sampling with replacement from 1 value)
     expect_equal(
       length(
-    data_prepared_1row),
+        data_prepared_1row
+      ),
       100
     )
 
@@ -3967,8 +3032,11 @@ test_that(
         vapply(
           data_prepared_1row[-1],
           function(
-    x) identical(
-    x[[1]]$data$age, data_prepared_1row[[1]][[1]]$data$age),
+              x) {
+            identical(
+              x[[1]]$data$age, data_prepared_1row[[1]][[1]]$data$age
+            )
+          },
           logical(1)
         )
       )
@@ -4011,24 +3079,18 @@ test_that(
     expect_false(
       all(
         vapply(
-          data_prepared_2rows[-1],
-          function(
-    x) identical(
-    x[[1]]$data$age, data_prepared_2rows[[1]][[1]]$data$age),
+          data_prepared_2rows[-1], # compare all to the first
+          function(x) {
+            identical(
+              x[[1]]$data$age, data_prepared_2rows[[1]][[1]]$data$age
+            )
+          },
           logical(1)
         )
       )
     )
 
-    # Test 3: Compare specific samples to ensure they can differ
-    expect_false(
-      identical(
-        data_prepared_2rows[[100]][[1]]$data$age,
-        data_prepared_2rows[[7]][[1]]$data$age
-      )
-    )
-
-    # Test 4: Verify sampling distribution with 2 rows
+    # Test 3: Verify sampling distribution with 2 rows
     # Extract all age vectors and count unique patterns
     age_vectors <-
       lapply(data_prepared_2rows, function(x) x[[1]]$data$age)
@@ -4077,33 +3139,54 @@ test_that(
     unique_age_patterns <-
       length(unique(age_vectors))
 
-      # Test 5: Control - compare against full uncertainty data
-  age_un_full <-
-    RRatepol::example_data$age_uncertainty[[1]]
-  
-  data_extract_full <-
-    extract_data(community, age, age_un_full)
-  data_smoothed_full <-
-    smooth_community_data(data_extract_full, smooth_method = "age.w")
-  data_work_full <-
-    reduce_data(data_smoothed_full)
-  
-  data_prepared_full <-
-    prepare_data(
-    data_work_full,
-    working_units = "MW",
-    number_of_shifts = 1,
-    rand = 100
-  )
-  
-  # Full uncertainty should have more variation than limited rows
-  age_vectors_full <-
-    lapply(data_prepared_full, function(x) x[[1]]$data$age)
-  unique_patterns_full <-
-    length(unique(age_vectors_full))
-  
-  expect_true(unique_patterns_full > unique_age_patterns)
+    # Test 4: Control - compare against full uncertainty data
+    age_un_full <-
+      RRatepol::example_data$age_uncertainty[[1]]
 
+    data_extract_full <-
+      extract_data(
+        community,
+        age,
+        age_un_full
+      )
+    data_smoothed_full <-
+      smooth_community_data(
+        data_extract_full,
+        smooth_method = "age.w"
+      )
+
+    data_work_full <-
+      reduce_data(
+        data_smoothed_full
+      )
+
+    data_prepared_full <-
+      prepare_data(
+        data_work_full,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
+
+    # Full uncertainty should have more variation than limited rows
+    age_vectors_full <-
+      lapply(
+        data_prepared_full,
+        function(
+            x) {
+          x[[1]]$data$age
+        }
+      )
+    unique_patterns_full <-
+      length(
+        unique(
+          age_vectors_full
+        )
+      )
+
+    expect_true(
+      unique_patterns_full > unique_age_patterns
+    )
   }
 )
 
@@ -4114,27 +3197,44 @@ test_that(
       RRatepol::example_data$pollen_data[[1]]
     age <-
       RRatepol::example_data$sample_age[[1]]
-    
+
     # Control - compare against full uncertainty data
     age_un_full <-
       RRatepol::example_data$age_uncertainty[[1]]
 
     data_extract_full <-
-      extract_data(community, age, age_un_full)
+      extract_data(
+        community,
+        age,
+        age_un_full
+      )
     data_smoothed_full <-
-      smooth_community_data(data_extract_full, smooth_method = "age.w")
+      smooth_community_data(
+        data_extract_full,
+        smooth_method = "age.w"
+      )
     data_work_full <-
-      reduce_data(data_smoothed_full)
-
-
-    # Test 6: Verify first sample is identical regardless of uncertainty data size
+      reduce_data(
+        data_smoothed_full
+      )
+    # Test 5: Verify first sample is identical regardless of uncertainty data size
     # (when using same random seed, first sample should use same row)
     set.seed(123)
     data_prep_full_seeded1 <-
-      prepare_data(data_work_full, working_units = "MW", number_of_shifts = 1, rand = 1)
+      prepare_data(
+        data_work_full,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
     set.seed(123)
     data_prep_full_seeded2 <-
-      prepare_data(data_work_full, working_units = "MW", number_of_shifts = 1, rand = 1)
+      prepare_data(
+        data_work_full,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
 
     # First random sample should be from same row index
     expect_identical(
@@ -4144,7 +3244,3009 @@ test_that(
   }
 )
 
+# -------------------------------------------------------------------- #
+# 2. Test edge-cases with zeros and NAs in the raw data
+# full estimate_roc() workflow:
+# -------------------------------------------------------------------- #
+# 2.1 With 0 or NA in samples
+## 2.1.1a) one row in community 0
+# ---- levels ---- #
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'age.w' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'grim' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+# --- bins --- #
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+# --- MW --- #
+test_that(
+  "prepare_data, working_units = 'MW', smooth_method = 'm.avg' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW', smooth_method = 'shep' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW', smooth_method = 'age.w' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW', smooth_method = 'grim' works with one row 0 in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      0
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+## 2.1.1b) one row in community NA
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
 
 
-# Q: What if age_un is empty or has NAs?
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
 
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data and working_units = 'levels' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data and working_units = 'levels' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$bins has only valid samples
+    expect_identical(
+      res[[1]][[1]]$bins$name,
+      valid_samples
+    )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+# --- bins --- #
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+# --- MW --- #
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in community",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    community[1, -1] <-
+      NA
+    valid_samples <-
+      community[-1, 1]$sample_id
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+## 2.1.2a) one row in age 0
+# -> no effect or reaction from function. Is just ignored.
+
+### ------ Review required ------- ###
+
+## Below are some tests where I manually fix some bugs
+## from upstream functions within each unit test and compare the
+## results to the expected results after fixing the bug.
+
+# To Do: Double-check below (NAs in age.)
+
+## 2.1.2b) one row in age NA
+# ---- levels ---- #
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # Control for when NA row is exculded from all data sources:
+    age_dropped <-
+      age %>%
+      na.omit()
+
+    community_dropped <-
+      community[-1, ]
+
+    age_un_dropped <-
+      age_uncertainty[, -1]
+
+    data_dropped <-
+      extract_data(
+        data_community_extract = community_dropped,
+        data_age_extract = age_dropped,
+        age_uncertainty = age_un_dropped
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res_dropped <-
+      prepare_data(
+        data_source_prep = data_dropped,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    expect_identical(
+      res,
+      res_dropped
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # Control for when NA row is exculded from all data sources:
+    age_dropped <-
+      age %>%
+      na.omit()
+    community_dropped <-
+      community[-1, ]
+    age_un_dropped <-
+      age_uncertainty[, -1]
+
+    data_dropped <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res_dropped <-
+      prepare_data(
+        data_source_prep = data_dropped,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    expect_identical(
+      res,
+      res_dropped
+    )
+  }
+)
+
+test_that(
+  "prepare_data and working_units = 'levels' works with one row NA in age (correct results)",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # Control for when NA row is exculded from all data sources:
+    age_dropped <-
+      age %>%
+      na.omit()
+    community_dropped <-
+      community[-1, ]
+    age_un_dropped <-
+      age_uncertainty[, -1]
+
+    data_dropped <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    res_dropped <-
+      prepare_data(
+        data_source_prep = data_dropped,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    expect_identical(
+      res,
+      res_dropped
+    )
+  }
+)
+
+# fails because smooth_community_data cannot handle NA
+test_that(
+  "prepare_data and working_units = 'levels' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_grim$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_grim$age <-
+      data_work_grim$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_grim$community <-
+      data_work_grim$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_grim$age_un <-
+      data_work_grim$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "levels",
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+
+    # expect no more NAs in age
+    expect_false(
+      any(
+        is.na(
+          res[[1]][[1]]$data$age
+        )
+      )
+    )
+
+    # expect no NAs in age-derivates
+    expect_false(
+      any(
+        is.na(
+          res[[1]][[1]]$bin$age_diff
+        )
+      )
+    )
+
+    # expect no NAs in age-derivates
+    expect_false(
+      any(
+        is.na(
+          res[[1]][[1]]$bin$res_age
+        )
+      )
+    )
+  }
+)
+
+
+# --- bins --- #
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_mavg$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_mavg$age <-
+      data_work_mavg$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_mavg$community <-
+      data_work_mavg$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_mavg$age_un <-
+      data_work_mavg$age_un %>%
+      select(valid_samples)
+
+    # use modified result for prepare_data()
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_shep$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_shep$age <-
+      data_work_shep$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_shep$community <-
+      data_work_shep$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_shep$age_un <-
+      data_work_shep$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_agew$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_agew$age <-
+      data_work_agew$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_agew$community <-
+      data_work_agew$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_agew$age_un <-
+      data_work_agew$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_grim$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_grim$age <-
+      data_work_grim$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_grim$community <-
+      data_work_grim$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_grim$age_un <-
+      data_work_grim$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "bins",
+        bin_size = 500,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+# --- MW --- #
+
+test_that(
+  "prepare_data and working_units = 'MW' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+    valid_samples <-
+      age %>%
+      na.omit() %>%
+      pull(sample_id)
+
+    data_work_mavg <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "m.avg",
+        smooth_n_points = 5
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_mavg$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_mavg$age <-
+      data_work_mavg$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_mavg$community <-
+      data_work_mavg$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_mavg$age_un <-
+      data_work_mavg$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_mavg,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_shep <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "shep",
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_shep$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_shep$age <-
+      data_work_shep$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_shep$community <-
+      data_work_shep$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_shep$age_un <-
+      data_work_shep$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_shep,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+    valid_samples <-
+      age %>%
+      na.omit() %>%
+      pull(sample_id)
+
+    data_work_agew <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "age.w",
+        smooth_n_points = 5,
+        smooth_age_range = 500
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_agew$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_agew$age <-
+      data_work_agew$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_agew$community <-
+      data_work_agew$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_agew$age_un <-
+      data_work_agew$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_agew,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+test_that(
+  "prepare_data, working_units = 'MW' works with one row NA in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    age$age[1] <-
+      NA
+
+    data_work_grim <-
+      extract_data(
+        data_community_extract = community,
+        data_age_extract = age,
+        age_uncertainty = age_uncertainty
+      ) %>%
+      smooth_community_data(
+        .,
+        smooth_method = "grim",
+        smooth_n_points = 5,
+        smooth_age_range = 500,
+        smooth_n_max = 9
+      ) %>%
+      reduce_data(
+        check_taxa = TRUE,
+        check_levels = TRUE
+      )
+
+    valid_samples <-
+      data_work_grim$age %>%
+      na.omit() %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      pull(sample_id)
+
+    # Simulating to fix the bugs in extract_data() and reduce_data():
+    # drop NAs from age manually
+    data_work_grim$age <-
+      data_work_grim$age %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    # perform two-way matching with community and age_un manually
+    data_work_grim$community <-
+      data_work_grim$community %>%
+      tibble::rownames_to_column(var = "sample_id") %>%
+      filter(sample_id %in% valid_samples) %>%
+      select(-sample_id)
+
+    data_work_grim$age_un <-
+      data_work_grim$age_un %>%
+      select(valid_samples)
+
+    res <-
+      prepare_data(
+        data_source_prep = data_work_grim,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # test if result$data has only valid samples
+    expect_identical(
+      rownames(
+        res[[1]][[1]]$data
+      ),
+      valid_samples
+    )
+  }
+)
+
+# ---------------- Check for NAs in output ------------------ #
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "shep"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    # empty working_units uses 'levels'
+    data_prepared <-
+      prepare_data(
+        data_work
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "m.avg"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    # empty working_units uses 'levels'
+    data_prepared <-
+      prepare_data(
+        data_work
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "grim"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    # empty working_units uses 'levels'
+    data_prepared <-
+      prepare_data(
+        data_work
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    # empty working_units uses 'levels'
+    data_prepared <-
+      prepare_data(
+        data_work
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "shep"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "bins"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "m.avg"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "bins"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "grim"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "bins"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "bins"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "shep"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "MW"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "m.avg"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "MW"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "grim"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "MW"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+# NAs in age (known issue)
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    age$age[1:10] <-
+      NA
+    age_uncertainty <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract <-
+      extract_data(
+        community,
+        age,
+        age_uncertainty
+      )
+
+    data_smoothed <-
+      smooth_community_data(
+        data_extract,
+        smooth_method = "age.w"
+      )
+
+    data_work <-
+      reduce_data(
+        data_smoothed
+      )
+
+    data_prepared <-
+      prepare_data(
+        data_work,
+        working_units = "MW"
+      )
+
+    # expect no more NAs in bins
+    expect_false(
+      isTRUE(
+        any(
+          is.na(
+            data_prepared[[1]][[1]]$bins
+          )
+        )
+      )
+    )
+  }
+)
+
+#####################
+## To Dos:
+# - Double check if the expectation shouldn't be the reverse below for age_un
+#####################
+
+## 2.1.3a) one column in age_un 0
+# ## Age_uncertainty data
+# # Zeros
+# test_that(
+#   "prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty",
+#   {
+#     example_data <-
+#       extract_data(
+#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#         data_age_extract = RRatepol::example_data$sample_age[[1]],
+#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#         verbose = FALSE
+#       )
+
+#     example_data$age_un[1:3] <-
+#       0
+
+#     expect_no_error(
+#       res <-
+#         prepare_data(
+#           example_data,
+#           working_units = "levels",
+#           rand = 1
+#         )
+#     )
+
+#     expect_false(
+#       identical(
+#         res[[1]][[1]]$data$age,
+#         example_data$age$age
+#       )
+#     )
+#   }
+# )
+
+# test_that(
+#   "prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty",
+#   {
+#     example_data <-
+#       extract_data(
+#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#         data_age_extract = RRatepol::example_data$sample_age[[1]],
+#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#         verbose = FALSE
+#       )
+
+#     example_data$age_un[1:3] <-
+#       0
+
+#     expect_no_error(
+#       res <-
+#         prepare_data(
+#           example_data,
+#           working_units = "bins",
+#           bin_size = 500,
+#           rand = 1
+#         )
+#     )
+
+#     expect_false(
+#       identical(
+#         res[[1]][[1]]$data$age,
+#         example_data$age$age
+#       )
+#     )
+#   }
+# )
+
+
+# test_that(
+#   "prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty",
+#   {
+#     example_data <-
+#       extract_data(
+#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#         data_age_extract = RRatepol::example_data$sample_age[[1]],
+#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#         verbose = FALSE
+#       )
+
+#     example_data$age_un[1:3] <-
+#       0
+
+#     expect_no_error(
+#       res <-
+#         prepare_data(
+#           example_data,
+#           working_units = "MW",
+#           bin_size = 500,
+#           number_of_shifts = 5,
+#           rand = 1
+#         )
+#     )
+
+#     expect_false(
+#       identical(
+#         res[[1]][[1]]$data$age,
+#         example_data$age$age
+#       )
+#     )
+
+#     expect_identical(
+#       res[[1]][[1]]$data$age[1:3],
+#       c(0, 0, 0)
+#     )
+#   }
+# )
+
+
+## 2.1.3b) one column in age_un NA
+# # NAs in Age_uncertainty
+# test_that(
+#   "prepare_data with working_units='levels' works if there are NAs in age_un data",
+#   {
+#     example_data <-
+#       extract_data(
+#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#         data_age_extract = RRatepol::example_data$sample_age[[1]],
+#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#         verbose = FALSE
+#       )
+
+#     example_data$age_un[1:3] <-
+#       NA
+
+#     expect_no_error(
+#       res <-
+#         prepare_data(
+#           example_data,
+#           working_units = "levels",
+#           rand = 1
+#         )
+#     )
+
+#     expect_identical(
+#       res[[1]][[1]]$data$age[1:3],
+#       as.numeric(c(NA, NA, NA))
+#     )
+#   }
+# )
+
+# test_that(
+#   "prepare_data with working_units='bins' works if there are NAs in age_un data",
+#   {
+#     example_data <-
+#       extract_data(
+#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#         data_age_extract = RRatepol::example_data$sample_age[[1]],
+#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#         verbose = FALSE
+#       )
+
+#     example_data$age_un[1:3] <-
+#       NA
+
+#     expect_no_error(
+#       prepare_data(
+#         example_data,
+#         working_units = "bins",
+#         bin_size = 500,
+#         rand = 1
+#       )
+#     )
+#   }
+# )
+
+# test_that(
+#   "prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty",
+#   {
+#     example_data <-
+#       extract_data(
+#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
+#         data_age_extract = RRatepol::example_data$sample_age[[1]],
+#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+#         verbose = FALSE
+#       )
+
+#     example_data$age_un[1:3] <-
+#       NA
+
+#     expect_no_error(
+#       res <-
+#         prepare_data(
+#           example_data,
+#           working_units = "MW",
+#           bin_size = 500,
+#           number_of_shifts = 5,
+#           rand = 1
+#         )
+#     )
+
+#     # returns NA in output$age
+#     expect_true(any(is.na(res[[1]][[1]]$data$age)))
+#   }
+# )

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -2789,7 +2789,8 @@ test_that(
       reduce_data(
         data_smoothed
       )
-
+    
+    set.seed(123)
     data_prepared_rand_1 <-
       prepare_data(
         data_work,
@@ -2798,6 +2799,7 @@ test_that(
         rand = 1
       )
 
+    set.seed(123)
     data_prepared_rand_null <-
       prepare_data(
         data_work,
@@ -6054,114 +6056,6 @@ test_that(
 ## To Dos:
 # - Double check if the expectation shouldn't be the reverse below for age_un
 #####################
-
-## 2.1.3a) one column in age_un 0
-# ## Age_uncertainty data
-# # Zeros
-# test_that(
-#   "prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty",
-#   {
-#     example_data <-
-#       extract_data(
-#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
-#         data_age_extract = RRatepol::example_data$sample_age[[1]],
-#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#         verbose = FALSE
-#       )
-
-#     example_data$age_un[1:3] <-
-#       0
-
-#     expect_no_error(
-#       res <-
-#         prepare_data(
-#           example_data,
-#           working_units = "levels",
-#           rand = 1
-#         )
-#     )
-
-#     expect_false(
-#       identical(
-#         res[[1]][[1]]$data$age,
-#         example_data$age$age
-#       )
-#     )
-#   }
-# )
-
-# test_that(
-#   "prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty",
-#   {
-#     example_data <-
-#       extract_data(
-#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
-#         data_age_extract = RRatepol::example_data$sample_age[[1]],
-#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#         verbose = FALSE
-#       )
-
-#     example_data$age_un[1:3] <-
-#       0
-
-#     expect_no_error(
-#       res <-
-#         prepare_data(
-#           example_data,
-#           working_units = "bins",
-#           bin_size = 500,
-#           rand = 1
-#         )
-#     )
-
-#     expect_false(
-#       identical(
-#         res[[1]][[1]]$data$age,
-#         example_data$age$age
-#       )
-#     )
-#   }
-# )
-
-
-# test_that(
-#   "prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty",
-#   {
-#     example_data <-
-#       extract_data(
-#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
-#         data_age_extract = RRatepol::example_data$sample_age[[1]],
-#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#         verbose = FALSE
-#       )
-
-#     example_data$age_un[1:3] <-
-#       0
-
-#     expect_no_error(
-#       res <-
-#         prepare_data(
-#           example_data,
-#           working_units = "MW",
-#           bin_size = 500,
-#           number_of_shifts = 5,
-#           rand = 1
-#         )
-#     )
-
-#     expect_false(
-#       identical(
-#         res[[1]][[1]]$data$age,
-#         example_data$age$age
-#       )
-#     )
-
-#     expect_identical(
-#       res[[1]][[1]]$data$age[1:3],
-#       c(0, 0, 0)
-#     )
-#   }
-# )
 
 
 ## 2.1.3b) one column in age_un NA

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -18,7 +18,8 @@ test_that(
 )
 
 test_that(
-  "prepare_data rejects incomplete list(data.frame) in data_source",
+  "prepare_data rejects incomplete list(
+    data.frame) in data_source",
   {
     expect_error(
       prepare_data(
@@ -1603,7 +1604,7 @@ test_that(
 
 # fails currently
 test_that(
-  "prepare_data samples reproducibly if rand > 1 and no seed set manually",
+  "prepare_data samples reproducibly if age_un is supplied, rand > 1 and no seed set manually",
   {
     example_data <-
       extract_data(
@@ -1635,7 +1636,41 @@ test_that(
   }
 )
 
-# fails currentöy
+
+test_that(
+  "prepare_data samples reproducibly if age_un = NULL and rand > 1 and no seed set manually",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = NULL,
+        verbose = FALSE
+      )
+
+    res1 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 1
+      )
+
+    res2 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 1
+      )
+
+    expect_identical(res1, res2)
+  }
+)
+
+
 test_that(
   "prepare_data does not change age if no age_uncertainty in data",
   {
@@ -1657,11 +1692,289 @@ test_that(
       )
 
     expect_identical(
-      res[[1]][[1]]$bins$res_age,
+      res[[1]][[1]]$data$age,
       example_data$age$age
     )
   }
 )
+
+test_that(
+  "prepare_data changes age if age_uncertainty is in data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 1,
+        rand = 1
+      )
+
+    expect_false(
+      identical(
+        res[[1]][[1]]$data$age,
+        example_data$age$age
+      )
+    )
+  }
+)
+
+# ---------------------------------------------------------- #
+#                Additional Edge Case Tests                  #
+# ---------------------------------------------------------- #
+
+test_that(
+  "prepare_data  throws error with empty data_source_prep list",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = list(),
+        working_units = "levels"
+      ),
+      "argument of length 0"
+    )
+  }
+)
+
+test_that(
+  "prepare_data  throws error with data_source_prep with wrong structure",
+  {
+    wrong_structure <-
+      list(
+      wrong_name = data.frame(
+    x = 1:5),
+      another_wrong = data.frame(y = 1:5)
+    )
+    
+    expect_error(
+      prepare_data(
+        data_source_prep = wrong_structure,
+        working_units = "levels"
+      ),
+      "argument of length 0"
+    )
+  }
+)
+
+#fails
+test_that(
+  "prepare_data  throws error with mismatched rownames between community and age",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    # Change rownames to create mismatch
+    rownames(example_data$community)[1:5] <-
+      paste0("wrong_", 1:5)
+    
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels"
+      ),
+      # none programmed into the function yet
+    )
+  }
+)
+
+test_that(
+  "prepare_data  throws error with age_uncertainty with wrong dimensions",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    # Add age_uncertainty with wrong number of columns
+    example_data$age_un <-
+      matrix(1:100, nrow = 10, ncol = 10)
+    
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        rand = 5
+      ),
+      "`age` must be size 63 or 1, not 10."
+    )
+  }
+)
+
+test_that(
+  "prepare_data handles extremely large bin_size",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    age_range <-
+      max(example_data$age$age) - min(example_data$age$age)
+    huge_bin_size <-
+      age_range * 10
+    
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = huge_bin_size
+      )
+    )
+  }
+)
+
+test_that(
+  "prepare_data handles extremely small bin_size efficiently",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    # This will create many bins
+    expect_no_error(
+      result <-
+        prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = 1
+      )
+    )
+    
+    # Should still return valid structure
+    expect_type(result, "list")
+    expect_true(length(result) >= 1)
+  }
+)
+
+test_that(
+  "prepare_data handles very large number_of_shifts",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    expect_no_error(
+      result <-
+        prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 100
+      )
+    )
+    
+    # Should create 100 different shifts
+    expect_equal(length(result[[1]]), 100)
+  }
+)
+
+test_that(
+  "prepare_data throws error with rand = 0",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+    
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        rand = 0
+      ),
+      "subscript out of bounds"
+    )
+  }
+)
+
+test_that(
+  "prepare_data throws error with negative rand",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+    
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        rand = -5
+      ),
+      "invalid 'size' argument"
+    )
+  }
+)
+
+# ---------------------------------------------------------- #
+#                Age Uncertainty Edge Cases                  #
+# ---------------------------------------------------------- #
+
+test_that(
+  "prepare_data handles age_uncertainty with all identical values",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+    
+    # Make all age uncertainty values identical
+    example_data$age_un[] <-
+      1000
+    
+    expect_no_error(
+      result <-
+        prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        rand = 10
+      )
+    )
+    
+    # All randomizations should be identical
+    expect_true(
+      all(
+        sapply(
+    result[-1], function(
+    x) 
+          identical(x[[1]]$data$age, result[[1]][[1]]$data$age)
+        )
+      )
+    )
+  }
+)
+
 
 
 
@@ -1671,6 +1984,38 @@ test_that(
 # ---------------------------------------------------------- #
 
 # with valid input:
+
+test_that(
+  "prepare_data returns consistent structure across different working_units",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    result_levels <-
+      prepare_data(example_data, working_units = "levels")
+    result_bins <-
+      prepare_data(example_data, working_units = "bins", bin_size = 500)
+    result_mw <-
+      prepare_data(example_data, working_units = "MW", bin_size = 500, number_of_shifts = 3)
+    
+    # All should have same top-level structure
+    expect_identical(names(result_levels), names(result_bins))
+    expect_identical(names(result_levels), names(result_mw))
+    
+    # All should have same internal structure
+    expect_identical(names(result_levels[[1]][[1]]), names(result_bins[[1]][[1]]))
+    expect_identical(names(result_levels[[1]][[1]]), names(result_mw[[1]][[1]]))
+    
+    # Bins should have same column structure
+    expect_identical(names(result_levels[[1]][[1]]$bins), names(result_bins[[1]][[1]]$bins))
+    expect_identical(names(result_levels[[1]][[1]]$bins), names(result_mw[[1]][[1]]$bins))
+  }
+)
+
 test_that(
   "prepare_data returns the correct output structure with default parameters (levels)",
   {
@@ -1782,6 +2127,16 @@ test_that(
       )
     )
 
+    # Correct types
+    expect_type(res[[1]][[1]]$bins$name, "double")
+    expect_type(res[[1]][[1]]$bins$shift, "integer")
+    expect_type(res[[1]][[1]]$bins$age_diff, "double")
+    expect_type(res[[1]][[1]]$bins$start, "double")
+    expect_type(res[[1]][[1]]$bins$end, "double")
+    expect_type(res[[1]][[1]]$bins$res_age, "double")
+    expect_type(res[[1]][[1]]$bins$label, "character")
+
+
     # $data is not all 0 or empty
     expect_false(all(res[[1]][[1]]$data == 0))
     expect_false(length(res[[1]][[1]]$data) == 0)
@@ -1792,8 +2147,60 @@ test_that(
 )
 
 
+# ---------------------------------------------------------- #
+#                Data Structure Validation Tests             #
+# ---------------------------------------------------------- #
 
 
+test_that(
+  "prepare_data handles single-row community data",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE],
+      data_age_extract = RRatepol::example_data$sample_age[[1]][1, , drop = FALSE],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]][,1 , drop = FALSE],
+      verbose = FALSE
+    )
+    
+    expect_no_error(
+      result <-
+        prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels"
+      )
+    )
+    
+    expect_equal(nrow(result[[1]][[1]]$bins), 1)
+  }
+)
+
+test_that(
+  "prepare_data handles single-column community data",
+  {
+    community_single <-
+      RRatepol::example_data$pollen_data[[1]][, 1:2] # sample_id + 1 species
+    
+    example_data <-
+      extract_data(
+      data_community_extract = community_single,
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    expect_no_error(
+      result <-
+        prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels"
+      )
+    )
+    
+    expect_equal(
+    ncol(
+    result[[1]][[1]]$data) - 1, 1) # -1 for age column
+  }
+)
 
 
 
@@ -1826,42 +2233,44 @@ test_that(
 
 # working_units = levels
 
-# 1. default with correct data
-test_that("prepare_data works correctly within estimate_roc() workflow", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  # empty working_units uses 'levels'
-  data_prepared <-
-    prepare_data(
-      data_work
-    )
-})
+# # 1. default with correct data
+# test_that(
+#   "prepare_data works correctly within estimate_roc() workflow", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "shep"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   # empty working_units uses 'levels'
+#   data_prepared <-
+#     prepare_data(
+#       data_work
+#     )
+# })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -1909,7 +2318,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -1958,7 +2368,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2006,7 +2417,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2055,7 +2467,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 
 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+test_that(
+  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
 
@@ -2099,7 +2512,8 @@ test_that("prepare_data works correctly within the workflow of estimate_roc() wi
 })
 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+test_that(
+  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
 
@@ -2143,7 +2557,8 @@ test_that("prepare_data works correctly within the workflow of estimate_roc() wi
 })
 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+test_that(
+  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
 
@@ -2187,7 +2602,8 @@ test_that("prepare_data works correctly within the workflow of estimate_roc() wi
 })
 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+test_that(
+  "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
 
@@ -2235,41 +2651,43 @@ test_that("prepare_data works correctly within the workflow of estimate_roc() wi
 # working_units = bins
 
 # 1. default with correct data
-test_that("prepare_data works correctly within estimate_roc() workflow", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-})
+# test_that(
+#   "prepare_data works correctly within estimate_roc() workflow", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "shep"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "bins"
+#     )
+# })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2317,7 +2735,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2366,7 +2785,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2414,7 +2834,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2463,221 +2884,227 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 
 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
-})
-
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "shep"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "bins"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "m.avg"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
-})
-
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "m.avg"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "bins"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "grim"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
-})
-
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "grim"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "bins"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "age.w"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "bins"
-    )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
-})
-
-
-
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "age.w"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "bins"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
+# 
+# 
 # working_units = MW
 
 # 1. default with correct data
-test_that("prepare_data works correctly within estimate_roc() workflow", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "shep"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-})
-
+# test_that(
+#   "prepare_data works correctly within estimate_roc() workflow", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "shep"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "MW"
+#     )
+# })
+# 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2725,7 +3152,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2774,7 +3202,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2822,7 +3251,8 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 })
 
 # NAs in age (known issue)
-test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+test_that(
+  "prepare_data works correctly within estimate_roc() workflow with NAs in age", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
   age <-
@@ -2871,30 +3301,245 @@ test_that("prepare_data works correctly within estimate_roc() workflow with NAs 
 
 
 # NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "shep"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "MW"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
+# NAs in community
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "m.avg"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "MW"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
+# NAs in community
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "grim"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "MW"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
+# NAs in community
+# test_that(
+#   "prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+#   community <-
+#     RRatepol::example_data$pollen_data[[1]]
+# 
+#   community[1:10, -1] <-
+#     NA
+# 
+#   age <-
+#     RRatepol::example_data$sample_age[[1]]
+# 
+#   age_uncertainty <-
+#     RRatepol::example_data$age_uncertainty[[1]]
+# 
+#   data_extract <-
+#     extract_data(
+#       community,
+#       age,
+#       age_uncertainty
+#     )
+# 
+#   data_smoothed <-
+#     smooth_community_data(
+#       data_extract,
+#       smooth_method = "age.w"
+#     )
+# 
+#   data_work <-
+#     reduce_data(
+#       data_smoothed
+#     )
+# 
+#   data_prepared <-
+#     prepare_data(
+#       data_work,
+#       working_units = "MW"
+#     )
+# 
+#   # expect_identical(
+#   #   data_prepared[[1]][[1]]$bins$name,
+#   #   rownames(data_work$community)
+#   # )
+# })
+# 
+# ---------------------------------------------------------- #
+#                Integration with make_bins Tests            #
+# ---------------------------------------------------------- #
+
+test_that(
+  "prepare_data correctly calls make_bins for each working_units type",
+  {
+    example_data <-
+      extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      verbose = FALSE
+    )
+    
+    # Test that bins are created correctly for each type
+    result_levels <-
+      prepare_data(example_data, working_units = "levels")
+    result_bins <-
+      prepare_data(example_data, working_units = "bins", bin_size = 500)
+    result_mw <-
+      prepare_data(example_data, working_units = "MW", bin_size = 500, number_of_shifts = 5)
+    
+    # Levels should have one bin per sample
+    expect_equal(nrow(result_levels[[1]][[1]]$bins), nrow(example_data$community))
+    
+    # MW should have multiple shifts
+    expect_true(max(result_mw[[1]][[1]]$bins$shift) <= 5)
+    expect_true(length(result_mw[[1]]) == 5)
+    
+    # Bins should have consistent bin_size
+    bins_result <-
+      result_bins[[1]][[1]]$bins
+    expect_true(all(bins_result$age_diff == 500))
+  }
+)
+
+
+
+# tests for specific parameter combinations:
+
+# Invalid parameter combinations:
+
+test_that(
+  "prepare_data throws message if invalid combinations of parameters are silently overridden", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
 
-  community[1:10, -1] <-
-    NA
-
   age <-
     RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
 
   data_extract <-
     extract_data(
       community,
       age,
-      age_uncertainty
     )
 
   data_smoothed <-
     smooth_community_data(
       data_extract,
-      smooth_method = "shep"
+      smooth_method = "age.w"
     )
 
   data_work <-
@@ -2902,113 +3547,25 @@ test_that("prepare_data works correctly within the workflow of estimate_roc() wi
       data_smoothed
     )
 
+expect_message(
   data_prepared <-
     prepare_data(
       data_work,
-      working_units = "MW"
+      working_units = "levels",
+      number_of_shifts = 5,
+      rand = 1
+    ),
+    # not programmed into the function yet.
+    # e.g., 
+    # "Invalid parameter 'number_of_shifts = 5' to working_units = 'levels'. number_of_shifts is automatically set to = 1"
     )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
 })
 
-# NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+
+test_that(
+  "prepare_data sets number_of_shifts =1 with user-supplied: 'MW' and number_of_shifts = 0", {
   community <-
     RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "m.avg"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
-})
-
-# NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
-
-  age <-
-    RRatepol::example_data$sample_age[[1]]
-
-  age_uncertainty <-
-    RRatepol::example_data$age_uncertainty[[1]]
-
-  data_extract <-
-    extract_data(
-      community,
-      age,
-      age_uncertainty
-    )
-
-  data_smoothed <-
-    smooth_community_data(
-      data_extract,
-      smooth_method = "grim"
-    )
-
-  data_work <-
-    reduce_data(
-      data_smoothed
-    )
-
-  data_prepared <-
-    prepare_data(
-      data_work,
-      working_units = "MW"
-    )
-
-  # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
-  # )
-})
-
-# NAs in community
-test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
-  community <-
-    RRatepol::example_data$pollen_data[[1]]
-
-  community[1:10, -1] <-
-    NA
 
   age <-
     RRatepol::example_data$sample_age[[1]]
@@ -3037,11 +3594,557 @@ test_that("prepare_data works correctly within the workflow of estimate_roc() wi
   data_prepared <-
     prepare_data(
       data_work,
-      working_units = "MW"
+      working_units = "MW",
+      number_of_shifts = 0
     )
 
+  expect_true(
+    unique(
+      data_prepared[[1]][[1]]$bins$shift
+    ) == 1
+  )
+})
+
+# Test combinations of rand and age_un.
+# Q: is it the same whether if the user sets rand = 1 or if the function does it if rand = NULL?
+# expect identical results for rand = 1 and rand = NULL.
+
+test_that(
+  "Prepare data returns identical results for rand=NULL and rand=1", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_1 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = 1
+    )
+
+  data_prepared_rand_null <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = NULL
+    )
+
+  expect_identical(
+    data_prepared_rand_1,
+    data_prepared_rand_null
+  )
+})
+
+
+test_that(
+  "Prepare data returns identical results for rand=NULL and rand=1 (without age_un)", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_1 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = 1
+    )
+
+  data_prepared_rand_null <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = NULL
+    )
+
+  expect_identical(
+    data_prepared_rand_1,
+    data_prepared_rand_null
+  )
+})
+
+
+# Is rand ignored if no age_un?
+test_that(
+  "prepare_data ignores rand parameter if no age_un is supplied", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_1 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 1
+    )
+
+  data_prepared_rand_100 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 100
+    )
+
+# Expect that rand is ignored if no age_un is supplied:
+expect_true(
+  length(data_prepared_rand_100) == length(data_prepared_rand_1)
+)
+
+  # # both results are identical
   # expect_identical(
-  #   data_prepared[[1]][[1]]$bins$name,
-  #   rownames(data_work$community)
+  #   data_prepared_rand_1[[1]][[1]]$bins,
+  #   data_prepared_rand_100[[2]][[1]]$bins
+  # )
+
+  # # all "randomized" samples are identical inside the same result
+  # expect_identical(
+  #   data_prepared_rand_100[[1]][[1]]$bins,
+  #   data_prepared_rand_100[[2]][[1]]$bins
+  # )
+
+  # expect_identical(
+  #   data_prepared_rand_100[[1]][[1]]$bins,
+  #   data_prepared_rand_100[[100]][[1]]$bins
   # )
 })
+
+
+test_that(
+  "prepare_data returns identical results across randomizations if age_un is not supplied but rand is", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_100 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 100
+    )
+
+    # Test if all elements in data_prepared_rand_100 are identical
+    expect_true(
+      all(
+      vapply(
+        data_prepared_rand_100[-1],
+        function(
+    x) identical(
+    x, data_prepared_rand_100[[1]]),
+        logical(1)
+      )
+      )
+    )
+})
+
+
+# Q: What happens if age_un has only 1 row but rand = 100?
+
+test_that(
+  "prepare_data returns randomized results if age_un has only 2 rows but rand = 100", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_un <-
+    RRatepol::example_data$age_uncertainty[[1]][1:2, 1:63]
+
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_un
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_100_2rows <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 100
+    )
+
+  expect_false(
+    identical(
+      data_prepared_rand_100_2rows[[100]][[1]]$bins,
+      data_prepared_rand_100_2rows[[7]][[1]]$bins
+    )
+  )
+
+
+  # Control:
+  age_un <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_un
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_100_full <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 100
+    )
+  
+
+  expect_identical(
+    data_prepared_rand_100_full[[1]],
+    data_prepared_rand_100_2rows[[1]]
+  )
+
+})
+
+
+
+
+
+
+
+### WIP:
+test_that(
+  "prepare_data handles only 1 age_uncertainty row with high rand values - expect identical results across randomizations",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+
+    # Test 1: What happens with only 1 row of age_un but rand = 100?
+    age_un_1row <-
+      RRatepol::example_data$age_uncertainty[[1]][1, 1:63, drop = FALSE]
+
+    data_extract_1row <-
+      extract_data(
+        community,
+        age,
+        age_un_1row
+      )
+
+    data_smoothed_1row <-
+      smooth_community_data(
+        data_extract_1row,
+        smooth_method = "age.w"
+      )
+
+    data_work_1row <-
+      reduce_data(
+        data_smoothed_1row
+      )
+
+    data_prepared_1row <-
+      prepare_data(
+        data_work_1row,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
+
+    # With only 1 row, ALL samples should be identical (sampling with replacement from 1 value)
+    expect_equal(
+      length(
+    data_prepared_1row),
+      100
+    )
+
+    expect_true(
+      all(
+        vapply(
+          data_prepared_1row[-1],
+          function(
+    x) identical(
+    x[[1]]$data$age, data_prepared_1row[[1]][[1]]$data$age),
+          logical(1)
+        )
+      )
+    )
+  }
+)
+
+test_that(
+  "prepare_data handles only 2 age_uncertainty rows with high rand values",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    # Test 2: What happens with 2 rows of age_un but rand = 100?
+    age_un_2rows <-
+      RRatepol::example_data$age_uncertainty[[1]][1:2, 1:63]
+
+    data_extract_2rows <-
+      extract_data(
+        community,
+        age,
+        age_un_2rows
+      )
+    data_smoothed_2rows <-
+      smooth_community_data(data_extract_2rows, smooth_method = "age.w")
+    data_work_2rows <-
+      reduce_data(data_smoothed_2rows)
+
+    data_prepared_2rows <-
+      prepare_data(
+        data_work_2rows,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
+
+    # With 2 rows, we should see some variation (not all identical)
+    expect_equal(length(data_prepared_2rows), 100)
+    expect_false(
+      all(
+        vapply(
+          data_prepared_2rows[-1],
+          function(
+    x) identical(
+    x[[1]]$data$age, data_prepared_2rows[[1]][[1]]$data$age),
+          logical(1)
+        )
+      )
+    )
+
+    # Test 3: Compare specific samples to ensure they can differ
+    expect_false(
+      identical(
+        data_prepared_2rows[[100]][[1]]$data$age,
+        data_prepared_2rows[[7]][[1]]$data$age
+      )
+    )
+
+    # Test 4: Verify sampling distribution with 2 rows
+    # Extract all age vectors and count unique patterns
+    age_vectors <-
+      lapply(data_prepared_2rows, function(x) x[[1]]$data$age)
+    unique_age_patterns <-
+      length(unique(age_vectors))
+
+    # Should have at most 2 unique patterns (since only 2 rows available)
+    expect_true(unique_age_patterns <= 2)
+    expect_true(unique_age_patterns >= 1)
+  }
+)
+
+test_that(
+  "prepare_data: with only 2 age_uncertainty rows and high rand, produces at most 2 unique randomizations, and full uncertainty produces more unique samples",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    # Test 2: What happens with 2 rows of age_un but rand = 100?
+    age_un_2rows <-
+      RRatepol::example_data$age_uncertainty[[1]][1:2, 1:63]
+
+    data_extract_2rows <-
+      extract_data(
+        community,
+        age,
+        age_un_2rows
+      )
+    data_smoothed_2rows <-
+      smooth_community_data(data_extract_2rows, smooth_method = "age.w")
+    data_work_2rows <-
+      reduce_data(data_smoothed_2rows)
+
+    data_prepared_2rows <-
+      prepare_data(
+        data_work_2rows,
+        working_units = "MW",
+        number_of_shifts = 1,
+        rand = 100
+      )
+
+    # Extract all age vectors and count unique patterns
+    age_vectors <-
+      lapply(data_prepared_2rows, function(x) x[[1]]$data$age)
+    unique_age_patterns <-
+      length(unique(age_vectors))
+
+      # Test 5: Control - compare against full uncertainty data
+  age_un_full <-
+    RRatepol::example_data$age_uncertainty[[1]]
+  
+  data_extract_full <-
+    extract_data(community, age, age_un_full)
+  data_smoothed_full <-
+    smooth_community_data(data_extract_full, smooth_method = "age.w")
+  data_work_full <-
+    reduce_data(data_smoothed_full)
+  
+  data_prepared_full <-
+    prepare_data(
+    data_work_full,
+    working_units = "MW",
+    number_of_shifts = 1,
+    rand = 100
+  )
+  
+  # Full uncertainty should have more variation than limited rows
+  age_vectors_full <-
+    lapply(data_prepared_full, function(x) x[[1]]$data$age)
+  unique_patterns_full <-
+    length(unique(age_vectors_full))
+  
+  expect_true(unique_patterns_full > unique_age_patterns)
+
+  }
+)
+
+test_that(
+  "prepare_data with seed produces reproducible results with rand = 100",
+  {
+    community <-
+      RRatepol::example_data$pollen_data[[1]]
+    age <-
+      RRatepol::example_data$sample_age[[1]]
+    
+    # Control - compare against full uncertainty data
+    age_un_full <-
+      RRatepol::example_data$age_uncertainty[[1]]
+
+    data_extract_full <-
+      extract_data(community, age, age_un_full)
+    data_smoothed_full <-
+      smooth_community_data(data_extract_full, smooth_method = "age.w")
+    data_work_full <-
+      reduce_data(data_smoothed_full)
+
+
+    # Test 6: Verify first sample is identical regardless of uncertainty data size
+    # (when using same random seed, first sample should use same row)
+    set.seed(123)
+    data_prep_full_seeded1 <-
+      prepare_data(data_work_full, working_units = "MW", number_of_shifts = 1, rand = 1)
+    set.seed(123)
+    data_prep_full_seeded2 <-
+      prepare_data(data_work_full, working_units = "MW", number_of_shifts = 1, rand = 1)
+
+    # First random sample should be from same row index
+    expect_identical(
+      data_prep_full_seeded1[[1]][[1]]$data$age,
+      data_prep_full_seeded2[[1]][[1]]$data$age
+    )
+  }
+)
+
+
+
+# Q: What if age_un is empty or has NAs?
+

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -2,7 +2,8 @@
 #               Data_source_prep Input Tests                 #
 # ---------------------------------------------------------- #
 
-test_that("prepare_data rejects NULL data_source", {
+test_that(
+  "prepare_data rejects NULL data_source", {
   expect_error(
     prepare_data(
       data_source_prep = NULL,
@@ -14,7 +15,8 @@ test_that("prepare_data rejects NULL data_source", {
   )
 })
 
-test_that("prepare_data rejects incomplete list(data.frame) in data_source", {
+test_that(
+  "prepare_data rejects incomplete list(data.frame) in data_source", {
   expect_error(
     prepare_data(
       data_source_prep = RRatepol::example_data$pollen_data[[1]],
@@ -26,7 +28,8 @@ test_that("prepare_data rejects incomplete list(data.frame) in data_source", {
   )
 })
 
-test_that("prepare_data fails if no community in data_source", {
+test_that(
+  "prepare_data fails if no community in data_source", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -34,7 +37,8 @@ test_that("prepare_data fails if no community in data_source", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  example_data$community <- NULL
+  example_data$community <-
+    NULL
   expect_error(
     prepare_data(
       data_source_prep = example_data,
@@ -47,7 +51,8 @@ test_that("prepare_data fails if no community in data_source", {
 })
 
 
-test_that("prepare_data fails if no age in data_source", {
+test_that(
+  "prepare_data fails if no age in data_source", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -55,7 +60,8 @@ test_that("prepare_data fails if no age in data_source", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  example_data$age <- NULL
+  example_data$age <-
+    NULL
   expect_error(
     prepare_data(
       data_source_prep = example_data,
@@ -67,7 +73,8 @@ test_that("prepare_data fails if no age in data_source", {
   )
 })
 
-test_that("prepare_data works if no age_uncertainty in data_source", {
+test_that(
+  "prepare_data works if no age_uncertainty in data_source", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -75,7 +82,8 @@ test_that("prepare_data works if no age_uncertainty in data_source", {
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
       verbose = FALSE
     )
-  example_data$age_un <- NULL
+  example_data$age_un <-
+    NULL
   expect_no_error(
     prepare_data(
       data_source_prep = example_data,
@@ -92,7 +100,8 @@ test_that("prepare_data works if no age_uncertainty in data_source", {
 
 ## Community data
 # Zeros
-test_that("prepare_data with working_units='levels' works if there are 0s in community data", {
+test_that(
+  "prepare_data with working_units='levels' works if there are 0s in community data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -101,7 +110,8 @@ test_that("prepare_data with working_units='levels' works if there are 0s in com
       verbose = FALSE
     )
 
-  example_data$community[1:3] <- 0
+  example_data$community[1:3] <-
+    0
 
   expect_no_error(
     prepare_data(
@@ -111,7 +121,8 @@ test_that("prepare_data with working_units='levels' works if there are 0s in com
   )
 })
 
-test_that("prepare_data with working_units='bins' works if there are 0s in community data", {
+test_that(
+  "prepare_data with working_units='bins' works if there are 0s in community data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -120,7 +131,8 @@ test_that("prepare_data with working_units='bins' works if there are 0s in commu
       verbose = FALSE
     )
 
-  example_data$community[1:3] <- 0
+  example_data$community[1:3] <-
+    0
 
   expect_no_error(
     prepare_data(
@@ -132,7 +144,8 @@ test_that("prepare_data with working_units='bins' works if there are 0s in commu
 })
 
 
-test_that("prepare_data with working_units='MW' works if there are 0s in community data", {
+test_that(
+  "prepare_data with working_units='MW' works if there are 0s in community data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -141,7 +154,8 @@ test_that("prepare_data with working_units='MW' works if there are 0s in communi
       verbose = FALSE
     )
 
-  example_data$community[1:3] <- 0
+  example_data$community[1:3] <-
+    0
 
   expect_no_error(
     prepare_data(
@@ -154,7 +168,8 @@ test_that("prepare_data with working_units='MW' works if there are 0s in communi
 })
 
 # NAs in Age
-test_that("prepare_data with working_units='levels' works if there are NAs in community data", {
+test_that(
+  "prepare_data with working_units='levels' works if there are NAs in community data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -163,7 +178,8 @@ test_that("prepare_data with working_units='levels' works if there are NAs in co
       verbose = FALSE
     )
 
-  example_data$community[1:3] <- NA
+  example_data$community[1:3] <-
+    NA
 
   expect_no_error(
     prepare_data(
@@ -173,7 +189,8 @@ test_that("prepare_data with working_units='levels' works if there are NAs in co
   )
 })
 
-test_that("prepare_data with working_units='bins' works if there are NAs in community data", {
+test_that(
+  "prepare_data with working_units='bins' works if there are NAs in community data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -182,7 +199,8 @@ test_that("prepare_data with working_units='bins' works if there are NAs in comm
       verbose = FALSE
     )
 
-  example_data$community[1:3] <- NA
+  example_data$community[1:3] <-
+    NA
 
   expect_no_error(
     prepare_data(
@@ -194,7 +212,8 @@ test_that("prepare_data with working_units='bins' works if there are NAs in comm
 })
 
 
-test_that("prepare_data with working_units='MW' works if there are NAs in community data", {
+test_that(
+  "prepare_data with working_units='MW' works if there are NAs in community data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -203,7 +222,8 @@ test_that("prepare_data with working_units='MW' works if there are NAs in commun
       verbose = FALSE
     )
 
-  example_data$community[1:3] <- NA
+  example_data$community[1:3] <-
+    NA
 
   expect_no_error(
     prepare_data(
@@ -218,7 +238,8 @@ test_that("prepare_data with working_units='MW' works if there are NAs in commun
 
 ## Age data
 # Zeros
-test_that("prepare_data with working_units='levels' works if there are 0s in age data", {
+test_that(
+  "prepare_data with working_units='levels' works if there are 0s in age data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -227,7 +248,8 @@ test_that("prepare_data with working_units='levels' works if there are 0s in age
       verbose = FALSE
     )
 
-  example_data$age$age[1:3] <- 0
+  example_data$age$age[1:3] <-
+    0
 
   expect_no_error(
     prepare_data(
@@ -237,7 +259,8 @@ test_that("prepare_data with working_units='levels' works if there are 0s in age
   )
 })
 
-test_that("prepare_data with working_units='bins' works if there are 0s in age data", {
+test_that(
+  "prepare_data with working_units='bins' works if there are 0s in age data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -246,7 +269,8 @@ test_that("prepare_data with working_units='bins' works if there are 0s in age d
       verbose = FALSE
     )
 
-  example_data$age$age[1:3] <- 0
+  example_data$age$age[1:3] <-
+    0
 
   expect_no_error(
     prepare_data(
@@ -258,7 +282,8 @@ test_that("prepare_data with working_units='bins' works if there are 0s in age d
 })
 
 
-test_that("prepare_data with working_units='MW' works if there are 0s in age data", {
+test_that(
+  "prepare_data with working_units='MW' works if there are 0s in age data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -267,7 +292,8 @@ test_that("prepare_data with working_units='MW' works if there are 0s in age dat
       verbose = FALSE
     )
 
-  example_data$age$age[1:3] <- 0
+  example_data$age$age[1:3] <-
+    0
 
   expect_no_error(
     prepare_data(
@@ -280,7 +306,8 @@ test_that("prepare_data with working_units='MW' works if there are 0s in age dat
 })
 
 # NAs in Age
-test_that("prepare_data with working_units='levels' works if there are NAs in age data", {
+test_that(
+  "prepare_data with working_units='levels' works if there are NAs in age data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -289,7 +316,8 @@ test_that("prepare_data with working_units='levels' works if there are NAs in ag
       verbose = FALSE
     )
 
-  example_data$age$age[1:3] <- NA
+  example_data$age$age[1:3] <-
+    NA
 
   expect_no_error(
     prepare_data(
@@ -299,7 +327,8 @@ test_that("prepare_data with working_units='levels' works if there are NAs in ag
   )
 })
 
-test_that("prepare_data with working_units='bins' fails if there are NAs in age data", {
+test_that(
+  "prepare_data with working_units='bins' fails if there are NAs in age data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -308,7 +337,8 @@ test_that("prepare_data with working_units='bins' fails if there are NAs in age 
       verbose = FALSE
     )
 
-  example_data$age$age[1:3] <- NA
+  example_data$age$age[1:3] <-
+    NA
 
   expect_error(
     prepare_data(
@@ -321,7 +351,8 @@ test_that("prepare_data with working_units='bins' fails if there are NAs in age 
 })
 
 
-test_that("prepare_data with working_units='MW' fails if there are NAs in age data", {
+test_that(
+  "prepare_data with working_units='MW' fails if there are NAs in age data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -330,7 +361,8 @@ test_that("prepare_data with working_units='MW' fails if there are NAs in age da
       verbose = FALSE
     )
 
-  example_data$age$age[1:3] <- NA
+  example_data$age$age[1:3] <-
+    NA
 
   expect_error(
     prepare_data(
@@ -346,7 +378,8 @@ test_that("prepare_data with working_units='MW' fails if there are NAs in age da
 
 ## Age_uncertainty data
 # Zeros
-test_that("prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty", {
+test_that(
+  "prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -355,10 +388,12 @@ test_that("prepare_data with working_units='levels' and rand=1 works if there ar
       verbose = FALSE
     )
 
-  example_data$age_un[1:3] <- 0
+  example_data$age_un[1:3] <-
+    0
 
   expect_no_error(
-    res <- prepare_data(
+    res <-
+      prepare_data(
       example_data,
       working_units = "levels",
       rand = 1
@@ -373,7 +408,8 @@ test_that("prepare_data with working_units='levels' and rand=1 works if there ar
   )
 })
 
-test_that("prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty", {
+test_that(
+  "prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -382,10 +418,12 @@ test_that("prepare_data with working_units='bins' and rand=1 works if there are 
       verbose = FALSE
     )
 
-  example_data$age_un[1:3] <- 0
+  example_data$age_un[1:3] <-
+    0
 
   expect_no_error(
-    res <- prepare_data(
+    res <-
+      prepare_data(
       example_data,
       working_units = "bins",
       bin_size = 500,
@@ -402,7 +440,8 @@ test_that("prepare_data with working_units='bins' and rand=1 works if there are 
 })
 
 
-test_that("prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty", {
+test_that(
+  "prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -411,10 +450,12 @@ test_that("prepare_data with working_units='MW' and rand=1 works if there are 0s
       verbose = FALSE
     )
 
-  example_data$age_un[1:3] <- 0
+  example_data$age_un[1:3] <-
+    0
 
   expect_no_error(
-    res <- prepare_data(
+    res <-
+      prepare_data(
       example_data,
       working_units = "MW",
       bin_size = 500,
@@ -433,7 +474,8 @@ test_that("prepare_data with working_units='MW' and rand=1 works if there are 0s
 
 
 # NAs in Age_uncertainty
-test_that("prepare_data with working_units='levels' works if there are NAs in age_un data", {
+test_that(
+  "prepare_data with working_units='levels' works if there are NAs in age_un data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -442,7 +484,8 @@ test_that("prepare_data with working_units='levels' works if there are NAs in ag
       verbose = FALSE
     )
 
-  example_data$age_un[1:3] <- NA
+  example_data$age_un[1:3] <-
+    NA
 
   expect_no_error(
     prepare_data(
@@ -453,7 +496,8 @@ test_that("prepare_data with working_units='levels' works if there are NAs in ag
   )
 })
 
-test_that("prepare_data with working_units='bins' works if there are NAs in age_un data", {
+test_that(
+  "prepare_data with working_units='bins' works if there are NAs in age_un data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -462,7 +506,8 @@ test_that("prepare_data with working_units='bins' works if there are NAs in age_
       verbose = FALSE
     )
 
-  example_data$age_un[1:3] <- NA
+  example_data$age_un[1:3] <-
+    NA
 
   expect_no_error(
     prepare_data(
@@ -475,7 +520,8 @@ test_that("prepare_data with working_units='bins' works if there are NAs in age_
 })
 
 
-test_that("prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty", {
+test_that(
+  "prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -484,7 +530,8 @@ test_that("prepare_data with working_units='MW' returns NA in data if there is N
       verbose = FALSE
     )
 
-  example_data$age_un[1:3] <- NA
+  example_data$age_un[1:3] <-
+    NA
 
   expect_no_error(
     res <-
@@ -505,7 +552,8 @@ test_that("prepare_data with working_units='MW' returns NA in data if there is N
 #                  Working Units Input Tests                 #
 # ---------------------------------------------------------- #
 
-test_that("prepare_data validates working_units is one of the three valid options", {
+test_that(
+  "prepare_data validates working_units is one of the three valid options", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -526,7 +574,8 @@ test_that("prepare_data validates working_units is one of the three valid option
   )
 })
 
-test_that("prepare_data validates working_units parameter is not numeric", {
+test_that(
+  "prepare_data validates working_units parameter is not numeric", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -547,7 +596,8 @@ test_that("prepare_data validates working_units parameter is not numeric", {
   )
 })
 
-test_that("prepare_data validates working_units parameter is not numeric", {
+test_that(
+  "prepare_data validates working_units parameter is not numeric", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -569,7 +619,8 @@ test_that("prepare_data validates working_units parameter is not numeric", {
 })
 
 
-test_that("prepare_data validates working_units parameter is not a vector of parameters", {
+test_that(
+  "prepare_data validates working_units parameter is not a vector of parameters", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -588,7 +639,8 @@ test_that("prepare_data validates working_units parameter is not a vector of par
   )
 })
 
-test_that("prepare_data validates working_units parameter is not a vector of parameters", {
+test_that(
+  "prepare_data validates working_units parameter is not a vector of parameters", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -608,7 +660,8 @@ test_that("prepare_data validates working_units parameter is not a vector of par
 
 
 # test fails because function silently uses the default parameters
-test_that("prepare_data rejects no working_unit as input", {
+test_that(
+  "prepare_data rejects no working_unit as input", {
   data_source_bins <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -625,7 +678,8 @@ test_that("prepare_data rejects no working_unit as input", {
   )
 })
 
-test_that("prepare_data validates working_units parameter is not 0", {
+test_that(
+  "prepare_data validates working_units parameter is not 0", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -644,7 +698,8 @@ test_that("prepare_data validates working_units parameter is not 0", {
 })
 
 
-test_that("prepare_data validates working_units parameter is not NULL", {
+test_that(
+  "prepare_data validates working_units parameter is not NULL", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -672,7 +727,8 @@ test_that("prepare_data validates working_units parameter is not NULL", {
 
 # 1.1 "levels"
 
-test_that("prepare_data validates bin_size is not NULL with working_unit='levels'", {
+test_that(
+  "prepare_data validates bin_size is not NULL with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -693,7 +749,8 @@ test_that("prepare_data validates bin_size is not NULL with working_unit='levels
   )
 })
 
-test_that("prepare_data validates bin_size is not Inf with working_unit='levels'", {
+test_that(
+  "prepare_data validates bin_size is not Inf with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -715,7 +772,8 @@ test_that("prepare_data validates bin_size is not Inf with working_unit='levels'
 })
 
 
-test_that("prepare_data validates bin_size is not negative with working_unit='levels'", {
+test_that(
+  "prepare_data validates bin_size is not negative with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -736,7 +794,8 @@ test_that("prepare_data validates bin_size is not negative with working_unit='le
   )
 })
 
-test_that("prepare_data validates bin_size is not NA with working_unit='levels'", {
+test_that(
+  "prepare_data validates bin_size is not NA with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -757,7 +816,8 @@ test_that("prepare_data validates bin_size is not NA with working_unit='levels'"
   )
 })
 
-test_that("prepare_data validates bin_size is integer with working_unit='levels'", {
+test_that(
+  "prepare_data validates bin_size is integer with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -777,7 +837,8 @@ test_that("prepare_data validates bin_size is integer with working_unit='levels'
   )
 })
 
-test_that("prepare_data validates bin_size is not 0 with working_unit='levels'", {
+test_that(
+  "prepare_data validates bin_size is not 0 with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -798,7 +859,8 @@ test_that("prepare_data validates bin_size is not 0 with working_unit='levels'",
 })
 
 
-test_that("prepare_data works with minimum bin_size (1) with working_unit='levels'", {
+test_that(
+  "prepare_data works with minimum bin_size (1) with working_unit='levels'", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -819,7 +881,8 @@ test_that("prepare_data works with minimum bin_size (1) with working_unit='level
 
 # 1.2 "bins"
 
-test_that("prepare_data validates bin_size is numeric", {
+test_that(
+  "prepare_data validates bin_size is numeric", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -840,7 +903,8 @@ test_that("prepare_data validates bin_size is numeric", {
   )
 })
 
-test_that("prepare_data validates bin_size is not Inf", {
+test_that(
+  "prepare_data validates bin_size is not Inf", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -862,7 +926,8 @@ test_that("prepare_data validates bin_size is not Inf", {
 })
 
 
-test_that("prepare_data validates bin_size is not negative", {
+test_that(
+  "prepare_data validates bin_size is not negative", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -883,7 +948,8 @@ test_that("prepare_data validates bin_size is not negative", {
   )
 })
 
-test_that("prepare_data validates bin_size is not NA", {
+test_that(
+  "prepare_data validates bin_size is not NA", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -904,7 +970,8 @@ test_that("prepare_data validates bin_size is not NA", {
   )
 })
 
-test_that("prepare_data validates bin_size is integer", {
+test_that(
+  "prepare_data validates bin_size is integer", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -924,7 +991,8 @@ test_that("prepare_data validates bin_size is integer", {
   )
 })
 
-test_that("prepare_data validates bin_size is not 0", {
+test_that(
+  "prepare_data validates bin_size is not 0", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -945,7 +1013,8 @@ test_that("prepare_data validates bin_size is not 0", {
 })
 
 
-test_that("prepare_data works with minimum bin_size (1)", {
+test_that(
+  "prepare_data works with minimum bin_size (1)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -967,7 +1036,8 @@ test_that("prepare_data works with minimum bin_size (1)", {
 
 # 1.3 "MW"
 
-test_that("prepare_data validates bin_size is numeric (working_units=WM)", {
+test_that(
+  "prepare_data validates bin_size is numeric (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -988,7 +1058,8 @@ test_that("prepare_data validates bin_size is numeric (working_units=WM)", {
   )
 })
 
-test_that("prepare_data validates bin_size is not Inf (working_units=WM)", {
+test_that(
+  "prepare_data validates bin_size is not Inf (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1010,7 +1081,8 @@ test_that("prepare_data validates bin_size is not Inf (working_units=WM)", {
 })
 
 
-test_that("prepare_data validates bin_size is not negative (working_units=WM)", {
+test_that(
+  "prepare_data validates bin_size is not negative (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1031,7 +1103,8 @@ test_that("prepare_data validates bin_size is not negative (working_units=WM)", 
   )
 })
 
-test_that("prepare_data validates bin_size is not NA (working_units=WM)", {
+test_that(
+  "prepare_data validates bin_size is not NA (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1053,7 +1126,8 @@ test_that("prepare_data validates bin_size is not NA (working_units=WM)", {
 })
 
 
-test_that("prepare_data validates bin_size is integer (working_units=WM)", {
+test_that(
+  "prepare_data validates bin_size is integer (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1074,7 +1148,8 @@ test_that("prepare_data validates bin_size is integer (working_units=WM)", {
 })
 
 
-test_that("prepare_data validates bin_size is not 0 (working_units=WM)", {
+test_that(
+  "prepare_data validates bin_size is not 0 (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1095,7 +1170,8 @@ test_that("prepare_data validates bin_size is not 0 (working_units=WM)", {
 })
 
 
-test_that("prepare_data works with minimum bin_size (1) and MW", {
+test_that(
+  "prepare_data works with minimum bin_size (1) and MW", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1120,7 +1196,8 @@ test_that("prepare_data works with minimum bin_size (1) and MW", {
 #                Number of shifts Input Tests                #
 # ---------------------------------------------------------- #
 
-test_that("prepare_data validates number_of_shifts is present (working_units=WM)", {
+test_that(
+  "prepare_data validates number_of_shifts is present (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1141,7 +1218,8 @@ test_that("prepare_data validates number_of_shifts is present (working_units=WM)
   )
 })
 
-test_that("prepare_data validates number_of_shifts is not Inf (working_units=WM)", {
+test_that(
+  "prepare_data validates number_of_shifts is not Inf (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1163,7 +1241,8 @@ test_that("prepare_data validates number_of_shifts is not Inf (working_units=WM)
 })
 
 
-test_that("prepare_data validates number_of_shifts is not negative (working_units=WM)", {
+test_that(
+  "prepare_data validates number_of_shifts is not negative (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1184,7 +1263,8 @@ test_that("prepare_data validates number_of_shifts is not negative (working_unit
   )
 })
 
-test_that("prepare_data validates number_of_shifts is not NA (working_units=WM)", {
+test_that(
+  "prepare_data validates number_of_shifts is not NA (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1206,7 +1286,8 @@ test_that("prepare_data validates number_of_shifts is not NA (working_units=WM)"
 })
 
 
-test_that("prepare_data validates number_of_shifts is integer (working_units=WM)", {
+test_that(
+  "prepare_data validates number_of_shifts is integer (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1227,7 +1308,8 @@ test_that("prepare_data validates number_of_shifts is integer (working_units=WM)
 })
 
 
-test_that("prepare_data works with number_of_shifts = 0 (working_units=WM)", {
+test_that(
+  "prepare_data works with number_of_shifts = 0 (working_units=WM)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1251,7 +1333,8 @@ test_that("prepare_data works with number_of_shifts = 0 (working_units=WM)", {
 #                 Rand Input Tests                           #
 # ---------------------------------------------------------- #
 
-test_that("prepare_data validates rand parameter when provided", {
+test_that(
+  "prepare_data validates rand parameter when provided", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1272,7 +1355,8 @@ test_that("prepare_data validates rand parameter when provided", {
   )
 })
 
-test_that("prepare_data validates rand is integer when numeric", {
+test_that(
+  "prepare_data validates rand is integer when numeric", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1293,7 +1377,8 @@ test_that("prepare_data validates rand is integer when numeric", {
   )
 })
 
-test_that("prepare_data produces N = rand random samples", {
+test_that(
+  "prepare_data produces N = rand random samples", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1326,7 +1411,8 @@ test_that("prepare_data produces N = rand random samples", {
   expect_equal(length(dat_5), 5)
 })
 
-test_that("prepare_data produces _randomized_ samples with every trial", {
+test_that(
+  "prepare_data produces _randomized_ samples with every trial", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1356,7 +1442,8 @@ test_that("prepare_data produces _randomized_ samples with every trial", {
 })
 
 
-test_that("prepare_data samples reproducibly if rand > 1 and seed set manually", {
+test_that(
+  "prepare_data samples reproducibly if rand > 1 and seed set manually", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1389,7 +1476,8 @@ test_that("prepare_data samples reproducibly if rand > 1 and seed set manually",
 })
 
 #fails currently
-test_that("prepare_data samples reproducibly if rand > 1 and no seed set manually", {
+test_that(
+  "prepare_data samples reproducibly if rand > 1 and no seed set manually", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1420,7 +1508,8 @@ test_that("prepare_data samples reproducibly if rand > 1 and no seed set manuall
 })
 
 # fails currentöy
-test_that("prepare_data does not change age if no age_uncertainty in data", {
+test_that(
+  "prepare_data does not change age if no age_uncertainty in data", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1452,7 +1541,8 @@ test_that("prepare_data does not change age if no age_uncertainty in data", {
 # ---------------------------------------------------------- #
 
 # with valid input:
-test_that("prepare_data returns the correct output structure with default parameters (levels)", {
+test_that(
+  "prepare_data returns the correct output structure with default parameters (levels)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1461,7 +1551,8 @@ test_that("prepare_data returns the correct output structure with default parame
       verbose = FALSE
     )
 
-  res <-1
+  res <-
+    1
   
     prepare_data(
       data_source_prep = example_data,
@@ -1478,13 +1569,15 @@ test_that("prepare_data returns the correct output structure with default parame
 
   # Named list elements
   expect_identical(
-    names(res[[1]][[1]]),
+    names(
+    res[[1]][[1]]),
     c("data", "bins")
   )
 
   # Named data object
   expect_identical(
-    names(res[[1]][[1]]$data),
+    names(
+    res[[1]][[1]]$data),
     c("age", names(example_data$community))
   )
 
@@ -1507,7 +1600,8 @@ test_that("prepare_data returns the correct output structure with default parame
 
 
 
-test_that("prepare_data returns the correct output structure with default parameters (MW)", {
+test_that(
+  "prepare_data returns the correct output structure with default parameters (MW)", {
   example_data <-
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
@@ -1532,13 +1626,15 @@ test_that("prepare_data returns the correct output structure with default parame
 
   # Named list elements
   expect_identical(
-    names(res[[1]][[1]]),
+    names(
+    res[[1]][[1]]),
     c("data", "bins")
   )
 
   # Named data object
   expect_identical(
-    names(res[[1]][[1]]$data),
+    names(
+    res[[1]][[1]]$data),
     c("age", names(example_data$community))
   )
 
@@ -1585,13 +1681,15 @@ expect_type(
 
 # Named list elements
 expect_identical(
-  names(res[[1]][[1]]),
+  names(
+    res[[1]][[1]]),
   c("data", "bins")
 )
 
 # Named data object
 expect_identical(
-  names(res[[1]][[1]]$data),
+  names(
+    res[[1]][[1]]$data),
   c("age", names(example_data$community))
 )
 

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -1,33 +1,3 @@
-# takes result from reduce_data() as input
-# parameters: working_units, bin_size, number_of_shifts, rand
-# returns: a list?
-
-
-# steps:
-## 1. checks input classes
-## 2. if a shift is present,
-## check N of shifts as well and set it = 1 if it is NULL
-## 3. if working_units is "levels", call make_bins() with "levels"
-## check if shifts are present, if so make bins with MW
-## of make bins with "bins" and bin_size
-## 4. check for age_un, if it is present, sample from it (SEED??)
-
-example_data <-
-  extract_data(
-    data_community_extract = RRatepol::example_data$pollen_data[[1]],
-    data_age_extract = RRatepol::example_data$sample_age[[1]],
-    age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-    verbose = FALSE
-  )
-
-prepare_data(example_data,
-  working_units = c("levels", "bins", "MW"),
-  bin_size = 500,
-  number_of_shifts = 5,
-  rand = NULL
-)
-
-
 
 # ---------------------------------------------------------- #
 #               Data_source_prep Input Tests                 #

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -3,97 +3,107 @@
 # ---------------------------------------------------------- #
 
 test_that(
-  "prepare_data rejects NULL data_source", {
-  expect_error(
-    prepare_data(
-      data_source_prep = NULL,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ), "'data_source_prep' must be one of the following: 'list'"
-  )
-})
+  "prepare_data rejects NULL data_source",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = NULL,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ), "'data_source_prep' must be one of the following: 'list'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data rejects incomplete list(data.frame) in data_source", {
-  expect_error(
-    prepare_data(
-      data_source_prep = RRatepol::example_data$pollen_data[[1]],
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ), "'data_source_prep' must be one of the following: 'list'"
-  )
-})
+  "prepare_data rejects incomplete list(data.frame) in data_source",
+  {
+    expect_error(
+      prepare_data(
+        data_source_prep = RRatepol::example_data$pollen_data[[1]],
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ), "'data_source_prep' must be one of the following: 'list'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data fails if no community in data_source", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data fails if no community in data_source",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    example_data$community <-
+      NULL
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ), "is not TRUE"
     )
-  example_data$community <-
-    NULL
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ), "is not TRUE"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data fails if no age in data_source", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data fails if no age in data_source",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    example_data$age <-
+      NULL
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ), "`names` must be a character vector"
     )
-  example_data$age <-
-    NULL
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ), "`names` must be a character vector"
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data works if no age_uncertainty in data_source", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data works if no age_uncertainty in data_source",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    example_data$age_un <-
+      NULL
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = c("levels", "bins", "MW"),
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
     )
-  example_data$age_un <-
-    NULL
-  expect_no_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = c("levels", "bins", "MW"),
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    )
-  )
-})
+  }
+)
 
 
 
@@ -101,621 +111,673 @@ test_that(
 ## Community data
 # Zeros
 test_that(
-  "prepare_data with working_units='levels' works if there are 0s in community data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='levels' works if there are 0s in community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$community[1:3] <-
-    0
+    example_data$community[1:3] <-
+      0
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "levels"
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "levels"
+      )
     )
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data with working_units='bins' works if there are 0s in community data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='bins' works if there are 0s in community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$community[1:3] <-
-    0
+    example_data$community[1:3] <-
+      0
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "bins",
-      bin_size = 500
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "bins",
+        bin_size = 500
+      )
     )
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data with working_units='MW' works if there are 0s in community data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='MW' works if there are 0s in community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$community[1:3] <-
-    0
+    example_data$community[1:3] <-
+      0
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      )
     )
-  )
-})
+  }
+)
 
 # NAs in Age
 test_that(
-  "prepare_data with working_units='levels' works if there are NAs in community data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='levels' works if there are NAs in community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$community[1:3] <-
-    NA
+    example_data$community[1:3] <-
+      NA
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "levels"
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "levels"
+      )
     )
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data with working_units='bins' works if there are NAs in community data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='bins' works if there are NAs in community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$community[1:3] <-
-    NA
+    example_data$community[1:3] <-
+      NA
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "bins",
-      bin_size = 500
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "bins",
+        bin_size = 500
+      )
     )
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data with working_units='MW' works if there are NAs in community data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='MW' works if there are NAs in community data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$community[1:3] <-
-    NA
+    example_data$community[1:3] <-
+      NA
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      )
     )
-  )
-})
+  }
+)
 
 
 ## Age data
 # Zeros
 test_that(
-  "prepare_data with working_units='levels' works if there are 0s in age data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='levels' works if there are 0s in age data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$age$age[1:3] <-
-    0
+    example_data$age$age[1:3] <-
+      0
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "levels"
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "levels"
+      )
     )
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data with working_units='bins' works if there are 0s in age data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='bins' works if there are 0s in age data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$age$age[1:3] <-
-    0
+    example_data$age$age[1:3] <-
+      0
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "bins",
-      bin_size = 500
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "bins",
+        bin_size = 500
+      )
     )
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data with working_units='MW' works if there are 0s in age data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='MW' works if there are 0s in age data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$age$age[1:3] <-
-    0
+    example_data$age$age[1:3] <-
+      0
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      )
     )
-  )
-})
+  }
+)
 
 # NAs in Age
 test_that(
-  "prepare_data with working_units='levels' works if there are NAs in age data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='levels' works if there are NAs in age data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$age$age[1:3] <-
-    NA
+    example_data$age$age[1:3] <-
+      NA
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "levels"
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "levels"
+      )
     )
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data with working_units='bins' fails if there are NAs in age data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data with working_units='bins' fails if there are NAs in age data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age$age[1:3] <-
+      NA
+
+    expect_error(
+      prepare_data(
+        example_data,
+        working_units = "bins",
+        bin_size = 500
+      ),
+      "'from' must be a finite number"
     )
-
-  example_data$age$age[1:3] <-
-    NA
-
-  expect_error(
-    prepare_data(
-      example_data,
-      working_units = "bins",
-      bin_size = 500
-    ),
-    "'from' must be a finite number"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data with working_units='MW' fails if there are NAs in age data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data with working_units='MW' fails if there are NAs in age data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age$age[1:3] <-
+      NA
+
+    expect_error(
+      prepare_data(
+        example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5
+      ),
+      "'from' must be a finite number"
     )
-
-  example_data$age$age[1:3] <-
-    NA
-
-  expect_error(
-    prepare_data(
-      example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5
-    ),
-    "'from' must be a finite number"
-  )
-})
+  }
+)
 
 
 ## Age_uncertainty data
 # Zeros
 test_that(
-  "prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data with working_units='levels' and rand=1 works if there are 0s in the age uncertainty",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age_un[1:3] <-
+      0
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          example_data,
+          working_units = "levels",
+          rand = 1
+        )
     )
 
-  example_data$age_un[1:3] <-
-    0
-
-  expect_no_error(
-    res <-
-      prepare_data(
-      example_data,
-      working_units = "levels",
-      rand = 1
+    expect_false(
+      identical(
+        res[[1]][[1]]$data$age,
+        example_data$age$age
+      )
     )
-  )
-
-  expect_false(
-    identical(
-      res[[1]][[1]]$data$age,
-      example_data$age$age
-    )
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data with working_units='bins' and rand=1 works if there are 0s in the age uncertainty",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age_un[1:3] <-
+      0
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          example_data,
+          working_units = "bins",
+          bin_size = 500,
+          rand = 1
+        )
     )
 
-  example_data$age_un[1:3] <-
-    0
-
-  expect_no_error(
-    res <-
-      prepare_data(
-      example_data,
-      working_units = "bins",
-      bin_size = 500,
-      rand = 1
+    expect_false(
+      identical(
+        res[[1]][[1]]$data$age,
+        example_data$age$age
+      )
     )
-  )
-
-  expect_false(
-    identical(
-      res[[1]][[1]]$data$age,
-      example_data$age$age
-    )
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data with working_units='MW' and rand=1 works if there are 0s in the age uncertainty",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age_un[1:3] <-
+      0
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          example_data,
+          working_units = "MW",
+          bin_size = 500,
+          number_of_shifts = 5,
+          rand = 1
+        )
     )
 
-  example_data$age_un[1:3] <-
-    0
-
-  expect_no_error(
-    res <-
-      prepare_data(
-      example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 1
+    expect_false(
+      identical(
+        res[[1]][[1]]$data$age,
+        example_data$age$age
+      )
     )
-  )
-
-  expect_false(
-    identical(
-      res[[1]][[1]]$data$age,
-      example_data$age$age
-    )
-  )
-})
+  }
+)
 
 
 # NAs in Age_uncertainty
 test_that(
-  "prepare_data with working_units='levels' works if there are NAs in age_un data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data with working_units='levels' works if there are NAs in age_un data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  example_data$age_un[1:3] <-
-    NA
+    example_data$age_un[1:3] <-
+      NA
 
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "levels",
-      rand = 1
-    )
-  )
-})
-
-test_that(
-  "prepare_data with working_units='bins' works if there are NAs in age_un data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  example_data$age_un[1:3] <-
-    NA
-
-  expect_no_error(
-    prepare_data(
-      example_data,
-      working_units = "bins",
-      bin_size = 500,
-      rand = 1
-    )
-  )
-})
-
-
-test_that(
-  "prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  example_data$age_un[1:3] <-
-    NA
-
-  expect_no_error(
-    res <-
+    expect_no_error(
       prepare_data(
         example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
+        working_units = "levels",
         rand = 1
       )
-  )
+    )
+  }
+)
 
-  # returns NA in output$age
-  expect_true(any(is.na(res[[1]][[1]]$data$age)))
-})
+test_that(
+  "prepare_data with working_units='bins' works if there are NAs in age_un data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age_un[1:3] <-
+      NA
+
+    expect_no_error(
+      prepare_data(
+        example_data,
+        working_units = "bins",
+        bin_size = 500,
+        rand = 1
+      )
+    )
+  }
+)
+
+
+test_that(
+  "prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    example_data$age_un[1:3] <-
+      NA
+
+    expect_no_error(
+      res <-
+        prepare_data(
+          example_data,
+          working_units = "MW",
+          bin_size = 500,
+          number_of_shifts = 5,
+          rand = 1
+        )
+    )
+
+    # returns NA in output$age
+    expect_true(any(is.na(res[[1]][[1]]$data$age)))
+  }
+)
 
 # ---------------------------------------------------------- #
 #                  Working Units Input Tests                 #
 # ---------------------------------------------------------- #
 
 test_that(
-  "prepare_data validates working_units is one of the three valid options", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units is one of the three valid options",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "invalid",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "invalid",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates working_units parameter is not numeric", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units parameter is not numeric",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = 123,
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = 123,
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates working_units parameter is not numeric", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units parameter is not numeric",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = NA,
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = NA,
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 
 test_that(
-  "prepare_data validates working_units parameter is not a vector of parameters", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units parameter is not a vector of parameters",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = c("MW", "bins", "levels"),
-      rand = NULL
-    ),
-    "'arg' must be of length 1"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = c("MW", "bins", "levels"),
+        rand = NULL
+      ),
+      "'arg' must be of length 1"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates working_units parameter is not a vector of parameters", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units parameter is not a vector of parameters",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = c("MW", "bins")
-    ),
-    "'arg' must be of length 1"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = c("MW", "bins")
+      ),
+      "'arg' must be of length 1"
+    )
+  }
+)
 
 
 # test fails because function silently uses the default parameters
 test_that(
-  "prepare_data rejects no working_unit as input", {
-  data_source_bins <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data rejects no working_unit as input",
+  {
+    data_source_bins <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_bins
+    expect_error(
+      prepare_data(
+        data_source_bins
+      )
+      # no error programmed into function yet
     )
-    # no error programmed into function yet
-  )
-})
+  }
+)
 
 test_that(
-  "prepare_data validates working_units parameter is not 0", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units parameter is not 0",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = 0
-    ),
-    "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = 0
+      ),
+      "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 
 test_that(
-  "prepare_data validates working_units parameter is not NULL", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates working_units parameter is not NULL",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = NULL
-    ),
-    "'working_units' must be one of the following: 'character'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = NULL
+      ),
+      "'working_units' must be one of the following: 'character'"
+    )
+  }
+)
 
 
 
@@ -728,467 +790,509 @@ test_that(
 # 1.1 "levels"
 
 test_that(
-  "prepare_data validates bin_size is not NULL with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates bin_size is not NULL with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = NULL,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates bin_size is not Inf with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not Inf with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = Inf,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'to' must be a finite number"
     )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = Inf,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'to' must be a finite number"
-  )
-})
-
-
-test_that(
-  "prepare_data validates bin_size is not negative with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = -500,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "wrong sign in 'by' argument"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is not NA with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = NA,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is integer with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500.5,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "' bin_size ' must be a an integer"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is not 0 with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 0,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "invalid"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data works with minimum bin_size (1) with working_unit='levels'", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not negative with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = -500,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "wrong sign in 'by' argument"
     )
-  expect_no_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 1,
-      number_of_shifts = NULL,
-      rand = NULL
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is not NA with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = NA,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'bin_size' must be one of the following: 'numeric'"
     )
-  )
-})
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is integer with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500.5,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "' bin_size ' must be a an integer"
+    )
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is not 0 with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 0,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "invalid"
+    )
+  }
+)
+
+
+test_that(
+  "prepare_data works with minimum bin_size (1) with working_unit='levels'",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 1,
+        number_of_shifts = NULL,
+        rand = NULL
+      )
+    )
+  }
+)
 
 # 1.2 "bins"
 
 test_that(
-  "prepare_data validates bin_size is numeric", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates bin_size is numeric",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = "500",
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = "500",
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates bin_size is not Inf", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not Inf",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = Inf,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'to' must be a finite number"
     )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = Inf,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'to' must be a finite number"
-  )
-})
-
-
-test_that(
-  "prepare_data validates bin_size is not negative", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = -500,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "wrong sign in 'by' argument"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is not NA", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = NA,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is integer", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = 500.5,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "' bin_size ' must be a an integer"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is not 0", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = 0,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "invalid"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data works with minimum bin_size (1)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not negative",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = -500,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "wrong sign in 'by' argument"
     )
-  expect_no_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = 1,
-      number_of_shifts = NULL,
-      rand = NULL
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is not NA",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = NA,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'bin_size' must be one of the following: 'numeric'"
     )
-  )
-})
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is integer",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = 500.5,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "' bin_size ' must be a an integer"
+    )
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is not 0",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = 0,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "invalid"
+    )
+  }
+)
+
+
+test_that(
+  "prepare_data works with minimum bin_size (1)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "bins",
+        bin_size = 1,
+        number_of_shifts = NULL,
+        rand = NULL
+      )
+    )
+  }
+)
 
 
 # 1.3 "MW"
 
 test_that(
-  "prepare_data validates bin_size is numeric (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates bin_size is numeric (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = "500",
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = "500",
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates bin_size is not Inf (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not Inf (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = Inf,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "'to' must be a finite number"
     )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = Inf,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "'to' must be a finite number"
-  )
-})
-
-
-test_that(
-  "prepare_data validates bin_size is not negative (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = -500,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "wrong sign in 'by' argument"
-  )
-})
-
-test_that(
-  "prepare_data validates bin_size is not NA (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = NA,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "'bin_size' must be one of the following: 'numeric'"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data validates bin_size is integer (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not negative (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = -500,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "wrong sign in 'by' argument"
     )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500.5,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "' bin_size ' must be a an integer"
-  )
-})
+  }
+)
+
+test_that(
+  "prepare_data validates bin_size is not NA (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = NA,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "'bin_size' must be one of the following: 'numeric'"
+    )
+  }
+)
 
 
 test_that(
-  "prepare_data validates bin_size is not 0 (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is integer (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500.5,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "' bin_size ' must be a an integer"
     )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 0,
-      number_of_shifts = 5,
-      rand = NULL
-    ),
-    "invalid"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data works with minimum bin_size (1) and MW", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates bin_size is not 0 (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 0,
+        number_of_shifts = 5,
+        rand = NULL
+      ),
+      "invalid"
     )
-  expect_no_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 1,
-      number_of_shifts = 5,
-      rand = NULL
+  }
+)
+
+
+test_that(
+  "prepare_data works with minimum bin_size (1) and MW",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 1,
+        number_of_shifts = 5,
+        rand = NULL
+      )
     )
-  )
-})
+  }
+)
 
 
 
@@ -1197,136 +1301,148 @@ test_that(
 # ---------------------------------------------------------- #
 
 test_that(
-  "prepare_data validates number_of_shifts is present (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates number_of_shifts is present (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = NULL,
-      rand = NULL
-    ),
-    "'number_of_shifts' must be one of the following: 'numeric'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = NULL,
+        rand = NULL
+      ),
+      "'number_of_shifts' must be one of the following: 'numeric'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates number_of_shifts is not Inf (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates number_of_shifts is not Inf (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = Inf,
+        rand = NULL
+      ),
+      "result would be too long a vector"
     )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = Inf,
-      rand = NULL
-    ),
-    "result would be too long a vector"
-  )
-})
-
-
-test_that(
-  "prepare_data validates number_of_shifts is not negative (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = -5,
-      rand = NULL
-    ),
-    "invalid 'times' argument"
-  )
-})
-
-test_that(
-  "prepare_data validates number_of_shifts is not NA (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = NA,
-      rand = NULL
-    ),
-    "'number_of_shifts' must be one of the following: 'numeric'"
-  )
-})
+  }
+)
 
 
 test_that(
-  "prepare_data validates number_of_shifts is integer (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates number_of_shifts is not negative (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = -5,
+        rand = NULL
+      ),
+      "invalid 'times' argument"
     )
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5.5,
-      rand = NULL
-    ),
-    "' number_of_shifts ' must be a an integer"
-  )
-})
+  }
+)
+
+test_that(
+  "prepare_data validates number_of_shifts is not NA (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = NA,
+        rand = NULL
+      ),
+      "'number_of_shifts' must be one of the following: 'numeric'"
+    )
+  }
+)
 
 
 test_that(
-  "prepare_data works with number_of_shifts = 0 (working_units=WM)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data validates number_of_shifts is integer (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5.5,
+        rand = NULL
+      ),
+      "' number_of_shifts ' must be a an integer"
     )
-  expect_no_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 0,
-      rand = NULL
-    ),
-  )
-})
+  }
+)
+
+
+test_that(
+  "prepare_data works with number_of_shifts = 0 (working_units=WM)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    expect_no_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 0,
+        rand = NULL
+      ),
+    )
+  }
+)
 
 
 # ---------------------------------------------------------- #
@@ -1334,60 +1450,100 @@ test_that(
 # ---------------------------------------------------------- #
 
 test_that(
-  "prepare_data validates rand parameter when provided", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates rand parameter when provided",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = "invalid"
-    ),
-    "'rand' must be one of the following: 'NULL', 'numeric'"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = "invalid"
+      ),
+      "'rand' must be one of the following: 'NULL', 'numeric'"
+    )
+  }
+)
 
 test_that(
-  "prepare_data validates rand is integer when numeric", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data validates rand is integer when numeric",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  expect_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 5.5
-    ),
-    "' rand ' must be a an integer"
-  )
-})
+    expect_error(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 5.5
+      ),
+      "' rand ' must be a an integer"
+    )
+  }
+)
 
 test_that(
-  "prepare_data produces N = rand random samples", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data produces N = rand random samples",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    expect_no_error(
+      dat_5 <-
+        prepare_data(
+          data_source_prep = example_data,
+          working_units = "levels",
+          bin_size = 500,
+          number_of_shifts = 5,
+          rand = 5
+        )
     )
 
-  expect_no_error(
+    dat_3 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 3
+      )
+
+    expect_equal(length(dat_3), 3)
+    expect_equal(length(dat_5), 5)
+  }
+)
+
+test_that(
+  "prepare_data produces _randomized_ samples with every trial",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
     dat_5 <-
       prepare_data(
         data_source_prep = example_data,
@@ -1396,142 +1552,116 @@ test_that(
         number_of_shifts = 5,
         rand = 5
       )
-  )
 
-  dat_3 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 3
-    )
-
-  expect_equal(length(dat_3), 3)
-  expect_equal(length(dat_5), 5)
-})
-
-test_that(
-  "prepare_data produces _randomized_ samples with every trial", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-
-  dat_5 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 5
-    )
-
-  dat_3 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 3
-    )
-  expect_false(identical(dat_3, dat_5[1:3]))
-})
+    dat_3 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 3
+      )
+    expect_false(identical(dat_3, dat_5[1:3]))
+  }
+)
 
 
 test_that(
-  "prepare_data samples reproducibly if rand > 1 and seed set manually", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data samples reproducibly if rand > 1 and seed set manually",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  set.seed(123)
-  res1 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 5
-    )
+    set.seed(123)
+    res1 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 5
+      )
 
-  set.seed(123)
-  res2 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 5
-    )
+    set.seed(123)
+    res2 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 5
+      )
 
-  expect_identical(res1, res2)
-})
+    expect_identical(res1, res2)
+  }
+)
 
-#fails currently
+# fails currently
 test_that(
-  "prepare_data samples reproducibly if rand > 1 and no seed set manually", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
+  "prepare_data samples reproducibly if rand > 1 and no seed set manually",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
 
-  res1 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 1
-    )
+    res1 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 1
+      )
 
-  res2 <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 1
-    )
+    res2 <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 1
+      )
 
-  expect_identical(res1, res2)
-})
+    expect_identical(res1, res2)
+  }
+)
 
 # fails currentöy
 test_that(
-  "prepare_data does not change age if no age_uncertainty in data", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = NULL,
-      verbose = FALSE
-    )
+  "prepare_data does not change age if no age_uncertainty in data",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = NULL,
+        verbose = FALSE
+      )
 
-  res <-
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 1,
-      rand = 1
-    )
+    res <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 1,
+        rand = 1
+      )
 
-  expect_identical(
-    res[[1]][[1]]$bins$res_age,
-    example_data$age$age
-  )
-})
+    expect_identical(
+      res[[1]][[1]]$bins$res_age,
+      example_data$age$age
+    )
+  }
+)
 
 
 
@@ -1542,169 +1672,1376 @@ test_that(
 
 # with valid input:
 test_that(
-  "prepare_data returns the correct output structure with default parameters (levels)", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+  "prepare_data returns the correct output structure with default parameters (levels)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      )
+
+    # General output structure tests:
+    expect_type(
+      res, "list"
     )
 
-  res <-
-    1
-  
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "levels",
-      bin_size = NULL,
-      number_of_shifts = NULL,
-      rand = NULL
+    # Named list elements
+    expect_identical(
+      names(
+        res[[1]][[1]]
+      ),
+      c("data", "bins")
     )
 
-  # General output structure tests:
-  expect_type(
-    res, "list"
-  )
-
-  # Named list elements
-  expect_identical(
-    names(
-    res[[1]][[1]]),
-    c("data", "bins")
-  )
-
-  # Named data object
-  expect_identical(
-    names(
-    res[[1]][[1]]$data),
-    c("age", names(example_data$community))
-  )
-
-  # Named bins object
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(res[[1]][[1]]$bins)
+    # Named data object
+    expect_identical(
+      names(
+        res[[1]][[1]]$data
+      ),
+      c("age", names(example_data$community))
     )
-  )
 
-  # $data is not all 0 or empty
-  expect_false(all(res[[1]][[1]]$data == 0))
-  expect_false(length(res[[1]][[1]]$data) == 0)
-  # $bins is not all 0 or empty
-  expect_false(all(res[[1]][[1]]$bins == 0))
-  expect_false(nrow(res[[1]][[1]]$bins) == 0)
-})
+    # Named bins object
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(res[[1]][[1]]$bins)
+      )
+    )
+
+    # $data is not all 0 or empty
+    expect_false(all(res[[1]][[1]]$data == 0))
+    expect_false(length(res[[1]][[1]]$data) == 0)
+    # $bins is not all 0 or empty
+    expect_false(all(res[[1]][[1]]$bins == 0))
+    expect_false(nrow(res[[1]][[1]]$bins) == 0)
+  }
+)
 
 
 
 test_that(
-  "prepare_data returns the correct output structure with default parameters (MW)", {
-  example_data <-
+  "prepare_data returns the correct output structure with default parameters (MW)",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+
+    res <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = NULL
+      )
+
+    # General output structure tests:
+    expect_type(
+      res, "list"
+    )
+
+    # Named list elements
+    expect_identical(
+      names(
+        res[[1]][[1]]
+      ),
+      c("data", "bins")
+    )
+
+    # Named data object
+    expect_identical(
+      names(
+        res[[1]][[1]]$data
+      ),
+      c("age", names(example_data$community))
+    )
+
+    # Named bins object
+    expect_true(
+      all(
+        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+        %in%
+          colnames(res[[1]][[1]]$bins)
+      )
+    )
+
+    # $data is not all 0 or empty
+    expect_false(all(res[[1]][[1]]$data == 0))
+    expect_false(length(res[[1]][[1]]$data) == 0)
+    # $bins is not all 0 or empty
+    expect_false(all(res[[1]][[1]]$bins == 0))
+    expect_false(nrow(res[[1]][[1]]$bins) == 0)
+  }
+)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# WIP
+
+
+
+# --------------------------------------------------------- #
+# Tests for the full functionality within estimate_roc()
+# --------------------------------------------------------- #
+
+# working_units = levels
+
+# 1. default with correct data
+test_that("prepare_data works correctly within estimate_roc() workflow", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
     extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      community,
+      age,
+      age_uncertainty
     )
 
-  res <-
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
     prepare_data(
-      data_source_prep = example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = NULL
+      data_work
+    )
+})
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
     )
 
-  # General output structure tests:
-  expect_type(
-    res, "list"
-  )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
 
-  # Named list elements
-  expect_identical(
-    names(
-    res[[1]][[1]]),
-    c("data", "bins")
-  )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-  # Named data object
-  expect_identical(
-    names(
-    res[[1]][[1]]$data),
-    c("age", names(example_data$community))
-  )
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
 
-  # Named bins object
-  expect_true(
-    all(
-      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-      %in%
-        colnames(res[[1]][[1]]$bins)
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
     )
   )
+})
 
-  # $data is not all 0 or empty
-  expect_false(all(res[[1]][[1]]$data == 0))
-  expect_false(length(res[[1]][[1]]$data) == 0)
-  # $bins is not all 0 or empty
-  expect_false(all(res[[1]][[1]]$bins == 0))
-  expect_false(nrow(res[[1]][[1]]$bins) == 0)
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  expect_identical(
+    data_prepared[[1]][[1]]$bins$name,
+    rownames(data_work$community)
+  )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  expect_identical(
+    data_prepared[[1]][[1]]$bins$name,
+    rownames(data_work$community)
+  )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  expect_identical(
+    data_prepared[[1]][[1]]$bins$name,
+    rownames(data_work$community)
+  )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
+
+  expect_identical(
+    data_prepared[[1]][[1]]$bins$name,
+    rownames(data_work$community)
+  )
 })
 
 
 
+# working_units = bins
 
+# 1. default with correct data
+test_that("prepare_data works correctly within estimate_roc() workflow", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
 
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
 
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+})
 
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
 
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
 
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
 
-
-
-
-
-
-# General output structure tests:
-expect_type(
-  res, "list"
-)
-
-# Named list elements
-expect_identical(
-  names(
-    res[[1]][[1]]),
-  c("data", "bins")
-)
-
-# Named data object
-expect_identical(
-  names(
-    res[[1]][[1]]$data),
-  c("age", names(example_data$community))
-)
-
-# Named bins object
-expect_true(
-  all(
-    c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-    %in%
-      colnames(res[[1]][[1]]$bins)
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
   )
-)
+})
 
-# $data is not all 0 or empty
-expect_false(all(res[[1]][[1]]$data == 0))
-expect_false(length(res[[1]][[1]]$data) == 0)
-# $bins is not all 0 or empty
-expect_false(all(res[[1]][[1]]$bins == 0))
-expect_false(nrow(res[[1]][[1]]$bins) == 0)
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+
+
+# working_units = MW
+
+# 1. default with correct data
+test_that("prepare_data works correctly within estimate_roc() workflow", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+})
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+# NAs in age (known issue)
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
+        )
+      )
+    )
+  )
+})
+
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})
+
+# NAs in community
+test_that("prepare_data works correctly within the workflow of estimate_roc() with NAs in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  community[1:10, -1] <-
+    NA
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
+
+  # expect_identical(
+  #   data_prepared[[1]][[1]]$bins$name,
+  #   rownames(data_work$community)
+  # )
+})

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -252,9 +252,10 @@ test_that(
 
     expect_equal(
       nrow(
-        result[[1]][[1]]$bins), 
+        result[[1]][[1]]$bins
+      ),
       1
-      )
+    )
   }
 )
 
@@ -282,7 +283,7 @@ test_that(
     expect_equal(
       ncol(result[[1]][[1]]$data) - 1, # -1 for age column
       1
-    ) 
+    )
   }
 )
 
@@ -905,7 +906,7 @@ test_that(
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
         verbose = FALSE
       )
-    
+
     expect_silent(
       prepare_data(
         data_source_prep = example_data,
@@ -1632,9 +1633,9 @@ test_that(
           working_units = "levels",
           rand = 10
         ),
-      #none programmed into the function yet
-      # e.g., 
-      #"Warning: age_uncertainty has only 1 unique value. 
+      # none programmed into the function yet
+      # e.g.,
+      # "Warning: age_uncertainty has only 1 unique value.
       # randomizations will result in identical results"
     )
 
@@ -1885,7 +1886,7 @@ test_that(
       prepare_data(
         data_source_prep = example_data,
         working_units = "levels",
-        #bin_size = NULL,
+        # bin_size = NULL,
         number_of_shifts = NULL,
         rand = NULL
       )
@@ -2239,7 +2240,7 @@ test_that(
       reduce_data(
         data_smoothed
       )
-    
+
     set.seed(123)
     data_prepared_rand_1 <-
       prepare_data(
@@ -2342,17 +2343,17 @@ test_that(
       )
 
     expect_warning(
-    data_prepared_rand_100 <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      ),
-    #none programmed into function yet
-    # e.g., 
-    # "Warning: setting rand != NULL without age_un will result 
-    # in identical randomization results."
+      data_prepared_rand_100 <-
+        prepare_data(
+          data_work,
+          working_units = "MW",
+          number_of_shifts = 1,
+          rand = 100
+        ),
+      # none programmed into function yet
+      # e.g.,
+      # "Warning: setting rand != NULL without age_un will result
+      # in identical randomization results."
     )
   }
 )
@@ -4277,4 +4278,3 @@ test_that(
     )
   }
 )
-

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -1,4 +1,3 @@
-
 # ---------------------------------------------------------- #
 #               Data_source_prep Input Tests                 #
 # ---------------------------------------------------------- #
@@ -91,7 +90,6 @@ test_that("prepare_data works if no age_uncertainty in data_source", {
 
 
 
-# to do: test with 0 and NAs in age/community data
 ## Community data
 # Zeros
 test_that("prepare_data with working_units='levels' works if there are 0s in community data", {
@@ -489,14 +487,14 @@ test_that("prepare_data with working_units='MW' returns NA in data if there is N
   example_data$age_un[1:3] <- NA
 
   expect_no_error(
-    res <-  
-    prepare_data(
-      example_data,
-      working_units = "MW",
-      bin_size = 500,
-      number_of_shifts = 5,
-      rand = 1
-    )
+    res <-
+      prepare_data(
+        example_data,
+        working_units = "MW",
+        bin_size = 500,
+        number_of_shifts = 5,
+        rand = 1
+      )
   )
 
   # returns NA in output$age
@@ -672,7 +670,154 @@ test_that("prepare_data validates working_units parameter is not NULL", {
 #                   Bin_size Input Tests                     #
 # ---------------------------------------------------------- #
 
-# 1.1 "bins"
+# 1.1 "levels"
+
+test_that("prepare_data validates bin_size is not NULL with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates bin_size is not Inf with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = Inf,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'to' must be a finite number"
+  )
+})
+
+
+test_that("prepare_data validates bin_size is not negative with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = -500,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "wrong sign in 'by' argument"
+  )
+})
+
+test_that("prepare_data validates bin_size is not NA with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = NA,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates bin_size is integer with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500.5,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "' bin_size ' must be a an integer"
+  )
+})
+
+test_that("prepare_data validates bin_size is not 0 with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 0,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "invalid"
+  )
+})
+
+
+test_that("prepare_data works with minimum bin_size (1) with working_unit='levels'", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 1,
+      number_of_shifts = NULL,
+      rand = NULL
+    )
+  )
+})
+
+# 1.2 "bins"
 
 test_that("prepare_data validates bin_size is numeric", {
   example_data <-
@@ -820,26 +965,7 @@ test_that("prepare_data works with minimum bin_size (1)", {
 })
 
 
-test_that("prepare_data works with minimum bin_size (1) and bins", {
-  example_data <-
-    extract_data(
-      data_community_extract = RRatepol::example_data$pollen_data[[1]],
-      data_age_extract = RRatepol::example_data$sample_age[[1]],
-      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
-    )
-  expect_no_error(
-    prepare_data(
-      data_source_prep = example_data,
-      working_units = "bins",
-      bin_size = 100,
-      number_of_shifts = NULL,
-      rand = NULL
-    )
-  )
-})
-
-# 1.2 "MW"
+# 1.3 "MW"
 
 test_that("prepare_data validates bin_size is numeric (working_units=WM)", {
   example_data <-
@@ -1262,6 +1388,7 @@ test_that("prepare_data samples reproducibly if rand > 1 and seed set manually",
   expect_identical(res1, res2)
 })
 
+#fails currently
 test_that("prepare_data samples reproducibly if rand > 1 and no seed set manually", {
   example_data <-
     extract_data(
@@ -1292,6 +1419,7 @@ test_that("prepare_data samples reproducibly if rand > 1 and no seed set manuall
   expect_identical(res1, res2)
 })
 
+# fails currentöy
 test_that("prepare_data does not change age if no age_uncertainty in data", {
   example_data <-
     extract_data(
@@ -1316,3 +1444,169 @@ test_that("prepare_data does not change age if no age_uncertainty in data", {
   )
 })
 
+
+
+# WIP:
+# ---------------------------------------------------------- #
+#                  Output structure Tests                    #
+# ---------------------------------------------------------- #
+
+# with valid input:
+test_that("prepare_data returns the correct output structure with default parameters (levels)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  res <-1
+  
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    )
+
+  # General output structure tests:
+  expect_type(
+    res, "list"
+  )
+
+  # Named list elements
+  expect_identical(
+    names(res[[1]][[1]]),
+    c("data", "bins")
+  )
+
+  # Named data object
+  expect_identical(
+    names(res[[1]][[1]]$data),
+    c("age", names(example_data$community))
+  )
+
+  # Named bins object
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(res[[1]][[1]]$bins)
+    )
+  )
+
+  # $data is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$data == 0))
+  expect_false(length(res[[1]][[1]]$data) == 0)
+  # $bins is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$bins == 0))
+  expect_false(nrow(res[[1]][[1]]$bins) == 0)
+})
+
+
+
+test_that("prepare_data returns the correct output structure with default parameters (MW)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      verbose = FALSE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+
+  # General output structure tests:
+  expect_type(
+    res, "list"
+  )
+
+  # Named list elements
+  expect_identical(
+    names(res[[1]][[1]]),
+    c("data", "bins")
+  )
+
+  # Named data object
+  expect_identical(
+    names(res[[1]][[1]]$data),
+    c("age", names(example_data$community))
+  )
+
+  # Named bins object
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+      %in%
+        colnames(res[[1]][[1]]$bins)
+    )
+  )
+
+  # $data is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$data == 0))
+  expect_false(length(res[[1]][[1]]$data) == 0)
+  # $bins is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$bins == 0))
+  expect_false(nrow(res[[1]][[1]]$bins) == 0)
+})
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# General output structure tests:
+expect_type(
+  res, "list"
+)
+
+# Named list elements
+expect_identical(
+  names(res[[1]][[1]]),
+  c("data", "bins")
+)
+
+# Named data object
+expect_identical(
+  names(res[[1]][[1]]$data),
+  c("age", names(example_data$community))
+)
+
+# Named bins object
+expect_true(
+  all(
+    c("name", "shift", "age_diff", "start", "end", "res_age", "label")
+    %in%
+      colnames(res[[1]][[1]]$bins)
+  )
+)
+
+# $data is not all 0 or empty
+expect_false(all(res[[1]][[1]]$data == 0))
+expect_false(length(res[[1]][[1]]$data) == 0)
+# $bins is not all 0 or empty
+expect_false(all(res[[1]][[1]]$bins == 0))
+expect_false(nrow(res[[1]][[1]]$bins) == 0)

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -150,8 +150,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data rejects incomplete list(
-    data.frame) in data_source",
+  "prepare_data rejects incomplete list(data.frame) in data_source",
   {
     expect_error(
       prepare_data(
@@ -179,7 +178,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data  throws error with data_source_prep with wrong structure",
+  "prepare_data throws error with data_source_prep with wrong structure",
   {
     wrong_structure <-
       list(
@@ -203,54 +202,6 @@ test_that(
 #                 input data internal structure validation
 # ----------------------------------------------------------------- #
 
-test_that(
-  "prepare_data fails if no community in data_source",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    example_data$community <-
-      NULL
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ), "is not TRUE"
-    )
-  }
-)
-
-test_that(
-  "prepare_data fails if no age in data_source",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    example_data$age <-
-      NULL
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ), "`names` must be a character vector"
-    )
-  }
-)
-
 # no error without age_uncertainty
 test_that(
   "prepare_data works if no age_uncertainty in data_source",
@@ -259,11 +210,10 @@ test_that(
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        age_uncertainty = NULL,
         verbose = FALSE
       )
-    example_data$age_un <-
-      NULL
+
     expect_no_error(
       prepare_data(
         data_source_prep = example_data,
@@ -300,7 +250,11 @@ test_that(
         )
     )
 
-    expect_equal(nrow(result[[1]][[1]]$bins), 1)
+    expect_equal(
+      nrow(
+        result[[1]][[1]]$bins), 
+      1
+      )
   }
 )
 
@@ -326,231 +280,9 @@ test_that(
     )
 
     expect_equal(
-      ncol(
-        result[[1]][[1]]$data
-      ) - 1, 1
-    ) # -1 for age column
-  }
-)
-
-# Zeros
-test_that(
-  "prepare_data with working_units='levels' works if there are 0s in community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$community[1:3] <-
-      0
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "levels"
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='bins' works if there are 0s in community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$community[1:3] <-
-      0
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "bins",
-        bin_size = 500
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='MW' works if there are 0s in community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$community[1:3] <-
-      0
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      )
-    )
-  }
-)
-
-# NAs in Community
-test_that(
-  "prepare_data with working_units='levels' works if there are NAs in community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$community[1:3] <-
-      NA
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "levels"
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='bins' works if there are NAs in community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$community[1:3] <-
-      NA
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "bins",
-        bin_size = 500
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='MW' works if there are NAs in community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$community[1:3] <-
-      NA
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      )
-    )
-  }
-)
-
-## Age data
-# Zeros
-test_that(
-  "prepare_data with working_units='levels' works if there are 0s in age data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age$age[1:3] <-
-      0
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "levels"
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='bins' works if there are 0s in age data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age$age[1:3] <-
-      0
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          example_data,
-          working_units = "bins",
-          bin_size = 500
-        )
-    )
-  }
-)
-
-test_that(
-  "prepare_data with working_units='MW' works if there are 0s in age data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    example_data$age$age[1:3] <-
-      0
-
-    expect_no_error(
-      prepare_data(
-        example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5
-      )
-    )
+      ncol(result[[1]][[1]]$data) - 1, # -1 for age column
+      1
+    ) 
   }
 )
 
@@ -607,7 +339,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data validates working_units parameter is not numeric",
+  "prepare_data validates working_units parameter is not NA",
   {
     example_data <-
       extract_data(
@@ -1158,222 +890,34 @@ test_that(
     )
   }
 )
-
-# 1.5 no user-defined input for working_units
-## (these tests fail because function will use defaults silently)
-test_that(
-  "prepare_data throws warning if no user-defined input for working_units is supplied",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data() %>%
-      reduce_data()
-
-    expect_warning(
-      res <-
-        prepare_data(
-          data_source_prep = data_work_mavg,
-          rand = NULL
-        ),
-      # none programmed into the function yet.
-      # e.g., "No user-defined input for working_units. Defaulting to 'levels'."
-    )
-  }
-)
-
-# 1.5.1  m.avg
-test_that(
-  "prepare_data, smooth_method = 'm.avg' uses 'levels' if no user-defined input for working_units",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data()
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          data_source_prep = data_work_mavg,
-          rand = NULL
-        )
-    )
-
-    # Control: if nothing is user-supplied, uses working_units = "levels"
-    res_levels <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "levels"
-      )
-
-    expect_identical(res, res_levels)
-  }
-)
-
-# 1.5.2. shep
-test_that(
-  "prepare_data, smooth_method = 'shep' uses 'levels' if no user-defined input for working_units",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep"
-      ) %>%
-      reduce_data()
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          data_source_prep = data_work_shep,
-          rand = NULL
-        )
-    )
-    # Control: if nothing is user-supplied, uses working_units = "levels"
-    res_levels <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "levels"
-      )
-
-    expect_identical(res, res_levels)
-  }
-)
-# 1.5.3. age.w
-test_that(
-  "prepare_data, smooth_method = 'age.w' uses 'levels' if no user-defined input for working_units",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data()
-
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          data_source_prep = data_work_agew,
-          rand = NULL
-        )
-    )
-
-    # Control: if nothing is user-supplied, uses working_units = "levels"
-    res_levels <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "levels"
-      )
-
-    expect_identical(res, res_levels)
-  }
-)
-# 1.5.4. grim
-test_that(
-  "prepare_data, smooth_method = 'grim' uses 'levels' if no user-defined input for working_units",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data()
-
-
-    expect_no_error(
-      res <-
-        prepare_data(
-          data_source_prep = data_work_grim,
-          rand = NULL
-        )
-    )
-
-    # Control: if nothing is user-supplied, uses working_units = "levels"
-    res_levels <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "levels"
-      )
-
-    expect_identical(res, res_levels)
-  }
-)
-
-
-### Bin Size ###
-
 # ---------------------------------------------------------- #
 #                   Bin_size Input Tests                     #
 # ---------------------------------------------------------- #
 
 # 1.1 "levels"
-## skipped because bin_size is not required for 'levels'
+test_that(
+  "prepare_data takes bin_size=NULL if working_units = levels",
+  {
+    example_data <-
+      extract_data(
+        data_community_extract = RRatepol::example_data$pollen_data[[1]],
+        data_age_extract = RRatepol::example_data$sample_age[[1]],
+        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+        verbose = FALSE
+      )
+    
+    expect_silent(
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels",
+        bin_size = NULL,
+        number_of_shifts = NULL,
+        rand = NULL
+      )
+    )
+  }
+)
+
 # 1.2 "bins"
 test_that(
   "prepare_data validates bin_size is numeric",
@@ -1730,32 +1274,6 @@ test_that(
   }
 )
 
-test_that(
-  "prepare_data handles small bin_size efficiently",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
-      )
-
-    # This will create many bins
-    expect_no_error(
-      result <-
-        prepare_data(
-          data_source_prep = example_data,
-          working_units = "bins",
-          bin_size = 1
-        )
-    )
-
-    # Should still return valid structure
-    expect_type(result, "list")
-    expect_true(length(result) >= 1)
-  }
-)
-
 # ---------------------------------------------------------- #
 #                Number of shifts Input Tests                #
 # ---------------------------------------------------------- #
@@ -2093,7 +1611,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data handles age_uncertainty with all identical values (returns identical age across randomizations)",
+  "prepare_data throws warning if age_uncertainty has all identical values",
   {
     example_data <-
       extract_data(
@@ -2107,16 +1625,21 @@ test_that(
     example_data$age_un[] <-
       1000
 
-    expect_no_error(
+    expect_warning(
       result <-
         prepare_data(
           data_source_prep = example_data,
           working_units = "levels",
           rand = 10
-        )
+        ),
+      #none programmed into the function yet
+      # e.g., 
+      #"Warning: age_uncertainty has only 1 unique value. 
+      # randomizations will result in identical results"
     )
 
     # All randomizations should be identical
+    # (returns identical age across randomizations)
     expect_true(
       all(
         sapply(
@@ -2169,72 +1692,6 @@ test_that(
   }
 )
 
-# fails currently
-test_that(
-  "prepare_data samples reproducibly if age_un is supplied, rand = 1 and no seed set manually",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res1 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 1
-      )
-
-    res2 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 1
-      )
-
-    expect_identical(res1, res2)
-  }
-)
-
-test_that(
-  "prepare_data samples reproducibly if age_un = NULL and rand > 1 and no seed set manually",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = NULL,
-        verbose = FALSE
-      )
-
-    res1 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 1
-      )
-
-    res2 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 1
-      )
-
-    expect_identical(res1, res2)
-  }
-)
 
 test_that(
   "prepare_data does not change age if no age_uncertainty in data",
@@ -2264,7 +1721,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data changes age if age_uncertainty is in data",
+  "prepare_data changes age if age_uncertainty is in data and working_units = MW",
   {
     example_data <-
       extract_data(
@@ -2293,7 +1750,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data changes age if age_uncertainty is in data",
+  "prepare_data changes age if age_uncertainty is in data and working_units = levels",
   {
     example_data <-
       extract_data(
@@ -2320,7 +1777,7 @@ test_that(
 )
 
 test_that(
-  "prepare_data changes age if age_uncertainty is in data",
+  "prepare_data changes age if age_uncertainty is in data and working_units = bins",
   {
     example_data <-
       extract_data(
@@ -2413,7 +1870,6 @@ test_that(
   }
 )
 
-# Fails because assertion for bin_size is in the wrong position in the function
 test_that(
   "prepare_data returns the correct output structure with default parameters (levels)",
   {
@@ -2429,7 +1885,7 @@ test_that(
       prepare_data(
         data_source_prep = example_data,
         working_units = "levels",
-        bin_size = NULL,
+        #bin_size = NULL,
         number_of_shifts = NULL,
         rand = NULL
       )
@@ -2659,12 +2115,6 @@ test_that(
   }
 )
 
-
-
-
-
-
-
 # ------------------------------------------------- #
 # Tests using internal estimate_roc workflow:       #
 #                   Errors                          #
@@ -2808,10 +2258,10 @@ test_that(
         rand = NULL
       )
 
-    expect_identical(
+    expect_true(identical(
       data_prepared_rand_1,
       data_prepared_rand_null
-    )
+    ))
   }
 )
 
@@ -2866,7 +2316,7 @@ test_that(
 
 # Is rand ignored if no age_un? - no. but results are identical.
 test_that(
-  "prepare_data ignores rand parameter if no age_un is supplied",
+  "prepare_data throws warning if rand parameter is supplied but not age_un",
   {
     community <-
       RRatepol::example_data$pollen_data[[1]]
@@ -2891,303 +2341,18 @@ test_that(
         data_smoothed
       )
 
-    data_prepared_rand_1 <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 1
-      )
-
+    expect_warning(
     data_prepared_rand_100 <-
       prepare_data(
         data_work,
         working_units = "MW",
         number_of_shifts = 1,
         rand = 100
-      )
-
-    # Expect that rand is ignored if no age_un is supplied:
-    expect_true(
-      length(data_prepared_rand_100) == length(data_prepared_rand_1)
-    )
-
-    # # both results are identical
-    # expect_identical(
-    #   data_prepared_rand_1[[1]][[1]]$bins,
-    #   data_prepared_rand_100[[2]][[1]]$bins
-    # )
-
-    # # all "randomized" samples are identical inside the same result
-    # expect_identical(
-    #   data_prepared_rand_100[[1]][[1]]$bins,
-    #   data_prepared_rand_100[[2]][[1]]$bins
-    # )
-
-    # expect_identical(
-    #   data_prepared_rand_100[[1]][[1]]$bins,
-    #   data_prepared_rand_100[[100]][[1]]$bins
-    # )
-  }
-)
-
-test_that(
-  "prepare_data returns identical results across randomizations if age_un is not supplied but rand is",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-
-    data_extract <-
-      extract_data(
-        community,
-        age
-      )
-
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
-
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
-
-    data_prepared_rand_100 <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      )
-
-    # Test if all elements in data_prepared_rand_100 are identical
-    expect_true(
-      all(
-        vapply(
-          data_prepared_rand_100[-1],
-          function(
-              x) {
-            identical(
-              x, data_prepared_rand_100[[1]]
-            )
-          },
-          logical(1)
-        )
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data handles only 1 age_uncertainty row with high rand values - expect identical results across randomizations",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-
-    # Test 1: What happens with only 1 row of age_un but rand = 100?
-    age_un_1row <-
-      RRatepol::example_data$age_uncertainty[[1]][1, 1:63, drop = FALSE]
-
-    data_extract_1row <-
-      extract_data(
-        community,
-        age,
-        age_un_1row
-      )
-
-    data_smoothed_1row <-
-      smooth_community_data(
-        data_extract_1row,
-        smooth_method = "age.w"
-      )
-
-    data_work_1row <-
-      reduce_data(
-        data_smoothed_1row
-      )
-
-    data_prepared_1row <-
-      prepare_data(
-        data_work_1row,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      )
-
-    # With only 1 row, ALL samples should be identical (sampling with replacement from 1 value)
-    expect_equal(
-      length(
-        data_prepared_1row
       ),
-      100
-    )
-
-    expect_true(
-      all(
-        vapply(
-          data_prepared_1row[-1],
-          function(
-              x) {
-            identical(
-              x[[1]]$data$age, data_prepared_1row[[1]][[1]]$data$age
-            )
-          },
-          logical(1)
-        )
-      )
-    )
-  }
-)
-
-test_that(
-  "prepare_data handles only 2 age_uncertainty rows with high rand values",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    # Test 2: What happens with 2 rows of age_un but rand = 100?
-    age_un_2rows <-
-      RRatepol::example_data$age_uncertainty[[1]][1:2, 1:63]
-
-    data_extract_2rows <-
-      extract_data(
-        community,
-        age,
-        age_un_2rows
-      )
-    data_smoothed_2rows <-
-      smooth_community_data(data_extract_2rows, smooth_method = "age.w")
-    data_work_2rows <-
-      reduce_data(data_smoothed_2rows)
-
-    data_prepared_2rows <-
-      prepare_data(
-        data_work_2rows,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      )
-
-    # With 2 rows, we should see some variation (not all identical)
-    expect_equal(length(data_prepared_2rows), 100)
-    expect_false(
-      all(
-        vapply(
-          data_prepared_2rows[-1], # compare all to the first
-          function(x) {
-            identical(
-              x[[1]]$data$age, data_prepared_2rows[[1]][[1]]$data$age
-            )
-          },
-          logical(1)
-        )
-      )
-    )
-
-    # Test 3: Verify sampling distribution with 2 rows
-    # Extract all age vectors and count unique patterns
-    age_vectors <-
-      lapply(data_prepared_2rows, function(x) x[[1]]$data$age)
-    unique_age_patterns <-
-      length(unique(age_vectors))
-
-    # Should have at most 2 unique patterns (since only 2 rows available)
-    expect_true(unique_age_patterns <= 2)
-    expect_true(unique_age_patterns >= 1)
-  }
-)
-
-test_that(
-  "prepare_data: with only 2 age_uncertainty rows and high rand, produces at most 2 unique randomizations, and full uncertainty produces more unique samples",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    # Test 2: What happens with 2 rows of age_un but rand = 100?
-    age_un_2rows <-
-      RRatepol::example_data$age_uncertainty[[1]][1:2, 1:63]
-
-    data_extract_2rows <-
-      extract_data(
-        community,
-        age,
-        age_un_2rows
-      )
-    data_smoothed_2rows <-
-      smooth_community_data(data_extract_2rows, smooth_method = "age.w")
-    data_work_2rows <-
-      reduce_data(data_smoothed_2rows)
-
-    data_prepared_2rows <-
-      prepare_data(
-        data_work_2rows,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      )
-
-    # Extract all age vectors and count unique patterns
-    age_vectors <-
-      lapply(data_prepared_2rows, function(x) x[[1]]$data$age)
-    unique_age_patterns <-
-      length(unique(age_vectors))
-
-    # Test 4: Control - compare against full uncertainty data
-    age_un_full <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_extract_full <-
-      extract_data(
-        community,
-        age,
-        age_un_full
-      )
-    data_smoothed_full <-
-      smooth_community_data(
-        data_extract_full,
-        smooth_method = "age.w"
-      )
-
-    data_work_full <-
-      reduce_data(
-        data_smoothed_full
-      )
-
-    data_prepared_full <-
-      prepare_data(
-        data_work_full,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      )
-
-    # Full uncertainty should have more variation than limited rows
-    age_vectors_full <-
-      lapply(
-        data_prepared_full,
-        function(
-            x) {
-          x[[1]]$data$age
-        }
-      )
-    unique_patterns_full <-
-      length(
-        unique(
-          age_vectors_full
-        )
-      )
-
-    expect_true(
-      unique_patterns_full > unique_age_patterns
+    #none programmed into function yet
+    # e.g., 
+    # "Warning: setting rand != NULL without age_un will result 
+    # in identical randomization results."
     )
   }
 )
@@ -4495,945 +3660,6 @@ test_that(
   }
 )
 
-## 2.1.2a) one row in age 0
-# -> no effect or reaction from function. Is just ignored.
-
-### ------ Review required ------- ###
-
-## Below are some tests where I manually fix some bugs
-## from upstream functions within each unit test and compare the
-## results to the expected results after fixing the bug.
-
-# To Do: Double-check below (NAs in age.)
-
-## 2.1.2b) one row in age NA
-# ---- levels ---- #
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # Control for when NA row is exculded from all data sources:
-    age_dropped <-
-      age %>%
-      na.omit()
-
-    community_dropped <-
-      community[-1, ]
-
-    age_un_dropped <-
-      age_uncertainty[, -1]
-
-    data_dropped <-
-      extract_data(
-        data_community_extract = community_dropped,
-        data_age_extract = age_dropped,
-        age_uncertainty = age_un_dropped
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res_dropped <-
-      prepare_data(
-        data_source_prep = data_dropped,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    expect_identical(
-      res,
-      res_dropped
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # Control for when NA row is exculded from all data sources:
-    age_dropped <-
-      age %>%
-      na.omit()
-    community_dropped <-
-      community[-1, ]
-    age_un_dropped <-
-      age_uncertainty[, -1]
-
-    data_dropped <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res_dropped <-
-      prepare_data(
-        data_source_prep = data_dropped,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    expect_identical(
-      res,
-      res_dropped
-    )
-  }
-)
-
-test_that(
-  "prepare_data and working_units = 'levels' works with one row NA in age (correct results)",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # Control for when NA row is exculded from all data sources:
-    age_dropped <-
-      age %>%
-      na.omit()
-    community_dropped <-
-      community[-1, ]
-    age_un_dropped <-
-      age_uncertainty[, -1]
-
-    data_dropped <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res_dropped <-
-      prepare_data(
-        data_source_prep = data_dropped,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    expect_identical(
-      res,
-      res_dropped
-    )
-  }
-)
-
-# fails because smooth_community_data cannot handle NA
-test_that(
-  "prepare_data and working_units = 'levels' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_grim$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_grim$age <-
-      data_work_grim$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_grim$community <-
-      data_work_grim$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_grim$age_un <-
-      data_work_grim$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-
-    # expect no more NAs in age
-    expect_false(
-      any(
-        is.na(
-          res[[1]][[1]]$data$age
-        )
-      )
-    )
-
-    # expect no NAs in age-derivates
-    expect_false(
-      any(
-        is.na(
-          res[[1]][[1]]$bin$age_diff
-        )
-      )
-    )
-
-    # expect no NAs in age-derivates
-    expect_false(
-      any(
-        is.na(
-          res[[1]][[1]]$bin$res_age
-        )
-      )
-    )
-  }
-)
-
-
-# --- bins --- #
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_mavg$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_mavg$age <-
-      data_work_mavg$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_mavg$community <-
-      data_work_mavg$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_mavg$age_un <-
-      data_work_mavg$age_un %>%
-      select(valid_samples)
-
-    # use modified result for prepare_data()
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_shep$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_shep$age <-
-      data_work_shep$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_shep$community <-
-      data_work_shep$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_shep$age_un <-
-      data_work_shep$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_agew$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_agew$age <-
-      data_work_agew$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_agew$community <-
-      data_work_agew$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_agew$age_un <-
-      data_work_agew$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_grim$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_grim$age <-
-      data_work_grim$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_grim$community <-
-      data_work_grim$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_grim$age_un <-
-      data_work_grim$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-# --- MW --- #
-
-test_that(
-  "prepare_data and working_units = 'MW' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-    valid_samples <-
-      age %>%
-      na.omit() %>%
-      pull(sample_id)
-
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_mavg$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_mavg$age <-
-      data_work_mavg$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_mavg$community <-
-      data_work_mavg$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_mavg$age_un <-
-      data_work_mavg$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_shep$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_shep$age <-
-      data_work_shep$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_shep$community <-
-      data_work_shep$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_shep$age_un <-
-      data_work_shep$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-    valid_samples <-
-      age %>%
-      na.omit() %>%
-      pull(sample_id)
-
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_agew$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_agew$age <-
-      data_work_agew$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_agew$community <-
-      data_work_agew$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_agew$age_un <-
-      data_work_agew$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    age$age[1] <-
-      NA
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    valid_samples <-
-      data_work_grim$age %>%
-      na.omit() %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      pull(sample_id)
-
-    # Simulating to fix the bugs in extract_data() and reduce_data():
-    # drop NAs from age manually
-    data_work_grim$age <-
-      data_work_grim$age %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    # perform two-way matching with community and age_un manually
-    data_work_grim$community <-
-      data_work_grim$community %>%
-      tibble::rownames_to_column(var = "sample_id") %>%
-      filter(sample_id %in% valid_samples) %>%
-      select(-sample_id)
-
-    data_work_grim$age_un <-
-      data_work_grim$age_un %>%
-      select(valid_samples)
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
 
 # ---------------- Check for NAs in output ------------------ #
 # NAs in age (known issue)
@@ -6052,95 +4278,3 @@ test_that(
   }
 )
 
-#####################
-## To Dos:
-# - Double check if the expectation shouldn't be the reverse below for age_un
-#####################
-
-
-## 2.1.3b) one column in age_un NA
-# # NAs in Age_uncertainty
-# test_that(
-#   "prepare_data with working_units='levels' works if there are NAs in age_un data",
-#   {
-#     example_data <-
-#       extract_data(
-#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
-#         data_age_extract = RRatepol::example_data$sample_age[[1]],
-#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#         verbose = FALSE
-#       )
-
-#     example_data$age_un[1:3] <-
-#       NA
-
-#     expect_no_error(
-#       res <-
-#         prepare_data(
-#           example_data,
-#           working_units = "levels",
-#           rand = 1
-#         )
-#     )
-
-#     expect_identical(
-#       res[[1]][[1]]$data$age[1:3],
-#       as.numeric(c(NA, NA, NA))
-#     )
-#   }
-# )
-
-# test_that(
-#   "prepare_data with working_units='bins' works if there are NAs in age_un data",
-#   {
-#     example_data <-
-#       extract_data(
-#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
-#         data_age_extract = RRatepol::example_data$sample_age[[1]],
-#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#         verbose = FALSE
-#       )
-
-#     example_data$age_un[1:3] <-
-#       NA
-
-#     expect_no_error(
-#       prepare_data(
-#         example_data,
-#         working_units = "bins",
-#         bin_size = 500,
-#         rand = 1
-#       )
-#     )
-#   }
-# )
-
-# test_that(
-#   "prepare_data with working_units='MW' returns NA in data if there is NA in age_uncertainty",
-#   {
-#     example_data <-
-#       extract_data(
-#         data_community_extract = RRatepol::example_data$pollen_data[[1]],
-#         data_age_extract = RRatepol::example_data$sample_age[[1]],
-#         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#         verbose = FALSE
-#       )
-
-#     example_data$age_un[1:3] <-
-#       NA
-
-#     expect_no_error(
-#       res <-
-#         prepare_data(
-#           example_data,
-#           working_units = "MW",
-#           bin_size = 500,
-#           number_of_shifts = 5,
-#           rand = 1
-#         )
-#     )
-
-#     # returns NA in output$age
-#     expect_true(any(is.na(res[[1]][[1]]$data$age)))
-#   }
-# )


### PR DESCRIPTION
Updated test suites for `prepare_data()` and internal function `make_bins()`.
I excluded tests for invalid data input that are already handled by upstream functions. 