### PR TITLE
Fixed bug in `estimate_dissimilarity_coefficient()`

### DIFF
--- a/R/estimate_dissimilarity_coefficient.R
+++ b/R/estimate_dissimilarity_coefficient.R
@@ -181,7 +181,7 @@ estimate_dissimilarity_coefficient <-
         as.matrix(
           vegan::vegdist(
             data_com,
-            method = "chord"
+            method = "chisq"
           )
         )
     }


### PR DESCRIPTION
Changed method supplied to `vegan::vegdist()` from `"chord"` to `"chisq"`
- #56 