### PR TITLE
Fixed bug in `subset_samples()`

### DIFF
--- a/R/subset_samples.R
+++ b/R/subset_samples.R
@@ -75,6 +75,9 @@ subset_samples <-
           res_com[i, ] <-
             subset_w[1, -1]
         }
+      } else {
+        res_com[i, ] <-
+          rep(0, ncol(data_source_subset) - 1)
       }
     }
 


### PR DESCRIPTION
`subset_samples()` used to return NA if a time period had 0 observations.
Instead of copying NAs to the result, it now adds a row of 0. These will be dropped in the next step with `reduce_data_simple()`.
- fix #61 
