### PR TITLE
Make `util_search_parameter()` separate file

### DIFF
--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -37,7 +37,6 @@ smooth_community_data <-
            smooth_age_range = 500,
            round_results = FALSE,
            verbose = FALSE) {
-
     # ----------------------------------------------
     # SETUP -----
     # ----------------------------------------------
@@ -140,7 +139,6 @@ smooth_community_data <-
 
     # for every species
     for (j in 1:ncol(dat_community)) {
-
       # select the species
       col_work <- .subset2(dat_community, j)
 
@@ -155,7 +153,6 @@ smooth_community_data <-
         if (
           smooth_method == "m.avg"
         ) {
-
           # Samples near beginning (moving window truncated)
           if (
             i < round(0.5 * (smooth_n_points)) + 1
@@ -189,7 +186,6 @@ smooth_community_data <-
         if (
           smooth_method == "grim"
         ) {
-
           # Samples near beginning (moving window truncated)
           if (
             i < round(0.5 * (smooth_n_max)) + 1
@@ -203,7 +199,11 @@ smooth_community_data <-
               util_search_parameter(
                 focus_par[i, 1],
                 focus_par[i, 2],
-                smooth_age_range
+                smooth_age_range,
+                smooth_n_max,
+                smooth_n_points,
+                dat_age,
+                dat_community
               )
           } else {
             # Samples near end
@@ -220,7 +220,11 @@ smooth_community_data <-
                 util_search_parameter(
                   focus_par[i, 1],
                   focus_par[i, 2],
-                  smooth_age_range
+                  smooth_age_range,
+                  smooth_n_max,
+                  smooth_n_points,
+                  dat_age,
+                  dat_community
                 )
             } else {
               focus_par[i, 1] <-
@@ -233,7 +237,11 @@ smooth_community_data <-
                 util_search_parameter(
                   focus_par[i, 1],
                   focus_par[i, 2],
-                  smooth_age_range
+                  smooth_age_range,
+                  smooth_n_max,
+                  smooth_n_points,
+                  dat_age,
+                  dat_community
                 )
             }
           }
@@ -247,7 +255,6 @@ smooth_community_data <-
         if (
           smooth_method == "age.w"
         ) {
-
           # Samples near beginning (moving window truncated)
           if (
             i < round(0.5 * (smooth_n_points)) + 1

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -82,46 +82,6 @@ smooth_community_data <-
       }
     }
 
-    # crete helper function for GRIMM smoothing
-    # test if this increase does not invalidate rules:
-    #   1) seach parameter cannot go outside of the sample size
-    #     (up or down)
-    #   2) seach parameter cannot be biger than selected maximum sample
-    #     sizes
-    #   3) the age difference between samples selected by the seach
-    #     paramated cannot be higher than defined max age range if all
-    #     of those ARE TRUE then increase the real search parameter
-
-    util_search_parameter <-
-      function(A, B, smooth_age_range) {
-        for (k in 1:(smooth_n_max - smooth_n_points)) {
-          # create new search parameter that is lower by 1
-          A_test <- A - 1
-          if (
-            A_test > 0 && B - A_test < smooth_n_max
-          ) { # i+N.active.test < nrow(dat_community) &
-            if (
-              abs(dat_age$age[A_test] - dat_age$age[B]) < smooth_age_range
-            ) {
-              A <- A_test
-            }
-          }
-
-          # create new search parameter that higher by 1
-          B_test <- B + 1
-          if (
-            B_test < nrow(dat_community) && B - A_test < smooth_n_max
-          ) {
-            if (
-              abs(dat_age$age[A] - dat_age$age[B_test]) < smooth_age_range
-            ) {
-              B <- B_test
-            }
-          }
-        }
-        return(c(A, B))
-      }
-
     # ----------------------------------------------
     # Additional information -----
     # ----------------------------------------------

--- a/R/util_search_parameter.R
+++ b/R/util_search_parameter.R
@@ -8,29 +8,30 @@
 util_search_parameter <- function(A, B, smooth_age_range,
                                   smooth_n_max, smooth_n_points,
                                   dat_age, dat_community) {
-            # create new search parameter that is lower by 1
-            A_test <- A - 1
+    for (k in 1:(smooth_n_max - smooth_n_points)) {
+        # create new search parameter that is lower by 1
+        A_test <- A - 1
+        if (
+            A_test > 0 && B - A_test < smooth_n_max
+        ) { # i+N.active.test < nrow(dat_community) &
             if (
-                A_test > 0 && B - A_test < smooth_n_max
-            ) { # i+N.active.test < nrow(dat_community) &
-                if (
-                    abs(dat_age$age[A_test] - dat_age$age[B]) < smooth_age_range
-                ) {
-                    A <- A_test
-                }
-            }
-
-            # create new search parameter that higher by 1
-            B_test <- B + 1
-            if (
-                B_test < nrow(dat_community) && B - A_test < smooth_n_max
+                abs(dat_age$age[A_test] - dat_age$age[B]) < smooth_age_range
             ) {
-                if (
-                    abs(dat_age$age[A] - dat_age$age[B_test]) < smooth_age_range
-                ) {
-                    B <- B_test
-                }
+                A <- A_test
             }
         }
-        return(c(A, B))
+
+        # create new search parameter that higher by 1
+        B_test <- B + 1
+        if (
+            B_test < nrow(dat_community) && B - A_test < smooth_n_max
+        ) {
+            if (
+                abs(dat_age$age[A] - dat_age$age[B_test]) < smooth_age_range
+            ) {
+                B <- B_test
+            }
+        }
     }
+    return(c(A, B))
+}

--- a/R/util_search_parameter.R
+++ b/R/util_search_parameter.R
@@ -1,0 +1,39 @@
+# crete helper function for GRIMM smoothing
+# test if this increase does not invalidate rules:
+#   1) seach parameter cannot go outside of the sample size
+#     (up or down)
+#   2) seach parameter cannot be biger than selected maximum sample
+#     sizes
+#   3) the age difference between samples selected by the seach
+#     paramated cannot be higher than defined max age range if all
+#     of those ARE TRUE then increase the real search parameter
+
+util_search_parameter <-
+    function(A, B, smooth_age_range) {
+        for (k in 1:(smooth_n_max - smooth_n_points)) {
+            # create new search parameter that is lower by 1
+            A_test <- A - 1
+            if (
+                A_test > 0 && B - A_test < smooth_n_max
+            ) { # i+N.active.test < nrow(dat_community) &
+                if (
+                    abs(dat_age$age[A_test] - dat_age$age[B]) < smooth_age_range
+                ) {
+                    A <- A_test
+                }
+            }
+
+            # create new search parameter that higher by 1
+            B_test <- B + 1
+            if (
+                B_test < nrow(dat_community) && B - A_test < smooth_n_max
+            ) {
+                if (
+                    abs(dat_age$age[A] - dat_age$age[B_test]) < smooth_age_range
+                ) {
+                    B <- B_test
+                }
+            }
+        }
+        return(c(A, B))
+    }

--- a/R/util_search_parameter.R
+++ b/R/util_search_parameter.R
@@ -1,16 +1,13 @@
-# crete helper function for GRIMM smoothing
-# test if this increase does not invalidate rules:
-#   1) seach parameter cannot go outside of the sample size
-#     (up or down)
-#   2) seach parameter cannot be biger than selected maximum sample
-#     sizes
-#   3) the age difference between samples selected by the seach
-#     paramated cannot be higher than defined max age range if all
-#     of those ARE TRUE then increase the real search parameter
-
-util_search_parameter <-
-    function(A, B, smooth_age_range) {
-        for (k in 1:(smooth_n_max - smooth_n_points)) {
+#' Window growth helper for GRIMM smoothing
+#'
+#' Expands the indices [A, B] while respecting (a) dataset bounds,
+#' (b) maximum window size, and (c) maximum age range.
+#'
+#' @keywords internal
+#' @noRd
+util_search_parameter <- function(A, B, smooth_age_range,
+                                  smooth_n_max, smooth_n_points,
+                                  dat_age, dat_community) {
             # create new search parameter that is lower by 1
             A_test <- A - 1
             if (


### PR DESCRIPTION
`util_search_parameter()` used to be internal to `smooth_community_data()` which impeded the explicit testing of the function using unit tests. 
- fix #96 

I made a new file but kept the function interal. It can now be called using: 
`getFromNamespace("util_search_parameter", "RRatepol")` or
`RRatepol:::util_search_parameter(...)`