### PR TITLE
Added NA counts to `check_data()` 

### DIFF
--- a/R/check_data.R
+++ b/R/check_data.R
@@ -1,4 +1,3 @@
-
 #' @title Check the data
 #'
 #' @param data_source_check
@@ -19,10 +18,11 @@ check_data <-
 
     RUtilpol::output_comment(
       paste0(
-        "Age data has values of min ", round(min(data_source_check$age$age)),
-        ", max ", round(max(data_source_check$age$age)),
-        ", mean ", round(mean(data_source_check$age$age)),
-        ", and median ", round(stats::median(data_source_check$age$age))
+        "Age data has values of min ", round(min(data_source_check$age$age, na.rm = TRUE)),
+        ", max ", round(max(data_source_check$age$age, na.rm = TRUE)),
+        ", mean ", round(mean(data_source_check$age$age, na.rm = TRUE)),
+        ", median ", round(stats::median(data_source_check$age$age, na.rm = TRUE)),
+        ", and NAs ", sum(is.na(data_source_check$age$age))
       )
     )
   }

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -8,11 +8,70 @@ check_data <-
   function(data_source_check) {
     RUtilpol::check_class("data_source_check", "list")
 
+    assertthat::assert_that(
+      nrow(data_source_check$community) > 0,
+      ncol(data_source_check$community) >= 1,
+      nrow(data_source_check$age) > 0,
+      ncol(data_source_check$age) == 1,
+      msg = "Error: Object 'data_source_check' was supplied with empty elements: 'community' and 'age'"
+    )
+    ## 1. dimensions
+    dims <-
+      lapply(data_source_check, dim)
+
+    if (length(dims) == 3) {
+      RUtilpol::output_comment(
+        paste(
+          "Community data have", dims$community[2],
+          "taxa and", dims$community[1], "samples.",
+          "Age data have", dims$age[1], "samples.",
+          "Age uncertainty data have", dims$age_un[2], "samples."
+        )
+      )
+    } else if (length(dims) == 2) {
+      RUtilpol::output_comment(
+        paste(
+          "Community data have", dims$community[2],
+          "taxa and", dims$community[1], "samples.",
+          "Age data have", dims$age[1], "samples.",
+          "Age uncertainty was not provided."
+        )
+      )
+    }
+
+    # 2. Missing data
+    nas <-
+      lapply(data_source_check, function(x) {
+        sum(is.na(x))
+      })
+
+    if (length(nas) == 3) {
+      RUtilpol::output_comment(
+        paste(
+          "Community data has", nas$community, "NAs.",
+          "Age data has", nas$age, "NAs.",
+          "Age uncertainty data has", nas$age_un, "NAs."
+        )
+      )
+    } else if (length(nas) == 2) {
+      RUtilpol::output_comment(
+        paste(
+          "Community data has", nas$community, "NAs.",
+          "Age data has", nas$age, "NAs.",
+          "Age uncertainty was not provided."
+        )
+      )
+    }
+
+    # 3. Summary of data
     RUtilpol::output_comment(
-      paste(
-        "Community data have", ncol(data_source_check$community),
-        "taxa and", nrow(data_source_check$community), "samples.",
-        " Age data have", nrow(data_source_check$age), "samples"
+      paste0(
+        "Community data has a value of min ",
+        round(min(rowSums(data_source_check$community, na.rm = TRUE))),
+        ", max ", round(max(rowSums(data_source_check$community, na.rm = TRUE))),
+        ", mean ", round(mean(rowSums(data_source_check$community, na.rm = TRUE))),
+        ", and median ", round(stats::median(rowSums(data_source_check$community, na.rm = TRUE))),
+        " observations."
       )
     )
 
@@ -21,8 +80,7 @@ check_data <-
         "Age data has values of min ", round(min(data_source_check$age$age, na.rm = TRUE)),
         ", max ", round(max(data_source_check$age$age, na.rm = TRUE)),
         ", mean ", round(mean(data_source_check$age$age, na.rm = TRUE)),
-        ", median ", round(stats::median(data_source_check$age$age, na.rm = TRUE)),
-        ", and NAs ", sum(is.na(data_source_check$age$age))
+        ", and median ", round(stats::median(data_source_check$age$age, na.rm = TRUE))
       )
     )
   }

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -42,34 +42,11 @@ test_that(
         verbose = FALSE
       )
 
-    msg <-
-      suppressWarnings(
-        capture.output(
-          check_data(
-            result_empty
-          ),
-          type = "message"
-        )
-      )
-
-
-    # Now check that check_data() reproduces the empty input data
-    expect_true(
-      any(
-        grepl(
-          "Community data have 0 taxa and 0 samples.  Age data have 0 samples",
-          msg
-        )
-      )
-    )
-
-    expect_true(
-      any(
-        grepl(
-          "Age data has values of min Inf, max -Inf, mean NaN, and median NA",
-          msg
-        )
-      )
+    expect_error(
+      check_data(
+        result_empty
+      ),
+      "Object 'data_source_check' was supplied with empty elements: 'community' and 'age'"
     )
   }
 )
@@ -113,13 +90,14 @@ test_that(
         type = "message"
       )
 
-    expect_false(
+    expect_true(
       any(
         grepl(
-          "Age data has values of min NA, max NA, mean NA, and median NA",
+          "Community data has 0 NAs. Age data has 6 NAs. Age uncertainty data has 6 NAs.",
           msg
         )
       )
     )
+
   }
 )


### PR DESCRIPTION
`check_data()` used to return NA if there was NA in age$age. Now it counts how many NAs there are and returns the correct statistical descriptor after removing the NAs. 
- fix #43
- fix #47 