### PR TITLE
`smooth_community_data()`: added argument assertions

### DIFF
--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -41,43 +41,39 @@ smooth_community_data <-
     # ----------------------------------------------
     # SETUP -----
     # ----------------------------------------------
+    # Mandatory assertions for all methods:
+    # Assert data_source_smooth is a list
+    assertthat::assert_that(is.list(data_source_smooth), msg = "'data_source_smooth' must be a list")
 
-    RUtilpol::check_class("data_source_smooth", "list")
+    # Assert smooth_method is character and valid
+    assertthat::assert_that(is.character(smooth_method), msg = "'smooth_method' must be character")
+    smooth_method <- match.arg(smooth_method, choices = c("m.avg", "grim", "age.w", "shep"))
 
-    RUtilpol::check_class("smooth_method", "character")
+    # Assert smooth_n_points is numeric
+    assertthat::assert_that(is.numeric(smooth_n_points), msg = "'smooth_n_points' must be numeric")
+    assertthat::assert_that(smooth_n_points < nrow(data_source_smooth$community), msg = "'smooth_n_points' must be < number of samples in 'community'")
 
-    RUtilpol::check_vector_values(
-      "smooth_method",
-      c("m.avg", "grim", "age.w", "shep")
-    )
+    # Assert that logical parameters are logical and either TRUE or FALSE
+    assertthat::assert_that(is.logical(round_results) && length(round_results) == 1 && (round_results == TRUE || round_results == FALSE), msg = "'round_results' must be logical and either TRUE or FALSE")
+    assertthat::assert_that(is.logical(verbose) && length(verbose) == 1 && (verbose == TRUE || verbose == FALSE), msg = "'verbose' must be logical and either TRUE or FALSE")
 
-    smooth_method <- match.arg(smooth_method)
+    # Method-specific assertions:
+    if (smooth_method == "shep") {
+      # must be > 2
+      assertthat::assert_that(smooth_n_points > 2, msg = "'smooth_n_points' must be > 2 for 'shep' smoothing")
+    }
 
-    if (
-      smooth_method != "shep"
-    ) {
-      assertthat::assert_that(
-        smooth_n_points %% 2 != 0,
-        msg = "'smooth_n_points' must be an odd number"
-      )
+    if (smooth_method %in% c("m.avg", "age.w", "grim")) {
+      # must be odd
+      assertthat::assert_that(smooth_n_points %% 2 != 0, msg = "'smooth_n_points' must be odd")
 
-      if (
-        smooth_method != "m.avg"
-      ) {
-        RUtilpol::check_class("smooth_age_range", "numeric")
+      if (smooth_method %in% c("age.w", "grim")) {
+        # smooth_age_range must be numeric
+        assertthat::assert_that(is.numeric(smooth_age_range), msg = "'smooth_age_range' must be numeric")
 
-        if (
-          smooth_method == "grim"
-        ) {
-          assertthat::assert_that(
-            smooth_n_max %% 2 != 0,
-            msg = "'smooth_n_max' must be an odd number"
-          )
-
-          assertthat::assert_that(
-            smooth_n_points < smooth_n_max,
-            msg = "'smooth_n_max' must be bigger than 'smooth_n_points"
-          )
+        if (smooth_method == "grim") {
+          # smooth_n_points must be < smooth_n_max
+          assertthat::assert_that(smooth_n_points < smooth_n_max, msg = "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing")
         }
       }
     }

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -154,6 +154,10 @@ smooth_community_data <-
             msg = "'smooth_n_max' must be numeric"
           )
           assertthat::assert_that(
+            smooth_n_max %% 2 != 0,
+            msg = "'smooth_n_max' must be odd"
+          )
+          assertthat::assert_that(
             length(smooth_n_max) == 1,
             msg = "'smooth_n_max' must be length 1"
           )

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -79,11 +79,7 @@ smooth_community_data <-
       !any(is.na(data_source_smooth$age)),
       msg = "'age' must not contain any NAs"
     )
-    # Assert that age has more than 1 unique value
-    assertthat::assert_that(
-      length(unique(data_source_smooth$age$age)) > 1,
-      msg = "'age' must contain more than 1 unique value"
-    )
+
     # Assert age is sorted
     assertthat::assert_that(
       is.unsorted(data_source_smooth$age$age) == FALSE,
@@ -109,8 +105,8 @@ smooth_community_data <-
       msg = "'smooth_n_points' must be numeric"
     )
     assertthat::assert_that(
-      smooth_n_points < nrow(data_source_smooth$community),
-      msg = "'smooth_n_points' must be < number of samples in 'community'"
+      smooth_n_points <= nrow(data_source_smooth$community),
+      msg = "'smooth_n_points' must be <= number of samples in 'community'"
     )
     # Assert that logical parameters are logical and either TRUE or FALSE
     assertthat::assert_that(
@@ -154,12 +150,16 @@ smooth_community_data <-
         if (smooth_method == "grim") {
           # smooth_n_max must be length 1
           assertthat::assert_that(
+            is.numeric(smooth_n_max),
+            msg = "'smooth_n_max' must be numeric"
+          )
+          assertthat::assert_that(
             length(smooth_n_max) == 1,
             msg = "'smooth_n_max' must be length 1"
           )
           assertthat::assert_that(
-            smooth_n_max < nrow(data_source_smooth$community),
-            msg = "'smooth_n_max' must be < number of samples in 'community'"
+            smooth_n_max <= nrow(data_source_smooth$community),
+            msg = "'smooth_n_max' must be <= number of samples in 'community'"
           )
           # smooth_n_points must be < smooth_n_max
           assertthat::assert_that(

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -37,43 +37,135 @@ smooth_community_data <-
            smooth_age_range = 500,
            round_results = FALSE,
            verbose = FALSE) {
-
     # ----------------------------------------------
     # SETUP -----
     # ----------------------------------------------
     # Mandatory assertions for all methods:
     # Assert data_source_smooth is a list
-    assertthat::assert_that(is.list(data_source_smooth), msg = "'data_source_smooth' must be a list")
-
+    assertthat::assert_that(
+      is.list(data_source_smooth),
+      msg = "'data_source_smooth' must be a list"
+    )
+    # Assert that community is not empty
+    assertthat::assert_that(
+      nrow(data_source_smooth$community) > 0,
+      msg = "'community' must have at least one row"
+    )
+    assertthat::assert_that(
+      ncol(data_source_smooth$community) > 0,
+      msg = "'community' must have at least one column"
+    )
+    # Assert community and age have the same rownames
+    assertthat::assert_that(
+      identical(
+        rownames(data_source_smooth$community),
+        rownames(data_source_smooth$age)
+      ),
+      msg = "'community' and 'age' must have identical rownames"
+    )
+    # Assert all values in community are numeric
+    assertthat::assert_that(
+      all(
+        sapply(data_source_smooth$community, is.numeric)
+      ),
+      msg = "All values in 'community' must be numeric"
+    )
+    # Assert that there are no NAs
+    assertthat::assert_that(
+      !any(is.na(data_source_smooth$community)),
+      msg = "'community' must not contain any NAs"
+    )
+    assertthat::assert_that(
+      !any(is.na(data_source_smooth$age)),
+      msg = "'age' must not contain any NAs"
+    )
+    # Assert that age has more than 1 unique value
+    assertthat::assert_that(
+      length(unique(data_source_smooth$age$age)) > 1,
+      msg = "'age' must contain more than 1 unique value"
+    )
+    # Assert age is sorted
+    assertthat::assert_that(
+      is.unsorted(data_source_smooth$age$age) == FALSE,
+      msg = "'age' must be sorted in increasing order"
+    )
     # Assert smooth_method is character and valid
-    assertthat::assert_that(is.character(smooth_method), msg = "'smooth_method' must be character")
-    smooth_method <- match.arg(smooth_method, choices = c("m.avg", "grim", "age.w", "shep"))
-
-    # Assert smooth_n_points is numeric
-    assertthat::assert_that(is.numeric(smooth_n_points), msg = "'smooth_n_points' must be numeric")
-    assertthat::assert_that(smooth_n_points < nrow(data_source_smooth$community), msg = "'smooth_n_points' must be < number of samples in 'community'")
-
+    assertthat::assert_that(
+      is.character(smooth_method),
+      msg = "'smooth_method' must be character"
+    )
+    smooth_method <-
+      match.arg(
+        smooth_method,
+        choices = c("m.avg", "grim", "age.w", "shep")
+      )
+    # Assert smooth_n_points is only 1 argument, numeric and smaller than N samples
+    assertthat::assert_that(
+      length(smooth_n_points) == 1,
+      msg = "'smooth_n_points' must be length 1"
+    )
+    assertthat::assert_that(
+      is.numeric(smooth_n_points),
+      msg = "'smooth_n_points' must be numeric"
+    )
+    assertthat::assert_that(
+      smooth_n_points < nrow(data_source_smooth$community),
+      msg = "'smooth_n_points' must be < number of samples in 'community'"
+    )
     # Assert that logical parameters are logical and either TRUE or FALSE
-    assertthat::assert_that(is.logical(round_results) && length(round_results) == 1 && (round_results == TRUE || round_results == FALSE), msg = "'round_results' must be logical and either TRUE or FALSE")
-    assertthat::assert_that(is.logical(verbose) && length(verbose) == 1 && (verbose == TRUE || verbose == FALSE), msg = "'verbose' must be logical and either TRUE or FALSE")
+    assertthat::assert_that(
+      is.logical(round_results) && length(round_results) == 1 && (round_results == TRUE || round_results == FALSE),
+      msg = "'round_results' must be logical and either TRUE or FALSE"
+    )
+    assertthat::assert_that(
+      is.logical(verbose) && length(verbose) == 1 && (verbose == TRUE || verbose == FALSE),
+      msg = "'verbose' must be logical and either TRUE or FALSE"
+    )
+
 
     # Method-specific assertions:
     if (smooth_method == "shep") {
       # must be > 2
-      assertthat::assert_that(smooth_n_points > 2, msg = "'smooth_n_points' must be > 2 for 'shep' smoothing")
+      assertthat::assert_that(
+        smooth_n_points > 2,
+        msg = "'smooth_n_points' must be > 2 for 'shep' smoothing"
+      )
     }
 
     if (smooth_method %in% c("m.avg", "age.w", "grim")) {
       # must be odd
-      assertthat::assert_that(smooth_n_points %% 2 != 0, msg = "'smooth_n_points' must be odd")
+      assertthat::assert_that(
+        smooth_n_points %% 2 != 0,
+        msg = "'smooth_n_points' must be odd"
+      )
 
       if (smooth_method %in% c("age.w", "grim")) {
+        # smooth_age_range must be length 1
+        assertthat::assert_that(
+          length(smooth_age_range) == 1,
+          msg = "'smooth_age_range' must be length 1"
+        )
         # smooth_age_range must be numeric
-        assertthat::assert_that(is.numeric(smooth_age_range), msg = "'smooth_age_range' must be numeric")
+        assertthat::assert_that(
+          is.numeric(smooth_age_range),
+          msg = "'smooth_age_range' must be numeric"
+        )
 
         if (smooth_method == "grim") {
+          # smooth_n_max must be length 1
+          assertthat::assert_that(
+            length(smooth_n_max) == 1,
+            msg = "'smooth_n_max' must be length 1"
+          )
+          assertthat::assert_that(
+            smooth_n_max < nrow(data_source_smooth$community),
+            msg = "'smooth_n_max' must be < number of samples in 'community'"
+          )
           # smooth_n_points must be < smooth_n_max
-          assertthat::assert_that(smooth_n_points < smooth_n_max, msg = "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing")
+          assertthat::assert_that(
+            smooth_n_points < smooth_n_max,
+            msg = "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
+          )
         }
       }
     }
@@ -176,7 +268,6 @@ smooth_community_data <-
 
     # for every species
     for (j in 1:ncol(dat_community)) {
-
       # select the species
       col_work <- .subset2(dat_community, j)
 
@@ -191,7 +282,6 @@ smooth_community_data <-
         if (
           smooth_method == "m.avg"
         ) {
-
           # Samples near beginning (moving window truncated)
           if (
             i < round(0.5 * (smooth_n_points)) + 1
@@ -225,7 +315,6 @@ smooth_community_data <-
         if (
           smooth_method == "grim"
         ) {
-
           # Samples near beginning (moving window truncated)
           if (
             i < round(0.5 * (smooth_n_max)) + 1
@@ -283,7 +372,6 @@ smooth_community_data <-
         if (
           smooth_method == "age.w"
         ) {
-
           # Samples near beginning (moving window truncated)
           if (
             i < round(0.5 * (smooth_n_points)) + 1


### PR DESCRIPTION
I have implemented additional assertions to `smooth_community_data()` to accomodate the test units that fail. 
Implementation of this PR should lead to less failing tests for the function - however, since I standardised some code, previous error messages have also changed. 
To adapt to these changes, I have created a new branch ('message-updates-new-assertions-test-smooth_community_data', #105 ) based on #53 where I updated the new error messages in the test-file. There are no more tests that fail for `smooth_community_data()` after merging the two new branches into 1.3.0.
Order should be: 
first #53, then this one #104 , then #105

- fix #51 
- fix #83

### Specific assertions in the function now:
- ✅`data_source_smooth`  = list  (replaced with assert that)
- 🆕`data_source_smooth$community` nrow > 0 & ncol  > 0
- 🆕`data_source_smooth$community` and `$age` have identical rownames
- 🆕all values in `community` are numeric
- 🆕`age` has to be sorted
- ✅`smooth_method` = character (replaced with assert that )
- ✅`smooth_method %in% c("m.avg", "grim", "age.w", "shep")` (replaced with match.arg to ensure only 1 is used)
- 🆕`smooth_n_points` (all of them) :
    - 🆕numeric
    - 🆕< nrow(community)
- 🆕`round_results` is only 1 and TRUE or FALSE
- 🆕`verbose` is only 1 and TRUE and FALSE
- 🆕if `smooth_method` is `shep`
    - 🆕`smooth_n_points` must be > 2
- ✅if `smooth_method` is **not** `shep` (replaced with : `if method %in% c(”m.avg”, “grim”, “age.w”)`
    - ✅`smooth_n_points` must be odd
    - ✅if `smooth_method` is **not** `m.avg` (replaced with: `if method %in% c(”grim”, “age.w”)`
        - ✅`smooth_age_range` must be numeric
        - ✅if `smooth_method` is `grim`
            - ✅`smooth_n_max` must be odd
            - ✅`smooth_n_max` must be bigger than `smooth_n_points`
            - 🆕`smooth_n_max` must be numeric
            - 🆕`smooth_n_max` must be ≤ `nrow(community)`