### PR TITLE
Fix bugs in extract_data() 

### DIFF
--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -113,7 +113,7 @@ extract_data <-
     )
 
     if (
-      isFALSE(is.unsorted(data_age_extract$age))
+      isTRUE(is.unsorted(data_age_extract$age))
     ) {
       # order of the age
       data_age_extract <-
@@ -178,7 +178,7 @@ extract_data <-
       # save as dataframe
       age_un <- data.frame(age_uncertainty)
 
-      names(age_un) <- dat_age$sample_id
+      names(age_un) <- row.names(dat_age)
     } else {
       age_un <- NULL
     }
@@ -205,7 +205,7 @@ extract_data <-
     }
 
     if (
-      any(is.na(dat_community$age))
+      any(is.na(dat_age$age))
     ) {
       RUtilpol::output_warning(
         paste(


### PR DESCRIPTION

This pull request makes several corrections to the `extract_data` function in `R/extract_data.R`, primarily focusing on fixing logic errors and ensuring that the correct data frames and columns are referenced. These changes help improve the reliability and accuracy of the data extraction process.

- fix #48
- fix #49 
- fix #50 

**Bug fixes and logic corrections:**

* Fixed the condition for checking if the `age` column in `data_age_extract` is unsorted, so that the data is now ordered when necessary.
* Corrected the assignment of column names for the `age_un` data frame to use row names from `dat_age` instead of the `sample_id` column, ensuring proper labeling.
* Fixed the check for missing values in the `age` column to reference `dat_age` instead of `dat_community`, ensuring the warning is triggered for the correct dataset.

