### PR TITLE
`plot_roc()`: Fix typo in example code

### DIFF
--- a/R/plot_roc.R
+++ b/R/plot_roc.R
@@ -70,7 +70,7 @@
 #'   )
 #'
 #' sequence_02_peak <-
-#'   detect_peak_points(sequence_01, sel_method = "trend_non_linear")
+#'   detect_peak_points(sequence_02, sel_method = "trend_non_linear")
 #'
 #' plot_roc(
 #'   sequence_02_peak,

--- a/man/plot_roc.Rd
+++ b/man/plot_roc.Rd
@@ -83,7 +83,7 @@ sequence_02 <-
   )
 
 sequence_02_peak <-
-  detect_peak_points(sequence_01, sel_method = "trend_non_linear")
+  detect_peak_points(sequence_02, sel_method = "trend_non_linear")
 
 plot_roc(
   sequence_02_peak,

--- a/man/plot_roc.Rd
+++ b/man/plot_roc.Rd
@@ -83,7 +83,7 @@ sequence_02 <-
   )
 
 sequence_02_peak <-
-  detect_peak_points(sequence_02, sel_method = "trend_non_linear")
+  detect_peak_points(sequence_01, sel_method = "trend_non_linear")
 
 plot_roc(
   sequence_02_peak,


### PR DESCRIPTION
The example from the function `plot_roc()` had the wrong object (`sequence_01` instead of `sequence_02`).
- fix #106 