### PR TITLE
Fixed bug in `detect_peak_points()`

### DIFF
--- a/R/detect_peak_points.R
+++ b/R/detect_peak_points.R
@@ -222,12 +222,12 @@ detect_peak_points <-
 
       gam_deriv <-
         gratia::derivatives(gam_model,
-          newdata = new_data,
+          data = new_data,
           n = 1000
         )
 
       data_source$Peak <-
-        (gam_deriv$lower > 0)
+        (gam_deriv$.lower_ci > 0)
     }
 
     #----------------------------------------------------------#


### PR DESCRIPTION
This pull request makes a small update to the `detect_peak_points` function in `R/detect_peak_points.R` to ensure compatibility with the latest output from the `gratia::derivatives` function.

- The code now uses the `.lower_ci` column instead of `lower` when determining peak points, reflecting changes in the `gratia` package output.
- fix #69 