### PR TITLE
`prepare_data()`: Removed orphaned 'res' object from return() 

### DIFF
--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -170,7 +170,7 @@ prepare_data <-
                                 ) %>%
                                     return()
                         ) %>%
-                            return(res)
+                            return()
                     }
                 ) %>%
                 return()


### PR DESCRIPTION
This pull request makes a minor change to the `prepare_data` function in `R/prepare_data.R`, simplifying a return statement to improve code clarity.
- fix #55
