### PR TITLE
Add 'silent' parameter and suppress output messages

### DIFF
--- a/R/check_data.R
+++ b/R/check_data.R
@@ -2,62 +2,88 @@
 #'
 #' @param data_source_check
 #' List with `community` and `age`
+#' @param silence
+#' Logical. If `TRUE`, suppress all console outputs. Useful for testing.
 #' @description Output summary information about the data
 #' @keywords internal
-check_data <-
-  function(data_source_check) {
-    RUtilpol::check_class("data_source_check", "list")
+check_data <- function(data_source_check, silence = FALSE) {
+  RUtilpol::check_class("data_source_check", "list")
 
-    assertthat::assert_that(
-      nrow(data_source_check$community) > 0,
-      ncol(data_source_check$community) >= 1,
-      nrow(data_source_check$age) > 0,
-      ncol(data_source_check$age) == 1,
-      msg = "Error: Object 'data_source_check' was supplied with empty elements: 'community' and 'age'"
-    )
-    ## 1. dimensions
-    dims <-
-      lapply(data_source_check, dim)
+  assertthat::assert_that(
+    nrow(data_source_check$community) > 0,
+    ncol(data_source_check$community) >= 1,
+    nrow(data_source_check$age) > 0,
+    ncol(data_source_check$age) == 1,
+    msg = "Error: Object 'data_source_check' was supplied with empty elements: 'community' and 'age'"
+  )
+  ## 1. dimensions
+  dims <-
+    lapply(data_source_check, dim)
 
+  if (isFALSE(silence)) {
     if (length(dims) == 3) {
       RUtilpol::output_comment(
         paste(
-          "Community data have", dims$community[2],
-          "taxa and", dims$community[1], "samples.",
-          "Age data have", dims$age[1], "samples.",
-          "Age uncertainty data have", dims$age_un[2], "samples."
+          "Community data have",
+          dims$community[2],
+          "taxa and",
+          dims$community[1],
+          "samples.",
+          "Age data have",
+          dims$age[1],
+          "samples.",
+          "Age uncertainty data have",
+          dims$age_un[2],
+          "samples."
         )
       )
     } else if (length(dims) == 2) {
       RUtilpol::output_comment(
         paste(
-          "Community data have", dims$community[2],
-          "taxa and", dims$community[1], "samples.",
-          "Age data have", dims$age[1], "samples.",
+          "Community data have",
+          dims$community[2],
+          "taxa and",
+          dims$community[1],
+          "samples.",
+          "Age data have",
+          dims$age[1],
+          "samples.",
           "Age uncertainty was not provided."
         )
       )
     }
+  }
 
-    # 2. Missing data
-    nas <-
-      lapply(data_source_check, function(x) {
-        sum(is.na(x))
-      })
+  # 2. Missing data
+  nas <-
+    lapply(data_source_check, function(x) {
+      sum(is.na(x))
+    })
 
+  if (isFALSE(silence)) {
     if (length(nas) == 3) {
       RUtilpol::output_comment(
         paste(
-          "Community data has", nas$community, "NAs.",
-          "Age data has", nas$age, "NAs.",
-          "Age uncertainty data has", nas$age_un, "NAs."
+          "Community data has",
+          nas$community,
+          "NAs.",
+          "Age data has",
+          nas$age,
+          "NAs.",
+          "Age uncertainty data has",
+          nas$age_un,
+          "NAs."
         )
       )
     } else if (length(nas) == 2) {
       RUtilpol::output_comment(
         paste(
-          "Community data has", nas$community, "NAs.",
-          "Age data has", nas$age, "NAs.",
+          "Community data has",
+          nas$community,
+          "NAs.",
+          "Age data has",
+          nas$age,
+          "NAs.",
           "Age uncertainty was not provided."
         )
       )
@@ -68,19 +94,30 @@ check_data <-
       paste0(
         "Community data has a value of min ",
         round(min(rowSums(data_source_check$community, na.rm = TRUE))),
-        ", max ", round(max(rowSums(data_source_check$community, na.rm = TRUE))),
-        ", mean ", round(mean(rowSums(data_source_check$community, na.rm = TRUE))),
-        ", and median ", round(stats::median(rowSums(data_source_check$community, na.rm = TRUE))),
+        ", max ",
+        round(max(rowSums(data_source_check$community, na.rm = TRUE))),
+        ", mean ",
+        round(mean(rowSums(data_source_check$community, na.rm = TRUE))),
+        ", and median ",
+        round(stats::median(rowSums(
+          data_source_check$community,
+          na.rm = TRUE
+        ))),
         " observations."
       )
     )
 
     RUtilpol::output_comment(
       paste0(
-        "Age data has values of min ", round(min(data_source_check$age$age, na.rm = TRUE)),
-        ", max ", round(max(data_source_check$age$age, na.rm = TRUE)),
-        ", mean ", round(mean(data_source_check$age$age, na.rm = TRUE)),
-        ", and median ", round(stats::median(data_source_check$age$age, na.rm = TRUE))
+        "Age data has values of min ",
+        round(min(data_source_check$age$age, na.rm = TRUE)),
+        ", max ",
+        round(max(data_source_check$age$age, na.rm = TRUE)),
+        ", mean ",
+        round(mean(data_source_check$age$age, na.rm = TRUE)),
+        ", and median ",
+        round(stats::median(data_source_check$age$age, na.rm = TRUE))
       )
     )
   }
+}

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -2,11 +2,11 @@
 #'
 #' @param data_source_check
 #' List with `community` and `age`
-#' @param silence
+#' @param silent
 #' Logical. If `TRUE`, suppress all console outputs. Useful for testing.
 #' @description Output summary information about the data
 #' @keywords internal
-check_data <- function(data_source_check, silence = FALSE) {
+check_data <- function(data_source_check, silent =FALSE) {
   RUtilpol::check_class("data_source_check", "list")
 
   assertthat::assert_that(
@@ -20,7 +20,7 @@ check_data <- function(data_source_check, silence = FALSE) {
   dims <-
     lapply(data_source_check, dim)
 
-  if (isFALSE(silence)) {
+  if (isFALSE(silent)) {
     if (length(dims) == 3) {
       RUtilpol::output_comment(
         paste(
@@ -60,7 +60,7 @@ check_data <- function(data_source_check, silence = FALSE) {
       sum(is.na(x))
     })
 
-  if (isFALSE(silence)) {
+  if (isFALSE(silent)) {
     if (length(nas) == 3) {
       RUtilpol::output_comment(
         paste(

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -6,7 +6,7 @@
 #' Logical. If `TRUE`, suppress all console outputs. Useful for testing.
 #' @description Output summary information about the data
 #' @keywords internal
-check_data <- function(data_source_check, silent =FALSE) {
+check_data <- function(data_source_check, silent = FALSE) {
   RUtilpol::check_class("data_source_check", "list")
 
   assertthat::assert_that(

--- a/R/estimate_dissimilarity_coefficient.R
+++ b/R/estimate_dissimilarity_coefficient.R
@@ -21,231 +21,202 @@
 #' biases related to the RoC estimation as a result of the varying
 #' inter-sample distances.
 #' @seealso [vegan::vegdist()]
-estimate_dissimilarity_coefficient <-
-  function(data_source_dc,
-           dissimilarity_coefficient = "chord",
-           verbose = FALSE) {
-    n_res <-
-      nrow(data_source_dc) - 1
+estimate_dissimilarity_coefficient <- function(
+  data_source_dc,
+  dissimilarity_coefficient = "chord",
+  verbose = FALSE,
+  silence = FALSE
+) {
+  n_res <-
+    nrow(data_source_dc) - 1
 
-    # pre-allocate some space
-    dat_res <-
-      vector(
+  # pre-allocate some space
+  dat_res <-
+    vector(
+      mode = "numeric",
+      length = n_res
+    )
+
+  data_com <-
+    subset_community(data_source_dc)
+
+  #----------------------------------------------------------#
+  # Standardised euclidan distace -----
+  #----------------------------------------------------------#
+
+  # for euc.sd use custom made calculation
+
+  if (dissimilarity_coefficient == "euc.sd") {
+    if (isFALSE(silence) && isTRUE(verbose)) {
+      RUtilpol::output_comment(
+        "Standardised Euclidan distance will be used as dissimilarity_coefficient"
+      )
+    }
+
+    # calculation of standard deviation for each species
+
+    # calculate the SD for each species
+    df_sp_supp <-
+      apply(data_com, 2, stats::sd)
+
+    # calculation of the dissimilarity_coefficient
+    # for each sample (except the last)
+    for (i in 1:n_res) {
+      # select only 2 samples (observed + 1 after)
+      df_work <-
+        data_com[c(i, i + 1), , drop = FALSE]
+
+      # get rid of "empty species" in data & in sp.std
+      df_sp_supp_work <-
+        df_sp_supp[colSums(df_work, na.rm = TRUE) > 0]
+      df_work <-
+        as.data.frame(df_work[, colSums(df_work, , na.rm = TRUE) > 0])
+
+      # vector for result for each species
+      vector_work <- vector(
         mode = "numeric",
-        length = n_res
+        length = ncol(df_work)
       )
 
-    data_com <-
-      subset_community(data_source_dc)
+      # for each species
+      for (j in 1:ncol(df_work)) {
+        # check if the standard deviation is not equal zero
+        if (df_sp_supp_work[j] != 0) {
+          a <-
+            .subset2(df_work, j)[1]
+          b <-
+            .subset2(df_work, j)[2]
 
-    #----------------------------------------------------------#
-    # Standardised euclidan distace -----
-    #----------------------------------------------------------#
-
-    # for euc.sd use custom made calculation
-
-    if (
-      dissimilarity_coefficient == "euc.sd"
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          "Standardised Euclidan distance will be used as dissimilarity_coefficient"
-        )
-      }
-
-      # calculation of standard deviation for each species
-
-      # calculate the SD for each species
-      df_sp_supp <-
-        apply(data_com, 2, stats::sd)
-
-      # calculation of the dissimilarity_coefficient
-      # for each sample (except the last)
-      for (i in 1:n_res) {
-
-        # select only 2 samples (observed + 1 after)
-        df_work <-
-          data_com[c(i, i + 1), , drop = FALSE]
-
-        # get rid of "empty species" in data & in sp.std
-        df_sp_supp_work <-
-          df_sp_supp[colSums(df_work, na.rm = TRUE) > 0]
-        df_work <-
-          as.data.frame(df_work[, colSums(df_work, , na.rm = TRUE) > 0])
-
-        # vector for result for each species
-        vector_work <- vector(
-          mode = "numeric",
-          length = ncol(df_work)
-        )
-
-        # for each species
-        for (j in 1:ncol(df_work)) {
-
-          # check if the standard deviation is not equal zero
-          if (
-            df_sp_supp_work[j] != 0
-          ) {
-            a <-
-              .subset2(df_work, j)[1]
-            b <-
-              .subset2(df_work, j)[2]
-
-            # calculate the difference
-            vector_work[j] <-
-              ((a - b) / df_sp_supp_work[j])**2
-          }
+          # calculate the difference
+          vector_work[j] <-
+            ((a - b) / df_sp_supp_work[j])**2
         }
-
-        # save the square root of sum of all differece
-        dat_res[i] <- sqrt(sum(vector_work))
       }
 
-      return(dat_res)
+      # save the square root of sum of all differece
+      dat_res[i] <- sqrt(sum(vector_work))
     }
-
-    # for all other dissimilarity_coefficient u se pre-made function from vegan package to
-    #   calculate correlation between all samples and then
-    #   only include calculation between subsequent samples
-
-    #----------------------------------------------------------#
-    # Euclidan distance -----
-    #----------------------------------------------------------#
-
-    if (
-      dissimilarity_coefficient == "euc"
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          "Euclidan distance will be used as dissimilarity_coefficient"
-        )
-      }
-
-      corrmat <-
-        as.matrix(
-          vegan::vegdist(
-            data_com,
-            method = "euclidean"
-          )
-        )
-    }
-    #----------------------------------------------------------#
-    # Chord's distance -----
-    #----------------------------------------------------------#
-
-    if (
-      dissimilarity_coefficient == "chord"
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          "Chord distance will be used as dissimilarity_coefficient"
-        )
-      }
-
-      # use pre-made function from vegan package to
-      #   calculate correlation between all samples
-      corrmat <-
-        as.matrix(
-          vegan::vegdist(
-            data_com,
-            method = "chord"
-          )
-        )
-    }
-
-
-    #----------------------------------------------------------#
-    # Chi-squared coeficient -----
-    #----------------------------------------------------------#
-
-    if (
-      dissimilarity_coefficient == "chisq"
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          "Chi-squared coeficient will be used as dissimilarity_coefficient"
-        )
-      }
-
-      # use pre-made function from vegan package to
-      #   calculate correlation between all samples
-      corrmat <-
-        as.matrix(
-          vegan::vegdist(
-            data_com,
-            method = "chisq"
-          )
-        )
-    }
-
-
-    #----------------------------------------------------------#
-    # Gower's distance -----
-    #----------------------------------------------------------#
-
-    if (
-      dissimilarity_coefficient == "gower"
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          "Gower's distance will be used as dissimilarity_coefficient"
-        )
-      }
-
-      # use pre-made function from vegan package to
-      #   calculate correlation between all samples
-      corrmat <- as.matrix(
-        vegan::vegdist(
-          data_com,
-          method = "gower"
-        )
-      )
-    }
-
-
-    #----------------------------------------------------------#
-    # Bray–Curtis distance -----
-    #----------------------------------------------------------#
-
-    if (
-      dissimilarity_coefficient == "bray"
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          "Bray-Curtis distance will be used as dissimilarity_coefficient"
-        )
-      }
-
-      # use pre-made function from vegan package to
-      #   calculate correlation between all samples
-      corrmat <-
-        as.matrix(
-          vegan::vegdist(
-            data_com,
-            method = "bray"
-          )
-        )
-    }
-
-    # only include calculation between subsequent samples
-    dat_res <-
-      corrmat[row(corrmat) == col(corrmat) + 1]
-
-    #----------------------------------------------------------#
-    # Return result -----
-    #----------------------------------------------------------#
 
     return(dat_res)
   }
+
+  # for all other dissimilarity_coefficient u se pre-made function from vegan package to
+  #   calculate correlation between all samples and then
+  #   only include calculation between subsequent samples
+
+  #----------------------------------------------------------#
+  # Euclidan distance -----
+  #----------------------------------------------------------#
+
+  if (dissimilarity_coefficient == "euc") {
+    if (isFALSE(silence) && isTRUE(verbose)) {
+      RUtilpol::output_comment(
+        "Euclidan distance will be used as dissimilarity_coefficient"
+      )
+    }
+
+    corrmat <-
+      as.matrix(
+        vegan::vegdist(
+          data_com,
+          method = "euclidean"
+        )
+      )
+  }
+  #----------------------------------------------------------#
+  # Chord's distance -----
+  #----------------------------------------------------------#
+
+  if (dissimilarity_coefficient == "chord") {
+    if (isFALSE(silence) && isTRUE(verbose)) {
+      RUtilpol::output_comment(
+        "Chord distance will be used as dissimilarity_coefficient"
+      )
+    }
+
+    # use pre-made function from vegan package to
+    #   calculate correlation between all samples
+    corrmat <-
+      as.matrix(
+        vegan::vegdist(
+          data_com,
+          method = "chord"
+        )
+      )
+  }
+
+  #----------------------------------------------------------#
+  # Chi-squared coeficient -----
+  #----------------------------------------------------------#
+
+  if (dissimilarity_coefficient == "chisq") {
+    if (isFALSE(silence) && isTRUE(verbose)) {
+      RUtilpol::output_comment(
+        "Chi-squared coeficient will be used as dissimilarity_coefficient"
+      )
+    }
+
+    # use pre-made function from vegan package to
+    #   calculate correlation between all samples
+    corrmat <-
+      as.matrix(
+        vegan::vegdist(
+          data_com,
+          method = "chisq"
+        )
+      )
+  }
+
+  #----------------------------------------------------------#
+  # Gower's distance -----
+  #----------------------------------------------------------#
+
+  if (dissimilarity_coefficient == "gower") {
+    if (isFALSE(silence) && isTRUE(verbose)) {
+      RUtilpol::output_comment(
+        "Gower's distance will be used as dissimilarity_coefficient"
+      )
+    }
+
+    # use pre-made function from vegan package to
+    #   calculate correlation between all samples
+    corrmat <- as.matrix(
+      vegan::vegdist(
+        data_com,
+        method = "gower"
+      )
+    )
+  }
+
+  #----------------------------------------------------------#
+  # Bray–Curtis distance -----
+  #----------------------------------------------------------#
+
+  if (dissimilarity_coefficient == "bray") {
+    if (isFALSE(silence) && isTRUE(verbose)) {
+      RUtilpol::output_comment(
+        "Bray-Curtis distance will be used as dissimilarity_coefficient"
+      )
+    }
+
+    # use pre-made function from vegan package to
+    #   calculate correlation between all samples
+    corrmat <-
+      as.matrix(
+        vegan::vegdist(
+          data_com,
+          method = "bray"
+        )
+      )
+  }
+
+  # only include calculation between subsequent samples
+  dat_res <-
+    corrmat[row(corrmat) == col(corrmat) + 1]
+
+  #----------------------------------------------------------#
+  # Return result -----
+  #----------------------------------------------------------#
+
+  return(dat_res)
+}

--- a/R/estimate_dissimilarity_coefficient.R
+++ b/R/estimate_dissimilarity_coefficient.R
@@ -25,7 +25,7 @@ estimate_dissimilarity_coefficient <- function(
   data_source_dc,
   dissimilarity_coefficient = "chord",
   verbose = FALSE,
-  silence = FALSE
+  silent =FALSE
 ) {
   n_res <-
     nrow(data_source_dc) - 1
@@ -47,7 +47,7 @@ estimate_dissimilarity_coefficient <- function(
   # for euc.sd use custom made calculation
 
   if (dissimilarity_coefficient == "euc.sd") {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         "Standardised Euclidan distance will be used as dissimilarity_coefficient"
       )
@@ -109,7 +109,7 @@ estimate_dissimilarity_coefficient <- function(
   #----------------------------------------------------------#
 
   if (dissimilarity_coefficient == "euc") {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         "Euclidan distance will be used as dissimilarity_coefficient"
       )
@@ -128,7 +128,7 @@ estimate_dissimilarity_coefficient <- function(
   #----------------------------------------------------------#
 
   if (dissimilarity_coefficient == "chord") {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         "Chord distance will be used as dissimilarity_coefficient"
       )
@@ -150,7 +150,7 @@ estimate_dissimilarity_coefficient <- function(
   #----------------------------------------------------------#
 
   if (dissimilarity_coefficient == "chisq") {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         "Chi-squared coeficient will be used as dissimilarity_coefficient"
       )
@@ -172,7 +172,7 @@ estimate_dissimilarity_coefficient <- function(
   #----------------------------------------------------------#
 
   if (dissimilarity_coefficient == "gower") {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         "Gower's distance will be used as dissimilarity_coefficient"
       )
@@ -193,7 +193,7 @@ estimate_dissimilarity_coefficient <- function(
   #----------------------------------------------------------#
 
   if (dissimilarity_coefficient == "bray") {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         "Bray-Curtis distance will be used as dissimilarity_coefficient"
       )

--- a/R/estimate_roc.R
+++ b/R/estimate_roc.R
@@ -95,7 +95,7 @@
 #' dissimilarity per 100 yr.
 #' @param verbose
 #' Logical. If `TRUE`, function will output messages about internal processes
-#' @param silence
+#' @param silent
 #' Logical. If `TRUE`, suppress all console outputs (overrides verbose). Useful for testing.
 #' @description
 #' A function to estimate Rate of change in community data in time series
@@ -265,7 +265,7 @@ estimate_roc <- function(
   interest_threshold = NULL,
   time_standardisation = NULL,
   verbose = FALSE,
-  silence = FALSE
+  silent = FALSE
 ) {
   # Start of the code
 
@@ -387,7 +387,7 @@ estimate_roc <- function(
 
   RUtilpol::check_class("verbose", "logical")
 
-  RUtilpol::check_class("silence", "logical")
+  RUtilpol::check_class("silent", "logical")
 
   #--------------------------------------------------#
   # 0.1. Report to user -----
@@ -395,7 +395,7 @@ estimate_roc <- function(
 
   start_time <- Sys.time()
 
-  if (isFALSE(silence)) {
+  if (isFALSE(silent)) {
     RUtilpol::output_heading(
       paste("RRatepol started", start_time),
       size = "h1"
@@ -403,14 +403,14 @@ estimate_roc <- function(
   }
 
   if (isFALSE(is.null(age_uncertainty))) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       RUtilpol::output_comment(
         "'age_uncertainty' will be used for in the RoC estimation"
       )
     }
 
     if (rand < 100) {
-      if (isFALSE(silence)) {
+      if (isFALSE(silent)) {
         RUtilpol::output_warning(
           paste(
             "'age_uncertainty' was selected to be used with low number",
@@ -421,7 +421,7 @@ estimate_roc <- function(
     }
   }
 
-  if (isFALSE(silence)) {
+  if (isFALSE(silent)) {
     switch(
       working_units,
       "levels" = {
@@ -454,14 +454,14 @@ estimate_roc <- function(
 
   if (working_units != "levels") {
     if (bin_selection == "random") {
-      if (isFALSE(silence)) {
+      if (isFALSE(silent)) {
         RUtilpol::output_comment(
           "Sample will randomly selected for each bin"
         )
       }
 
       if (rand < 100) {
-        if (isFALSE(silence)) {
+        if (isFALSE(silent)) {
           RUtilpol::output_warning(
             paste(
               "'bin_selection' was selected as 'random' with low number",
@@ -471,7 +471,7 @@ estimate_roc <- function(
         }
       }
     } else {
-      if (isFALSE(silence)) {
+      if (isFALSE(silent)) {
         RUtilpol::output_comment(
           "First sample of each time bin will selected"
         )
@@ -479,7 +479,7 @@ estimate_roc <- function(
     }
   }
 
-  if (isFALSE(silence)) {
+  if (isFALSE(silent)) {
     RUtilpol::output_comment(
       paste(
         "'time_standardisation' =",
@@ -493,7 +493,7 @@ estimate_roc <- function(
   }
 
   if (working_units != "levels" && time_standardisation != bin_size) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       RUtilpol::output_comment(
         paste(
           "RoC values will be reported in different units than size of bin.",
@@ -505,7 +505,7 @@ estimate_roc <- function(
   }
 
   if (isTRUE(standardise)) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       RUtilpol::output_comment(
         paste(
           "Data will be standardise in each Working unit to",
@@ -516,7 +516,7 @@ estimate_roc <- function(
     }
 
     if (rand < 100) {
-      if (isFALSE(silence)) {
+      if (isFALSE(silent)) {
         RUtilpol::output_warning(
           paste(
             "'standardise' was selected as 'TRUE' with low number of replication.",
@@ -539,11 +539,11 @@ estimate_roc <- function(
       data_age_extract = data_source_age,
       age_uncertainty = age_uncertainty,
       verbose = verbose,
-      silence = silence
+      silent = silent
     )
 
   if (ncol(data_extract$community) == 1 && isTRUE(tranform_to_proportions)) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       RUtilpol::output_warning(
         msg = paste(
           "Community data has only 1 variable and `tranform_to_proportions`",
@@ -572,7 +572,7 @@ estimate_roc <- function(
         smooth_age_range = smooth_age_range,
         round_results = standardise,
         verbose = verbose,
-        silence = silence
+        silent = silent
       )
   } else {
     data_smooth <- data_extract
@@ -584,8 +584,8 @@ estimate_roc <- function(
       data_source_reduce = data_smooth
     )
 
-  if (isFALSE(silence) && isTRUE(verbose)) {
-    check_data(data_work, silence = silence)
+  if (isFALSE(silent) && isTRUE(verbose)) {
+    check_data(data_work, silent = silent)
   }
 
   #----------------------------------------------------------#
@@ -598,7 +598,7 @@ estimate_roc <- function(
       isFALSE(is.null(rand)) &&
       (working_units == "levels" || bin_selection == "first")
   ) {
-    if (isFALSE(silence) && isTRUE(verbose)) {
+    if (isFALSE(silent) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         msg = paste(
           "There is no need for randomisation.",
@@ -626,7 +626,7 @@ estimate_roc <- function(
   # 4. Estimation -----
   #----------------------------------------------------------#
 
-  if (isFALSE(silence) && isTRUE(verbose)) {
+  if (isFALSE(silent) && isTRUE(verbose)) {
     RUtilpol::output_heading(
       msg = "Start of estimation",
       size = "h2"
@@ -663,6 +663,13 @@ estimate_roc <- function(
     cl <- NULL
   }
 
+  pbapply::pboptions(type = "timer")
+
+  if (isTRUE(silent)) {
+    pbapply_setting <-
+      pbapply::pboptions(type = "none")
+  }
+
   # run the estimation with progress bar
   result_list <-
     pbapply::pblapply(
@@ -676,8 +683,12 @@ estimate_roc <- function(
       dissimilarity_coefficient = dissimilarity_coefficient,
       time_standardisation = time_standardisation,
       verbose = verbose,
-      silence = silence
+      silent = silent
     )
+
+  if (isTRUE(silent)) {
+    pbapply::pboptions(pbapply_setting)
+  }
 
   # close progress bar and cluster
   if (isFALSE(is.null(cl))) {
@@ -731,7 +742,7 @@ estimate_roc <- function(
   end_time <- Sys.time()
   time_duration <- end_time - start_time
 
-  if (isFALSE(silence)) {
+  if (isFALSE(silent)) {
     RUtilpol::output_heading(
       paste(
         "RRatepol finished",

--- a/R/estimate_roc.R
+++ b/R/estimate_roc.R
@@ -95,6 +95,8 @@
 #' dissimilarity per 100 yr.
 #' @param verbose
 #' Logical. If `TRUE`, function will output messages about internal processes
+#' @param silence
+#' Logical. If `TRUE`, suppress all console outputs (overrides verbose). Useful for testing.
 #' @description
 #' A function to estimate Rate of change in community data in time series
 #' @details R-Ratepol is written as an R package and includes a range of
@@ -235,185 +237,180 @@
 #'   roc_threshold = 1
 #' )
 #' }
-estimate_roc <-
-  function(data_source_community,
-           data_source_age,
-           age_uncertainty = NULL,
-           smooth_method = c("none", "m.avg", "grim", "age.w", "shep"),
-           smooth_n_points = 5,
-           smooth_age_range = 500,
-           smooth_n_max = 9,
-           working_units = c("levels", "bins", "MW"),
-           bin_size = 500,
-           number_of_shifts = 5,
-           bin_selection = c("random", "first"),
-           standardise = FALSE,
-           n_individuals = 150,
-           dissimilarity_coefficient = c("euc", "euc.sd", "chord", "chisq", "gower", "bray"),
-           tranform_to_proportions = TRUE,
-           rand = NULL,
-           use_parallel = FALSE,
-           interest_threshold = NULL,
-           time_standardisation = NULL,
-           verbose = FALSE) {
-    # Start of the code
+estimate_roc <- function(
+  data_source_community,
+  data_source_age,
+  age_uncertainty = NULL,
+  smooth_method = c("none", "m.avg", "grim", "age.w", "shep"),
+  smooth_n_points = 5,
+  smooth_age_range = 500,
+  smooth_n_max = 9,
+  working_units = c("levels", "bins", "MW"),
+  bin_size = 500,
+  number_of_shifts = 5,
+  bin_selection = c("random", "first"),
+  standardise = FALSE,
+  n_individuals = 150,
+  dissimilarity_coefficient = c(
+    "euc",
+    "euc.sd",
+    "chord",
+    "chisq",
+    "gower",
+    "bray"
+  ),
+  tranform_to_proportions = TRUE,
+  rand = NULL,
+  use_parallel = FALSE,
+  interest_threshold = NULL,
+  time_standardisation = NULL,
+  verbose = FALSE,
+  silence = FALSE
+) {
+  # Start of the code
 
-    #----------------------------------------------------------#
-    # 0. Arguments check -----
-    #----------------------------------------------------------#
+  #----------------------------------------------------------#
+  # 0. Arguments check -----
+  #----------------------------------------------------------#
 
-    assertthat::assert_that(
-      !missing(data_source_community),
-      msg = "Object 'data_source_community' must be included as a 'data.frame'"
-    )
+  assertthat::assert_that(
+    !missing(data_source_community),
+    msg = "Object 'data_source_community' must be included as a 'data.frame'"
+  )
 
-    assertthat::assert_that(
-      !missing(data_source_age),
-      msg = "Object 'data_source_age' must be included as a 'data.frame'"
-    )
+  assertthat::assert_that(
+    !missing(data_source_age),
+    msg = "Object 'data_source_age' must be included as a 'data.frame'"
+  )
 
-    RUtilpol::check_class("data_source_community", "data.frame")
+  RUtilpol::check_class("data_source_community", "data.frame")
 
-    RUtilpol::check_class("data_source_age", "data.frame")
+  RUtilpol::check_class("data_source_age", "data.frame")
 
-    RUtilpol::check_class("age_uncertainty", c("NULL", "matrix"))
+  RUtilpol::check_class("age_uncertainty", c("NULL", "matrix"))
 
-    RUtilpol::check_class("working_units", "character")
+  RUtilpol::check_class("working_units", "character")
 
-    RUtilpol::check_vector_values("working_units", c("levels", "bins", "MW"))
+  RUtilpol::check_vector_values("working_units", c("levels", "bins", "MW"))
 
-    working_units <- match.arg(working_units)
+  working_units <- match.arg(working_units)
 
-    if (
-      is.null(time_standardisation)
-    ) {
-      time_standardisation <- bin_size
+  if (is.null(time_standardisation)) {
+    time_standardisation <- bin_size
+  }
+  RUtilpol::check_class("time_standardisation", "numeric")
+
+  RUtilpol::check_if_integer("time_standardisation")
+
+  if (working_units != "levels") {
+    RUtilpol::check_class("bin_size", "numeric")
+
+    RUtilpol::check_if_integer("bin_size")
+
+    RUtilpol::check_class("bin_selection", "character")
+
+    RUtilpol::check_vector_values("bin_selection", c("first", "random"))
+
+    bin_selection <- match.arg(bin_selection)
+
+    if (working_units == "MW") {
+      RUtilpol::check_class("number_of_shifts", "numeric")
+
+      RUtilpol::check_if_integer("number_of_shifts")
     }
-    RUtilpol::check_class("time_standardisation", "numeric")
+  }
 
-    RUtilpol::check_if_integer("time_standardisation")
+  RUtilpol::check_class("standardise", "logical")
 
-    if (
-      working_units != "levels"
-    ) {
-      RUtilpol::check_class("bin_size", "numeric")
+  if (isTRUE(standardise)) {
+    RUtilpol::check_class("n_individuals", "numeric")
 
-      RUtilpol::check_if_integer("bin_size")
+    RUtilpol::check_if_integer("n_individuals")
+  }
 
-      RUtilpol::check_class("bin_selection", "character")
+  RUtilpol::check_class("tranform_to_proportions", "logical")
 
-      RUtilpol::check_vector_values("bin_selection", c("first", "random"))
+  RUtilpol::check_class("interest_threshold", c("NULL", "numeric"))
 
-      bin_selection <- match.arg(bin_selection)
+  RUtilpol::check_class("smooth_method", "character")
 
-      if (
-        working_units == "MW"
-      ) {
-        RUtilpol::check_class("number_of_shifts", "numeric")
+  RUtilpol::check_vector_values(
+    "smooth_method",
+    c("none", "m.avg", "grim", "age.w", "shep")
+  )
 
-        RUtilpol::check_if_integer("number_of_shifts")
+  smooth_method <- match.arg(smooth_method)
+
+  if (!smooth_method %in% c("none", "shep")) {
+    assertthat::assert_that(
+      smooth_n_points %% 2 != 0,
+      msg = "'smooth_n_points' must be an odd number"
+    )
+
+    if (smooth_method != "m.avg") {
+      RUtilpol::check_class("smooth_age_range", "numeric")
+
+      if (smooth_method == "grim") {
+        assertthat::assert_that(
+          smooth_n_max %% 2 != 0,
+          msg = "'smooth_n_max' must be an odd number"
+        )
+
+        assertthat::assert_that(
+          smooth_n_points < smooth_n_max,
+          msg = "'smooth_n_max' must be bigger than 'smooth_n_points"
+        )
       }
     }
+  }
 
-    RUtilpol::check_class("standardise", "logical")
+  RUtilpol::check_class("dissimilarity_coefficient", "character")
 
-    if (
-      isTRUE(standardise)
-    ) {
-      RUtilpol::check_class("n_individuals", "numeric")
+  RUtilpol::check_vector_values(
+    "dissimilarity_coefficient",
+    c("euc", "euc.sd", "chord", "chisq", "gower", "bray")
+  )
 
-      RUtilpol::check_if_integer("n_individuals")
-    }
+  dissimilarity_coefficient <- match.arg(dissimilarity_coefficient)
 
-    RUtilpol::check_class("tranform_to_proportions", "logical")
+  RUtilpol::check_class("rand", c("NULL", "numeric"))
 
-    RUtilpol::check_class("interest_threshold", c("NULL", "numeric"))
+  if (isFALSE(is.null(rand))) {
+    RUtilpol::check_if_integer("rand")
+  }
 
-    RUtilpol::check_class("smooth_method", "character")
+  RUtilpol::check_class("use_parallel", c("logical", "numeric"))
 
-    RUtilpol::check_vector_values(
-      "smooth_method",
-      c("none", "m.avg", "grim", "age.w", "shep")
-    )
+  if (is.numeric(use_parallel)) {
+    RUtilpol::check_if_integer("use_parallel")
+  }
 
-    smooth_method <- match.arg(smooth_method)
+  RUtilpol::check_class("verbose", "logical")
 
-    if (
-      !smooth_method %in% c("none", "shep")
-    ) {
-      assertthat::assert_that(
-        smooth_n_points %% 2 != 0,
-        msg = "'smooth_n_points' must be an odd number"
-      )
+  RUtilpol::check_class("silence", "logical")
 
-      if (
-        smooth_method != "m.avg"
-      ) {
-        RUtilpol::check_class("smooth_age_range", "numeric")
+  #--------------------------------------------------#
+  # 0.1. Report to user -----
+  #--------------------------------------------------#
 
-        if (
-          smooth_method == "grim"
-        ) {
-          assertthat::assert_that(
-            smooth_n_max %% 2 != 0,
-            msg = "'smooth_n_max' must be an odd number"
-          )
+  start_time <- Sys.time()
 
-          assertthat::assert_that(
-            smooth_n_points < smooth_n_max,
-            msg = "'smooth_n_max' must be bigger than 'smooth_n_points"
-          )
-        }
-      }
-    }
-
-    RUtilpol::check_class("dissimilarity_coefficient", "character")
-
-    RUtilpol::check_vector_values(
-      "dissimilarity_coefficient",
-      c("euc", "euc.sd", "chord", "chisq", "gower", "bray")
-    )
-
-    dissimilarity_coefficient <- match.arg(dissimilarity_coefficient)
-
-    RUtilpol::check_class("rand", c("NULL", "numeric"))
-
-    if (
-      isFALSE(is.null(rand))
-    ) {
-      RUtilpol::check_if_integer("rand")
-    }
-
-    RUtilpol::check_class("use_parallel", c("logical", "numeric"))
-
-    if (
-      is.numeric(use_parallel)
-    ) {
-      RUtilpol::check_if_integer("use_parallel")
-    }
-
-    RUtilpol::check_class("verbose", "logical")
-
-    #--------------------------------------------------#
-    # 0.1. Report to user -----
-    #--------------------------------------------------#
-
-    start_time <- Sys.time()
-
+  if (isFALSE(silence)) {
     RUtilpol::output_heading(
       paste("RRatepol started", start_time),
       size = "h1"
     )
+  }
 
-    if (
-      isFALSE(is.null(age_uncertainty))
-    ) {
+  if (isFALSE(is.null(age_uncertainty))) {
+    if (isFALSE(silence)) {
       RUtilpol::output_comment(
         "'age_uncertainty' will be used for in the RoC estimation"
       )
+    }
 
-      if (
-        rand < 100) {
+    if (rand < 100) {
+      if (isFALSE(silence)) {
         RUtilpol::output_warning(
           paste(
             "'age_uncertainty' was selected to be used with low number",
@@ -422,8 +419,11 @@ estimate_roc <-
         )
       }
     }
+  }
 
-    switch(working_units,
+  if (isFALSE(silence)) {
+    switch(
+      working_units,
       "levels" = {
         RUtilpol::output_comment(
           "RoC will be estimated between individual subsequent levels"
@@ -432,7 +432,8 @@ estimate_roc <-
       "bins" = {
         RUtilpol::output_comment(
           paste(
-            "RoC will be estimated using selective binning with", bin_size,
+            "RoC will be estimated using selective binning with",
+            bin_size,
             "yr time bin"
           )
         )
@@ -441,25 +442,26 @@ estimate_roc <-
         RUtilpol::output_comment(
           paste(
             "RoC will be estimated using 'binning with the mowing window' of",
-            bin_size, "yr time bin over", number_of_shifts, "number of window shifts"
+            bin_size,
+            "yr time bin over",
+            number_of_shifts,
+            "number of window shifts"
           )
         )
       }
     )
+  }
 
-    if (
-      working_units != "levels"
-    ) {
-      if (
-        bin_selection == "random"
-      ) {
+  if (working_units != "levels") {
+    if (bin_selection == "random") {
+      if (isFALSE(silence)) {
         RUtilpol::output_comment(
           "Sample will randomly selected for each bin"
         )
+      }
 
-        if (
-          rand < 100
-        ) {
+      if (rand < 100) {
+        if (isFALSE(silence)) {
           RUtilpol::output_warning(
             paste(
               "'bin_selection' was selected as 'random' with low number",
@@ -467,24 +469,31 @@ estimate_roc <-
             )
           )
         }
-      } else {
+      }
+    } else {
+      if (isFALSE(silence)) {
         RUtilpol::output_comment(
           "First sample of each time bin will selected"
         )
       }
     }
+  }
 
+  if (isFALSE(silence)) {
     RUtilpol::output_comment(
       paste(
-        "'time_standardisation' =", time_standardisation, ":",
-        "RoC values will be reported as disimilarity per", time_standardisation,
+        "'time_standardisation' =",
+        time_standardisation,
+        ":",
+        "RoC values will be reported as disimilarity per",
+        time_standardisation,
         "years."
       )
     )
+  }
 
-    if (
-      working_units != "levels" && time_standardisation != bin_size
-    ) {
+  if (working_units != "levels" && time_standardisation != bin_size) {
+    if (isFALSE(silence)) {
       RUtilpol::output_comment(
         paste(
           "RoC values will be reported in different units than size of bin.",
@@ -493,20 +502,21 @@ estimate_roc <-
         )
       )
     }
+  }
 
-    if (
-      isTRUE(standardise)
-    ) {
+  if (isTRUE(standardise)) {
+    if (isFALSE(silence)) {
       RUtilpol::output_comment(
         paste(
-          "Data will be standardise in each Working unit to", n_individuals,
+          "Data will be standardise in each Working unit to",
+          n_individuals,
           "or the lowest number detected in dataset"
         )
       )
+    }
 
-      if (
-        rand < 100
-      ) {
+    if (rand < 100) {
+      if (isFALSE(silence)) {
         RUtilpol::output_warning(
           paste(
             "'standardise' was selected as 'TRUE' with low number of replication.",
@@ -515,25 +525,25 @@ estimate_roc <-
         )
       }
     }
+  }
 
+  #----------------------------------------------------------#
+  # 1. Data extraction -----
+  #----------------------------------------------------------#
 
-    #----------------------------------------------------------#
-    # 1. Data extraction -----
-    #----------------------------------------------------------#
+  # extract data into working format
+  # already include data check
+  data_extract <-
+    extract_data(
+      data_community_extract = data_source_community,
+      data_age_extract = data_source_age,
+      age_uncertainty = age_uncertainty,
+      verbose = verbose,
+      silence = silence
+    )
 
-    # extract data into working format
-    # already include data check
-    data_extract <-
-      extract_data(
-        data_community_extract = data_source_community,
-        data_age_extract = data_source_age,
-        age_uncertainty = age_uncertainty,
-        verbose = verbose
-      )
-
-    if (
-      ncol(data_extract$community) == 1 && isTRUE(tranform_to_proportions)
-    ) {
+  if (ncol(data_extract$community) == 1 && isTRUE(tranform_to_proportions)) {
+    if (isFALSE(silence)) {
       RUtilpol::output_warning(
         msg = paste(
           "Community data has only 1 variable and `tranform_to_proportions`",
@@ -542,207 +552,198 @@ estimate_roc <-
           "Therefore, `tranform_to_proportions` will be set to `FALSE`"
         )
       )
-
-      tranform_to_proportions <- FALSE
     }
 
+    tranform_to_proportions <- FALSE
+  }
 
-    #----------------------------------------------------------#
-    # 2. Data smoothing -----
-    #----------------------------------------------------------#
+  #----------------------------------------------------------#
+  # 2. Data smoothing -----
+  #----------------------------------------------------------#
 
-    if (
-      smooth_method != "none"
-    ) {
-      # smooth data by selected smoothing type
-      data_smooth <-
-        smooth_community_data(
-          data_source_smooth = data_extract,
-          smooth_method = smooth_method,
-          smooth_n_points = smooth_n_points,
-          smooth_n_max = smooth_n_max,
-          smooth_age_range = smooth_age_range,
-          round_results = standardise,
-          verbose = verbose
-        )
-    } else {
-      data_smooth <- data_extract
-    }
-
-    # reduce data dimentions
-    data_work <-
-      reduce_data(
-        data_source_reduce = data_smooth
+  if (smooth_method != "none") {
+    # smooth data by selected smoothing type
+    data_smooth <-
+      smooth_community_data(
+        data_source_smooth = data_extract,
+        smooth_method = smooth_method,
+        smooth_n_points = smooth_n_points,
+        smooth_n_max = smooth_n_max,
+        smooth_age_range = smooth_age_range,
+        round_results = standardise,
+        verbose = verbose,
+        silence = silence
       )
+  } else {
+    data_smooth <- data_extract
+  }
 
-    if (
-      isTRUE(verbose)
-    ) {
-      check_data(data_work)
-    }
+  # reduce data dimentions
+  data_work <-
+    reduce_data(
+      data_source_reduce = data_smooth
+    )
 
+  if (isFALSE(silence) && isTRUE(verbose)) {
+    check_data(data_work, silence = silence)
+  }
 
-    #----------------------------------------------------------#
-    # 3. Crete datasets to use -----
-    #----------------------------------------------------------#
+  #----------------------------------------------------------#
+  # 3. Crete datasets to use -----
+  #----------------------------------------------------------#
 
-    if (
-      is.null(age_uncertainty) &&
-        isFALSE(standardise) &&
-        isFALSE(is.null(rand)) &&
-        (working_units == "levels" || bin_selection == "first")
-    ) {
-      if (
-        isTRUE(verbose)
-      ) {
-        RUtilpol::output_comment(
-          msg = paste(
-            "There is no need for randomisation.",
-            "Changing `rand` to NULL"
-          )
-        )
-      }
-
-      rand <- NULL
-    }
-
-    data_prepared <-
-      prepare_data(
-        data_source_prep = data_work,
-        working_units = working_units,
-        bin_size = bin_size,
-        number_of_shifts = number_of_shifts,
-        rand = rand
-      )
-
-    data_to_run <-
-      RUtilpol::flatten_list_by_one(data_prepared)
-
-
-    #----------------------------------------------------------#
-    # 4. Estimation -----
-    #----------------------------------------------------------#
-
-
-    if (
-      isTRUE(verbose)
-    ) {
-      RUtilpol::output_heading(
-        msg = "Start of estimation",
-        size = "h2"
-      )
-
+  if (
+    is.null(age_uncertainty) &&
+      isFALSE(standardise) &&
+      isFALSE(is.null(rand)) &&
+      (working_units == "levels" || bin_selection == "first")
+  ) {
+    if (isFALSE(silence) && isTRUE(verbose)) {
       RUtilpol::output_comment(
         msg = paste(
-          "Number of estimation set to", length(data_to_run)
+          "There is no need for randomisation.",
+          "Changing `rand` to NULL"
         )
       )
     }
 
-    # select the preferred number of cores for of cores for parallel computation
-    if (
-      isTRUE(use_parallel)
-    ) {
-      if (
-        methods::is(use_parallel, "numeric")
-      ) {
-        n_cores <-
-          as.numeric(use_parallel) # set value
-      } else {
-        n_cores <-
-          parallel::detectCores() # detect number
-      }
+    rand <- NULL
+  }
 
-      # create cluster
-      cl <-
-        parallel::makeCluster(n_cores)
+  data_prepared <-
+    prepare_data(
+      data_source_prep = data_work,
+      working_units = working_units,
+      bin_size = bin_size,
+      number_of_shifts = number_of_shifts,
+      rand = rand
+    )
 
-      # eval packages
-      parallel::clusterEvalQ(cl, {
-        library("tidyverse")
-        library("RRatepol")
-      })
+  data_to_run <-
+    RUtilpol::flatten_list_by_one(data_prepared)
+
+  #----------------------------------------------------------#
+  # 4. Estimation -----
+  #----------------------------------------------------------#
+
+  if (isFALSE(silence) && isTRUE(verbose)) {
+    RUtilpol::output_heading(
+      msg = "Start of estimation",
+      size = "h2"
+    )
+
+    RUtilpol::output_comment(
+      msg = paste(
+        "Number of estimation set to",
+        length(data_to_run)
+      )
+    )
+  }
+
+  # select the preferred number of cores for of cores for parallel computation
+  if (isTRUE(use_parallel)) {
+    if (methods::is(use_parallel, "numeric")) {
+      n_cores <-
+        as.numeric(use_parallel) # set value
     } else {
-      cl <- NULL
+      n_cores <-
+        parallel::detectCores() # detect number
     }
 
-    # run the estimation with progress bar
-    result_list <-
-      pbapply::pblapply(
-        X = data_to_run,
-        FUN = run_iteration,
-        cl = cl,
-        bin_selection = bin_selection,
-        standardise = standardise,
-        n_individuals = n_individuals,
-        tranform_to_proportions = tranform_to_proportions,
-        dissimilarity_coefficient = dissimilarity_coefficient,
-        time_standardisation = time_standardisation,
-        verbose = verbose
-      )
+    # create cluster
+    cl <-
+      parallel::makeCluster(n_cores)
 
-    # close progress bar and cluster
-    if (
-      isFALSE(is.null(cl))
-    ) {
-      parallel::stopCluster(cl)
-      cl <- NULL
-    }
-    gc(verbose = FALSE)
+    # eval packages
+    parallel::clusterEvalQ(cl, {
+      library("tidyverse")
+      library("RRatepol")
+    })
+  } else {
+    cl <- NULL
+  }
 
-    #----------------------------------------------------------#
-    # 5. Results Summary -----
-    #----------------------------------------------------------#
+  # run the estimation with progress bar
+  result_list <-
+    pbapply::pblapply(
+      X = data_to_run,
+      FUN = run_iteration,
+      cl = cl,
+      bin_selection = bin_selection,
+      standardise = standardise,
+      n_individuals = n_individuals,
+      tranform_to_proportions = tranform_to_proportions,
+      dissimilarity_coefficient = dissimilarity_coefficient,
+      time_standardisation = time_standardisation,
+      verbose = verbose,
+      silence = silence
+    )
 
-    # create new dataframe with summary of randomisation results
+  # close progress bar and cluster
+  if (isFALSE(is.null(cl))) {
+    parallel::stopCluster(cl)
+    cl <- NULL
+  }
+  gc(verbose = FALSE)
+
+  #----------------------------------------------------------#
+  # 5. Results Summary -----
+  #----------------------------------------------------------#
+
+  # create new dataframe with summary of randomisation results
+  results_full <-
+    purrr::map_dfr(
+      .x = result_list,
+      .f = as.data.frame,
+      .id = "it"
+    ) %>%
+    dplyr::group_by(.data$label) %>%
+    dplyr::summarise(
+      .groups = "drop",
+      Age = stats::median(.data$res_age, na.rm = TRUE),
+      ROC = stats::median(.data$roc, na.rm = TRUE),
+      ROC_up = stats::quantile(.data$roc, 0.975, na.rm = TRUE),
+      ROC_dw = stats::quantile(.data$roc, 0.025, na.rm = TRUE)
+    ) %>%
+    dplyr::select(
+      Working_Unit = "label",
+      "Age",
+      "ROC",
+      "ROC_up",
+      "ROC_dw"
+    )
+
+  # reduce results by the focus age time
+  if (methods::is(interest_threshold, "numeric")) {
     results_full <-
-      purrr::map_dfr(
-        .x = result_list,
-        .f = as.data.frame,
-        .id = "it"
-      ) %>%
-      dplyr::group_by(.data$label) %>%
-      dplyr::summarise(
-        .groups = "drop",
-        Age = stats::median(.data$res_age, na.rm = TRUE),
-        ROC = stats::median(.data$roc, na.rm = TRUE),
-        ROC_up = stats::quantile(.data$roc, 0.975, na.rm = TRUE),
-        ROC_dw = stats::quantile(.data$roc, 0.025, na.rm = TRUE)
-      ) %>%
-      dplyr::select(
-        Working_Unit = "label",
-        "Age", "ROC", "ROC_up", "ROC_dw"
-      )
-
-    # reduce results by the focus age time
-    if (
-      methods::is(interest_threshold, "numeric")
-    ) {
-      results_full <-
-        results_full %>%
-        dplyr::filter(
-          .data$Age <= interest_threshold
-        )
-    }
-
-    # final tibble (sort samples by age)
-    results_full_fin <-
       results_full %>%
-      dplyr::arrange(.data$Age)
+      dplyr::filter(
+        .data$Age <= interest_threshold
+      )
+  }
 
+  # final tibble (sort samples by age)
+  results_full_fin <-
+    results_full %>%
+    dplyr::arrange(.data$Age)
 
-    # time duration output
-    end_time <- Sys.time()
-    time_duration <- end_time - start_time
+  # time duration output
+  end_time <- Sys.time()
+  time_duration <- end_time - start_time
 
+  if (isFALSE(silence)) {
     RUtilpol::output_heading(
       paste(
-        "RRatepol finished", end_time, "taking",
-        round(time_duration, 2), units(time_duration)
+        "RRatepol finished",
+        end_time,
+        "taking",
+        round(time_duration, 2),
+        units(time_duration)
       ),
       size = "h1"
     )
-
-    return(results_full_fin)
   }
+
+  return(results_full_fin)
+}
 # end of code

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -19,7 +19,7 @@
 #' }
 #' @param verbose DESCRIPTION.
 #' Logical. If `TRUE`, function will output messages about internal processes
-#' @param silence
+#' @param silent
 #' Logical. If `TRUE`, suppress all console outputs (overrides verbose). Useful for testing.
 #' @description
 #' Function for general preparation of input data
@@ -28,7 +28,7 @@ extract_data <- function(
   data_age_extract,
   age_uncertainty = NULL,
   verbose = FALSE,
-  silence = FALSE
+  silent =FALSE
 ) {
   # 1. Initial tests -----
 
@@ -36,9 +36,9 @@ extract_data <- function(
 
   RUtilpol::check_class("verbose", "logical")
 
-  RUtilpol::check_class("silence", "logical")
+  RUtilpol::check_class("silent", "logical")
 
-  if (isFALSE(silence) && isTRUE(verbose)) {
+  if (isFALSE(silent) && isTRUE(verbose)) {
     RUtilpol::output_heading(
       paste(
         "Data extraction started",
@@ -58,7 +58,7 @@ extract_data <- function(
   # community
 
   if ("sample.id" %in% names(data_community_extract)) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       usethis::ui_oops(
         paste(
           "'sample.id' was detected in 'data_community'",
@@ -83,7 +83,7 @@ extract_data <- function(
 
   # age
   if ("sample.id" %in% names(data_age_extract)) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       usethis::ui_oops(
         paste(
           "'sample.id' was detected in 'data_age' but 'sample_id' is prefered.",
@@ -184,7 +184,7 @@ extract_data <- function(
 
   # 2.4 Missing values ---
   if (any(is.na(dat_community))) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       RUtilpol::output_warning(
         paste(
           "Missing data has been detected in community data",
@@ -204,7 +204,7 @@ extract_data <- function(
   }
 
   if (any(is.na(dat_age$age))) {
-    if (isFALSE(silence)) {
+    if (isFALSE(silent)) {
       RUtilpol::output_warning(
         paste(
           "Missing 'age' values has detected in age data",
@@ -236,10 +236,10 @@ extract_data <- function(
       check_levels = TRUE
     )
 
-  if (isFALSE(silence) && isTRUE(verbose)) {
+  if (isFALSE(silent) && isTRUE(verbose)) {
     check_data(
       data_source_check = dat_merge,
-      silence = silence
+      silent =silent
     )
 
     RUtilpol::output_heading(

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -28,7 +28,7 @@ extract_data <- function(
   data_age_extract,
   age_uncertainty = NULL,
   verbose = FALSE,
-  silent =FALSE
+  silent = FALSE
 ) {
   # 1. Initial tests -----
 
@@ -239,7 +239,7 @@ extract_data <- function(
   if (isFALSE(silent) && isTRUE(verbose)) {
     check_data(
       data_source_check = dat_merge,
-      silent =silent
+      silent = silent
     )
 
     RUtilpol::output_heading(

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -19,44 +19,46 @@
 #' }
 #' @param verbose DESCRIPTION.
 #' Logical. If `TRUE`, function will output messages about internal processes
+#' @param silence
+#' Logical. If `TRUE`, suppress all console outputs (overrides verbose). Useful for testing.
 #' @description
 #' Function for general preparation of input data
-extract_data <-
-  function(data_community_extract,
-           data_age_extract,
-           age_uncertainty = NULL,
-           verbose = FALSE) {
+extract_data <- function(
+  data_community_extract,
+  data_age_extract,
+  age_uncertainty = NULL,
+  verbose = FALSE,
+  silence = FALSE
+) {
+  # 1. Initial tests -----
 
-    # 1. Initial tests -----
+  # 1.1 Data types -----
 
-    # 1.1 Data types -----
+  RUtilpol::check_class("verbose", "logical")
 
-    RUtilpol::check_class("verbose", "logical")
+  RUtilpol::check_class("silence", "logical")
 
-    if (
-      isTRUE(verbose)
-    ) {
-      RUtilpol::output_heading(
-        paste(
-          "Data extraction started",
-          Sys.time()
-        ),
-        size = "h2"
-      )
-    }
+  if (isFALSE(silence) && isTRUE(verbose)) {
+    RUtilpol::output_heading(
+      paste(
+        "Data extraction started",
+        Sys.time()
+      ),
+      size = "h2"
+    )
+  }
 
-    RUtilpol::check_class("data_community_extract", "data.frame")
+  RUtilpol::check_class("data_community_extract", "data.frame")
 
-    RUtilpol::check_class("data_age_extract", "data.frame")
+  RUtilpol::check_class("data_age_extract", "data.frame")
 
-    RUtilpol::check_class("age_uncertainty", c("NULL", "matrix"))
+  RUtilpol::check_class("age_uncertainty", c("NULL", "matrix"))
 
-    # 1.2. Sample id -----
-    # community
+  # 1.2. Sample id -----
+  # community
 
-    if (
-      "sample.id" %in% names(data_community_extract)
-    ) {
+  if ("sample.id" %in% names(data_community_extract)) {
+    if (isFALSE(silence)) {
       usethis::ui_oops(
         paste(
           "'sample.id' was detected in 'data_community'",
@@ -64,194 +66,190 @@ extract_data <-
           "Recommend renaming your data"
         )
       )
-
-      data_community_extract <-
-        data_community_extract %>%
-        dplyr::rename(sample_id = .data$sample.id)
     }
 
-    RUtilpol::check_col_names("data_community_extract", "sample_id")
+    data_community_extract <-
+      data_community_extract %>%
+      dplyr::rename(sample_id = .data$sample.id)
+  }
 
-    assertthat::assert_that(
-      "character" %in% class(data_community_extract$sample_id),
-      msg = "Variable 'sample_id' in 'data_community' must
+  RUtilpol::check_col_names("data_community_extract", "sample_id")
+
+  assertthat::assert_that(
+    "character" %in% class(data_community_extract$sample_id),
+    msg = "Variable 'sample_id' in 'data_community' must
     be a 'character'"
-    )
+  )
 
-    # age
-    if (
-      "sample.id" %in% names(data_age_extract)
-    ) {
+  # age
+  if ("sample.id" %in% names(data_age_extract)) {
+    if (isFALSE(silence)) {
       usethis::ui_oops(
         paste(
           "'sample.id' was detected in 'data_age' but 'sample_id' is prefered.",
           "Recomend renaming your data"
         )
       )
-
-      data_age_extract <-
-        data_age_extract %>%
-        dplyr::rename(sample_id = .data$sample.id)
     }
 
-    RUtilpol::check_col_names("data_age_extract", "sample_id")
+    data_age_extract <-
+      data_age_extract %>%
+      dplyr::rename(sample_id = .data$sample.id)
+  }
 
-    assertthat::assert_that(
-      all(data_community_extract$sample_id %in% data_age_extract$sample_id) &&
-        all(data_age_extract$sample_id %in% data_community_extract$sample_id),
-      msg = "Variable 'sample_id' must have same values in
+  RUtilpol::check_col_names("data_age_extract", "sample_id")
+
+  assertthat::assert_that(
+    all(data_community_extract$sample_id %in% data_age_extract$sample_id) &&
+      all(data_age_extract$sample_id %in% data_community_extract$sample_id),
+    msg = "Variable 'sample_id' must have same values in
     'data_age' and 'data_community'"
-    )
+  )
 
-    # 1.3. Age test -----
+  # 1.3. Age test -----
 
-    RUtilpol::check_col_names("data_age_extract", "sample_id")
+  RUtilpol::check_col_names("data_age_extract", "sample_id")
 
-    assertthat::assert_that(
-      "numeric" %in% class(data_age_extract$age),
-      msg = "Variable 'age' in 'data_source_age' must be a 'numeric'"
-    )
+  assertthat::assert_that(
+    "numeric" %in% class(data_age_extract$age),
+    msg = "Variable 'age' in 'data_source_age' must be a 'numeric'"
+  )
 
-    if (
-      isTRUE(is.unsorted(data_age_extract$age))
-    ) {
-      # order of the age
-      data_age_extract <-
-        data_age_extract %>%
-        dplyr::arrange(.data$age)
-    }
+  if (isTRUE(is.unsorted(data_age_extract$age))) {
+    # order of the age
+    data_age_extract <-
+      data_age_extract %>%
+      dplyr::arrange(.data$age)
+  }
 
-    # 1.4. Size test -----
+  # 1.4. Size test -----
 
-    n_samples_com <- nrow(data_community_extract)
-    n_samples_age <- nrow(data_age_extract)
+  n_samples_com <- nrow(data_community_extract)
+  n_samples_age <- nrow(data_age_extract)
 
-    assertthat::assert_that(
-      n_samples_com == n_samples_age,
-      msg = "Object 'data_community' and 'data_age'
+  assertthat::assert_that(
+    n_samples_com == n_samples_age,
+    msg = "Object 'data_community' and 'data_age'
     must have the same number of levels"
-    )
+  )
 
-    # 2. Processes data -----
+  # 2. Processes data -----
 
-    # 2.1 Extract data  -----
+  # 2.1 Extract data  -----
 
-    # extract both important tables if stored as tibbles
-    dat_age <-
-      as.data.frame(data_age_extract)
-    dat_community <-
-      as.data.frame(data_community_extract)
+  # extract both important tables if stored as tibbles
+  dat_age <-
+    as.data.frame(data_age_extract)
+  dat_community <-
+    as.data.frame(data_community_extract)
 
-    # select only variable 'age' and 'sample id'
-    dat_age <-
-      dat_age %>%
-      dplyr::select("sample_id", "age")
+  # select only variable 'age' and 'sample id'
+  dat_age <-
+    dat_age %>%
+    dplyr::select("sample_id", "age")
 
-    # 2.2 Row.names  -----
+  # 2.2 Row.names  -----
 
-    # add row.names to commity, age, and uncertainty data
-    dat_community <-
-      dat_community %>%
-      tibble::column_to_rownames("sample_id")
+  # add row.names to commity, age, and uncertainty data
+  dat_community <-
+    dat_community %>%
+    tibble::column_to_rownames("sample_id")
 
-    dat_age <-
-      dat_age %>%
-      tibble::column_to_rownames("sample_id")
+  dat_age <-
+    dat_age %>%
+    tibble::column_to_rownames("sample_id")
 
-    # 2.3 Age uncertainty  -----
+  # 2.3 Age uncertainty  -----
 
-    # if age_uncertainty is used
-    if (
-      isFALSE(is.null(age_uncertainty))
-    ) {
-      RUtilpol::check_class("age_uncertainty", "matrix")
+  # if age_uncertainty is used
+  if (isFALSE(is.null(age_uncertainty))) {
+    RUtilpol::check_class("age_uncertainty", "matrix")
 
-      n_samples_un <- ncol(age_uncertainty)
+    n_samples_un <- ncol(age_uncertainty)
 
-      assertthat::assert_that(
-        n_samples_age == n_samples_un,
-        msg = "Object 'data_source_age' and 'age_uncertainty' must have
+    assertthat::assert_that(
+      n_samples_age == n_samples_un,
+      msg = "Object 'data_source_age' and 'age_uncertainty' must have
       the same number of levels. 'age_uncertainty' must have samples stored as
       columns"
-      )
+    )
 
-      # save as dataframe
-      age_un <- data.frame(age_uncertainty)
+    # save as dataframe
+    age_un <- data.frame(age_uncertainty)
 
-      names(age_un) <- row.names(dat_age)
-    } else {
-      age_un <- NULL
-    }
+    names(age_un) <- row.names(dat_age)
+  } else {
+    age_un <- NULL
+  }
 
-    # 2.4 Missing values ---
-    if (
-      any(is.na(dat_community))
-    ) {
+  # 2.4 Missing values ---
+  if (any(is.na(dat_community))) {
+    if (isFALSE(silence)) {
       RUtilpol::output_warning(
         paste(
           "Missing data has been detected in community data",
           "and automatically replaces with '0'"
         )
       )
-
-      dat_community <-
-        dat_community %>%
-        dplyr::mutate(
-          dplyr::across(
-            dplyr::everything(),
-            ~ tidyr::replace_na(.x, 0)
-          )
-        )
     }
 
-    if (
-      any(is.na(dat_age$age))
-    ) {
+    dat_community <-
+      dat_community %>%
+      dplyr::mutate(
+        dplyr::across(
+          dplyr::everything(),
+          ~ tidyr::replace_na(.x, 0)
+        )
+      )
+  }
+
+  if (any(is.na(dat_age$age))) {
+    if (isFALSE(silence)) {
       RUtilpol::output_warning(
         paste(
           "Missing 'age' values has detected in age data",
           "Such levels has been filtered out"
         )
       )
-
-      dat_age <-
-        dat_age %>%
-        tidyr::drop_na(.data$age)
     }
 
-    # 2.5 Summary  ----
-
-    # create list of 3 variables pollen, age, age_un
-    dat_merge <-
-      list(
-        community = dat_community,
-        age = dat_age,
-        age_un = age_un
-      )
-
-    #  exclude redundnat rows and columns
-    dat_merge <-
-      reduce_data(
-        data_source_reduce = dat_merge,
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    if (
-      isTRUE(verbose)
-    ) {
-      check_data(
-        data_source_check = dat_merge
-      )
-
-      RUtilpol::output_heading(
-        paste(
-          "Data extraction completed",
-          Sys.time()
-        ),
-        size = "h2"
-      )
-    }
-
-    return(dat_merge)
+    dat_age <-
+      dat_age %>%
+      tidyr::drop_na(.data$age)
   }
+
+  # 2.5 Summary  ----
+
+  # create list of 3 variables pollen, age, age_un
+  dat_merge <-
+    list(
+      community = dat_community,
+      age = dat_age,
+      age_un = age_un
+    )
+
+  #  exclude redundnat rows and columns
+  dat_merge <-
+    reduce_data(
+      data_source_reduce = dat_merge,
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  if (isFALSE(silence) && isTRUE(verbose)) {
+    check_data(
+      data_source_check = dat_merge,
+      silence = silence
+    )
+
+    RUtilpol::output_heading(
+      paste(
+        "Data extraction completed",
+        Sys.time()
+      ),
+      size = "h2"
+    )
+  }
+
+  return(dat_merge)
+}

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -215,7 +215,7 @@ extract_data <- function(
 
     dat_age <-
       dat_age %>%
-      tidyr::drop_na(.data$age)
+      tidyr::drop_na("age")
   }
 
   # 2.5 Summary  ----

--- a/R/make_bins.R
+++ b/R/make_bins.R
@@ -4,125 +4,122 @@
 #' @param data_source_bins
 #' List with `community` and `age`
 #' @keywords internal
-make_bins <-
-    function(data_source_bins,
-             working_units = c("levels", "bins", "MW"),
-             bin_size = 500,
-             number_of_shifts = 5) {
-        RUtilpol::check_class("data_source_bins", "list")
+make_bins <- function(
+  data_source_bins,
+  working_units = c("levels", "bins", "MW"),
+  bin_size = 500,
+  number_of_shifts = 5
+) {
+  RUtilpol::check_class("data_source_bins", "list")
 
-        RUtilpol::check_class("working_units", "character")
+  RUtilpol::check_class("working_units", "character")
 
-        RUtilpol::check_vector_values(
-            "working_units",
-            c("levels", "bins", "MW")
+  RUtilpol::check_vector_values(
+    "working_units",
+    c("levels", "bins", "MW")
+  )
+
+  working_units <- match.arg(working_units)
+
+  age_dat <-
+    data_source_bins$age
+
+  if (working_units == "levels") {
+    n_levels <-
+      nrow(age_dat)
+
+    age_dat_longer <-
+      dplyr::bind_rows(
+        age_dat,
+        data.frame(
+          age = Inf,
+          row.names = c("Inf")
         )
+      )
 
-        working_units <- match.arg(working_units)
+    age_vec <-
+      age_dat_longer[, "age"]
 
-        age_dat <-
-            data_source_bins$age
+    res <-
+      data.frame(
+        name = rownames(age_dat_longer)[1:n_levels],
+        shift = 1
+      ) %>%
+      dplyr::mutate(
+        age_diff = abs(
+          age_vec[1 + (1:n_levels)] -
+            age_vec[1:n_levels]
+        ),
+        age_diff = ifelse(.data$age_diff == 0, 0.1, .data$age_diff),
+        start = as.character(.data$name),
+        end = as.character(
+          rownames(age_dat_longer)[1 + 1:n_levels]
+        ),
+        res_age = age_vec[1:n_levels],
+        label = paste(.data$start, .data$end, sep = "-")
+      )
+    return(res)
+  }
 
-        if (
-            working_units == "levels"
-        ) {
-            n_levels <-
-                nrow(age_dat)
+  RUtilpol::check_class("bin_size", "numeric")
 
-            age_dat_longer <-
-                dplyr::bind_rows(
-                    age_dat,
-                    data.frame(
-                        age = Inf,
-                        row.names = c("Inf")
-                    )
-                )
+  RUtilpol::check_if_integer("bin_size")
 
-            age_vec <-
-                age_dat_longer[, "age"]
+  bin_oldest <-
+    ceiling(
+      max(age_dat$age)
+    ) +
+    bin_size
 
-            res <-
-                data.frame(
-                    name = rownames(age_dat_longer)[1:n_levels],
-                    shift = 1
-                ) %>%
-                dplyr::mutate(
-                    age_diff = abs(
-                        age_vec[1 + (1:n_levels)] -
-                            age_vec[1:n_levels]
-                    ),
-                    age_diff = ifelse(.data$age_diff == 0, 0.1, .data$age_diff),
-                    start = as.character(.data$name),
-                    end = as.character(
-                        rownames(age_dat_longer)[1 + 1:n_levels]
-                    ),
-                    res_age = age_vec[1:n_levels],
-                    label = paste(.data$start, .data$end, sep = "-")
-                )
-            return(res)
-        }
+  bin_youngest <-
+    floor(
+      min(age_dat$age)
+    )
 
-        RUtilpol::check_class("bin_size", "numeric")
+  bin_breaks <- seq(
+    from = bin_youngest,
+    to = bin_oldest,
+    by = bin_size
+  )
 
-        RUtilpol::check_if_integer("bin_size")
+  if (working_units == "bins") {
+    res_df <-
+      data.frame(
+        name = bin_breaks,
+        shift = 1
+      )
+  } else {
+    RUtilpol::check_class("number_of_shifts", "numeric")
 
-        bin_oldest <-
-            ceiling(
-                max(age_dat$age)
-            ) + bin_size
+    RUtilpol::check_if_integer("number_of_shifts")
+  }
 
-        bin_youngest <-
-            floor(
-                min(age_dat$age)
-            )
+  if (working_units == "MW") {
+    shift_value <- bin_size / number_of_shifts
 
-        bin_breaks <- seq(
-            from = bin_youngest,
-            to = bin_oldest,
-            by = bin_size
-        )
+    shift_increment <-
+      shift_value *
+      sort(
+        rep(0:(number_of_shifts - 1), length(bin_breaks))
+      )
 
-        if (
-            working_units == "bins"
-        ) {
-            res_df <-
-                data.frame(
-                    name = bin_breaks,
-                    shift = 1
-                )
-        } else {
-            RUtilpol::check_class("number_of_shifts", "numeric")
+    res_df <-
+      data.frame(
+        name = (rep(bin_breaks, number_of_shifts) +
+          shift_increment),
+        shift = sort(rep(c(1:number_of_shifts), length(bin_breaks)))
+      )
+  }
 
-            RUtilpol::check_if_integer("number_of_shifts")
-        }
+  res <-
+    res_df %>%
+    dplyr::mutate(
+      age_diff = bin_size,
+      start = .data$name,
+      end = .data$start + bin_size,
+      res_age = (.data$end + .data$start) / 2,
+      label = paste(.data$start, .data$end, sep = "-")
+    )
 
-        if (
-            working_units == "MW"
-        ) {
-            shift_value <- bin_size / number_of_shifts
-
-            shift_increment <-
-                shift_value * sort(
-                    rep(0:(number_of_shifts - 1), length(bin_breaks))
-                )
-
-            res_df <-
-                data.frame(
-                    name = (rep(bin_breaks, number_of_shifts) +
-                        shift_increment),
-                    shift = sort(rep(c(1:number_of_shifts), length(bin_breaks)))
-                )
-        }
-
-        res <-
-            res_df %>%
-            dplyr::mutate(
-                age_diff = bin_size,
-                start = .data$name,
-                end = .data$start + bin_size,
-                res_age = (.data$end + .data$start) / 2,
-                label = paste(.data$start, .data$end, sep = "-")
-            )
-
-        return(res)
-    }
+  return(res)
+}

--- a/R/plot_roc.R
+++ b/R/plot_roc.R
@@ -80,172 +80,159 @@
 #'   trend = "trend_non_linear"
 #' )
 #' }
-plot_roc <-
-  function(data_source,
-           age_threshold = NULL,
-           roc_threshold = NULL,
-           peaks = FALSE,
-           trend = NULL) {
+plot_roc <- function(
+  data_source,
+  age_threshold = NULL,
+  roc_threshold = NULL,
+  peaks = FALSE,
+  trend = NULL,
+  silence = FALSE
+) {
+  # age_threshold
+  RUtilpol::check_class("data_source", "data.frame")
 
-    # age_threshold
-    RUtilpol::check_class("data_source", "data.frame")
+  RUtilpol::check_col_names(
+    "data_source",
+    c("Age", "ROC", "ROC_up", "ROC_dw")
+  )
 
-    RUtilpol::check_col_names(
-      "data_source",
-      c("Age", "ROC", "ROC_up", "ROC_dw")
+  RUtilpol::check_class("age_threshold", c("NULL", "numeric"))
+
+  if (isTRUE(is.null(age_threshold))) {
+    age_threshold <- max(data_source$Age)
+  }
+
+  data_source_filter <-
+    data_source %>%
+    dplyr::filter(.data$Age <= age_threshold)
+
+  # roc_threshold
+  RUtilpol::check_class("roc_threshold", c("NULL", "numeric"))
+
+  if (isTRUE(is.null(roc_threshold))) {
+    roc_threshold <- max(data_source$ROC_up)
+  }
+
+  RUtilpol::check_class("peaks", "logical")
+
+  RUtilpol::check_class("trend", c("NULL", "character"))
+
+  p_res <-
+    ggplot2::ggplot(
+      data_source_filter,
+      mapping = ggplot2::aes(
+        y = .data$ROC,
+        x = .data$Age
+      )
+    ) +
+    ggplot2::theme_classic() +
+    ggplot2::scale_x_continuous(trans = "reverse") +
+    ggplot2::geom_vline(
+      xintercept = seq(0, age_threshold, 2e3),
+      colour = "gray90",
+      size = 0.1
+    ) +
+    ggplot2::coord_flip(
+      xlim = c(age_threshold, 0),
+      ylim = c(0, roc_threshold)
+    ) +
+    ggplot2::geom_ribbon(
+      mapping = ggplot2::aes(
+        ymin = .data$ROC_up,
+        ymax = .data$ROC_dw
+      ),
+      fill = "gray90"
+    ) +
+    ggplot2::geom_line(
+      alpha = 1,
+      size = 1,
+      color = "gray30"
+    ) +
+    ggplot2::geom_hline(
+      yintercept = 0,
+      color = "gray30",
+      lty = 3
+    ) +
+    ggplot2::labs(
+      x = "Age (cal yr BP)",
+      y = "Rate of change score"
     )
 
-    RUtilpol::check_class("age_threshold", c("NULL", "numeric"))
+  if (isFALSE(is.null(trend))) {
+    RUtilpol::check_vector_values(
+      "trend",
+      c("threshold", "trend_linear", "trend_non_linear")
+    )
 
-
-    if (
-      isTRUE(is.null(age_threshold))
-    ) {
-      age_threshold <- max(data_source$Age)
-    }
-
-    data_source_filter <-
-      data_source %>%
-      dplyr::filter(.data$Age <= age_threshold)
-
-    # roc_threshold
-    RUtilpol::check_class("roc_threshold", c("NULL", "numeric"))
-
-    if (
-      isTRUE(is.null(roc_threshold))
-    ) {
-      roc_threshold <- max(data_source$ROC_up)
-    }
-
-    RUtilpol::check_class("peaks", "logical")
-
-    RUtilpol::check_class("trend", c("NULL", "character"))
-
-    p_res <-
-      ggplot2::ggplot(
-        data_source_filter,
-        mapping = ggplot2::aes(
-          y = .data$ROC,
-          x = .data$Age
-        )
-      ) +
-      ggplot2::theme_classic() +
-      ggplot2::scale_x_continuous(trans = "reverse") +
-      ggplot2::geom_vline(
-        xintercept = seq(0, age_threshold, 2e3),
-        colour = "gray90",
-        size = 0.1
-      ) +
-      ggplot2::coord_flip(
-        xlim = c(age_threshold, 0),
-        ylim = c(0, roc_threshold)
-      ) +
-      ggplot2::geom_ribbon(
-        mapping = ggplot2::aes(
-          ymin = .data$ROC_up,
-          ymax = .data$ROC_dw
-        ),
-        fill = "gray90"
-      ) +
-      ggplot2::geom_line(
-        alpha = 1,
-        size = 1,
-        color = "gray30"
-      ) +
-      ggplot2::geom_hline(
-        yintercept = 0,
-        color = "gray30",
-        lty = 3
-      ) +
-      ggplot2::labs(
-        x = "Age (cal yr BP)",
-        y = "Rate of change score"
-      )
-
-    if (
-      isFALSE(is.null(trend))
-    ) {
-      RUtilpol::check_vector_values(
-        "trend",
-        c("threshold", "trend_linear", "trend_non_linear")
-      )
-
-      if (
-        isFALSE(peaks)
-      ) {
+    if (isFALSE(peaks)) {
+      if (isFALSE(silence)) {
         RUtilpol::output_comment(
           msg = paste(
             "'trend' has been set to NOT 'NULL',",
             "'peaks' will be plotted"
           )
         )
-        # set peaks
-        peaks <- TRUE
       }
-
-      if (
-        trend == "threshold"
-      ) {
-        p_res <-
-          p_res +
-          ggplot2::geom_hline(
-            yintercept = stats::median(data_source_filter$ROC),
-            color = "blue",
-            size = 1
-          )
-      }
-
-      if (
-        trend == "trend_linear"
-      ) {
-        p_res <-
-          p_res +
-          ggplot2::geom_line(
-            data = data.frame(
-              ROC = make_trend(
-                data_source = data_source,
-                sel_method = "linear"
-              ),
-              Age = data_source$Age
-            ),
-            color = "blue", size = 1
-          )
-      }
-
-      if (
-        trend == "trend_non_linear"
-      ) {
-        p_res <-
-          p_res +
-          ggplot2::geom_line(
-            data = data.frame(
-              ROC = make_trend(
-                data_source = data_source,
-                sel_method = "non_linear"
-              ),
-              Age = data_source$Age
-            ),
-            color = "blue",
-            size = 1
-          )
-      }
+      # set peaks
+      peaks <- TRUE
     }
 
-    if (
-      isTRUE(peaks)
-    ) {
-      RUtilpol::check_col_names("data_source", "Peak")
-
+    if (trend == "threshold") {
       p_res <-
         p_res +
-        ggplot2::geom_point(
-          data = data_source_filter %>%
-            dplyr::filter(.data$Peak == TRUE),
-          color = "green",
-          alpha = 1,
-          size = 3
+        ggplot2::geom_hline(
+          yintercept = stats::median(data_source_filter$ROC),
+          color = "blue",
+          size = 1
         )
     }
 
-    return(p_res)
+    if (trend == "trend_linear") {
+      p_res <-
+        p_res +
+        ggplot2::geom_line(
+          data = data.frame(
+            ROC = make_trend(
+              data_source = data_source,
+              sel_method = "linear"
+            ),
+            Age = data_source$Age
+          ),
+          color = "blue",
+          size = 1
+        )
+    }
+
+    if (trend == "trend_non_linear") {
+      p_res <-
+        p_res +
+        ggplot2::geom_line(
+          data = data.frame(
+            ROC = make_trend(
+              data_source = data_source,
+              sel_method = "non_linear"
+            ),
+            Age = data_source$Age
+          ),
+          color = "blue",
+          size = 1
+        )
+    }
   }
+
+  if (isTRUE(peaks)) {
+    RUtilpol::check_col_names("data_source", "Peak")
+
+    p_res <-
+      p_res +
+      ggplot2::geom_point(
+        data = data_source_filter %>%
+          dplyr::filter(.data$Peak == TRUE),
+        color = "green",
+        alpha = 1,
+        size = 3
+      )
+  }
+
+  return(p_res)
+}

--- a/R/plot_roc.R
+++ b/R/plot_roc.R
@@ -86,7 +86,7 @@ plot_roc <- function(
   roc_threshold = NULL,
   peaks = FALSE,
   trend = NULL,
-  silence = FALSE
+  silent =FALSE
 ) {
   # age_threshold
   RUtilpol::check_class("data_source", "data.frame")
@@ -165,7 +165,7 @@ plot_roc <- function(
     )
 
     if (isFALSE(peaks)) {
-      if (isFALSE(silence)) {
+      if (isFALSE(silent)) {
         RUtilpol::output_comment(
           msg = paste(
             "'trend' has been set to NOT 'NULL',",

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -106,7 +106,7 @@ prepare_data <- function(
         tibble::rownames_to_column("row_name"),
       by = "row_name"
     ) %>%
-    dplyr::relocate(.data$age) %>%
+    dplyr::relocate("age") %>%
     tibble::column_to_rownames("row_name")
 
   shift_vec <-

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -7,173 +7,160 @@
 #' Create a single list with all information needed to estimate RoC.
 #' This is done because such list can be then evaluated in parallel.
 #' @keywords internal
-prepare_data <-
-    function(data_source_prep,
-             working_units = c("levels", "bins", "MW"),
-             bin_size = 500,
-             number_of_shifts = 5,
-             rand = NULL) {
-        RUtilpol::check_class("data_source_prep", "list")
+prepare_data <- function(
+  data_source_prep,
+  working_units = c("levels", "bins", "MW"),
+  bin_size = 500,
+  number_of_shifts = 5,
+  rand = NULL
+) {
+  RUtilpol::check_class("data_source_prep", "list")
 
-        RUtilpol::check_class("working_units", "character")
+  RUtilpol::check_class("working_units", "character")
 
-        RUtilpol::check_vector_values("working_units", c("levels", "bins", "MW"))
+  RUtilpol::check_vector_values("working_units", c("levels", "bins", "MW"))
 
-        working_units <- match.arg(working_units)
+  working_units <- match.arg(working_units)
 
-        RUtilpol::check_class("bin_size", "numeric")
+  RUtilpol::check_class("bin_size", "numeric")
 
-        RUtilpol::check_if_integer("bin_size")
+  RUtilpol::check_if_integer("bin_size")
 
-        RUtilpol::check_class("rand", c("NULL", "numeric"))
+  RUtilpol::check_class("rand", c("NULL", "numeric"))
 
-        # check the condition
-        is_shift_present <-
-            working_units == "MW" && (number_of_shifts != 0)
+  # check the condition
+  is_shift_present <-
+    working_units == "MW" && (number_of_shifts != 0)
 
-        if (
-            isFALSE(is_shift_present)
-        ) {
-            number_of_shifts <- 1
-        } else {
-            RUtilpol::check_class("number_of_shifts", "numeric")
-            RUtilpol::check_if_integer("number_of_shifts")
-        }
+  if (isFALSE(is_shift_present)) {
+    number_of_shifts <- 1
+  } else {
+    RUtilpol::check_class("number_of_shifts", "numeric")
+    RUtilpol::check_if_integer("number_of_shifts")
+  }
 
-        is_rand_present <-
-            isFALSE(is.null(rand))
+  is_rand_present <-
+    isFALSE(is.null(rand))
 
-        if (
-            isTRUE(is_rand_present)
-        ) {
-            RUtilpol::check_if_integer("rand")
-        } else {
-            rand <- 1
-        }
+  if (isTRUE(is_rand_present)) {
+    RUtilpol::check_if_integer("rand")
+  } else {
+    rand <- 1
+  }
 
-        if (
-            working_units == "levels"
-        ) {
-            bin_dummy <-
-                make_bins(
-                    data_source_bins = data_source_prep,
-                    working_units = "levels"
-                )
-        } else if (
-            isTRUE(is_shift_present)
-        ) {
-            bin_dummy <-
-                make_bins(
-                    data_source_bins = data_source_prep,
-                    working_units = "MW",
-                    bin_size = bin_size,
-                    number_of_shifts = number_of_shifts
-                )
-        } else {
-            bin_dummy <-
-                make_bins(
-                    data_source_bins = data_source_prep,
-                    working_units = "bins",
-                    bin_size = bin_size
-                )
-        }
+  if (working_units == "levels") {
+    bin_dummy <-
+      make_bins(
+        data_source_bins = data_source_prep,
+        working_units = "levels"
+      )
+  } else if (isTRUE(is_shift_present)) {
+    bin_dummy <-
+      make_bins(
+        data_source_bins = data_source_prep,
+        working_units = "MW",
+        bin_size = bin_size,
+        number_of_shifts = number_of_shifts
+      )
+  } else {
+    bin_dummy <-
+      make_bins(
+        data_source_bins = data_source_prep,
+        working_units = "bins",
+        bin_size = bin_size
+      )
+  }
 
-        is_uncertit_present <-
-            isFALSE(is.null(data_source_prep$age_un))
+  is_uncertit_present <-
+    isFALSE(is.null(data_source_prep$age_un))
 
-        if (
-            isTRUE(is_uncertit_present)
-        ) {
-            if (
-                isTRUE(is_rand_present)
-            ) {
-                random_value <-
-                    sample(
-                        c(
-                            1:max(1, nrow(data_source_prep$age_un))
-                        ),
-                        rand,
-                        replace = TRUE
-                    )
+  if (isTRUE(is_uncertit_present)) {
+    if (isTRUE(is_rand_present)) {
+      random_value <-
+        sample(
+          c(
+            1:max(1, nrow(data_source_prep$age_un))
+          ),
+          rand,
+          replace = TRUE
+        )
 
-                random_age <-
-                    purrr::map(
-                        .x = seq_along(random_value),
-                        .f = ~ as.numeric(
-                            data_source_prep$age_un[random_value[.x], ]
-                        )
-                    )
-            } else {
-                random_age <-
-                    list(data_source_prep$age$age)
-            }
-        }
-
-        data_merge <-
-            data_source_prep$community %>%
-            tibble::rownames_to_column("row_name") %>%
-            dplyr::left_join(
-                data_source_prep$age %>%
-                    tibble::rownames_to_column("row_name"),
-                by = "row_name"
-            ) %>%
-            dplyr::relocate(.data$age) %>%
-            tibble::column_to_rownames("row_name")
-
-        shift_vec <-
-            c(1:number_of_shifts) %>%
-            rlang::set_names(
-                nm = as.character(1:number_of_shifts)
-            )
-
-        rand_vec <-
-            c(1:rand) %>%
-            rlang::set_names(
-                nm = as.character(1:rand)
-            )
-
-        if (
-            # is_rand_present is TRUE
-            isFALSE(is_uncertit_present)
-        ) {
-            rand_vec %>%
-                purrr::map(
-                    .f = ~ purrr::map(
-                        .x = shift_vec,
-                        .f = ~
-                            list(
-                                data = data_merge,
-                                bins = bin_dummy %>%
-                                    dplyr::filter(shift == .x)
-                            )
-                    )
-                ) %>%
-                return()
-        } else {
-            # is_uncertit_present is TRUE
-            rand_vec %>%
-                purrr::map(
-                    .f = ~ {
-                        data_with_random_age <-
-                            data_merge %>%
-                            dplyr::mutate(
-                                age = random_age[[.x]]
-                            )
-
-                        purrr::map(
-                            .x = shift_vec,
-                            .f = ~
-                                list(
-                                    data = data_with_random_age,
-                                    bins = bin_dummy %>%
-                                        dplyr::filter(shift == .x)
-                                ) %>%
-                                    return()
-                        ) %>%
-                            return()
-                    }
-                ) %>%
-                return()
-        }
-        # stop("Not a valid setting for creating bins")
+      random_age <-
+        purrr::map(
+          .x = seq_along(random_value),
+          .f = ~ as.numeric(
+            data_source_prep$age_un[random_value[.x], ]
+          )
+        )
+    } else {
+      random_age <-
+        list(data_source_prep$age$age)
     }
+  }
+
+  data_merge <-
+    data_source_prep$community %>%
+    tibble::rownames_to_column("row_name") %>%
+    dplyr::left_join(
+      data_source_prep$age %>%
+        tibble::rownames_to_column("row_name"),
+      by = "row_name"
+    ) %>%
+    dplyr::relocate(.data$age) %>%
+    tibble::column_to_rownames("row_name")
+
+  shift_vec <-
+    c(1:number_of_shifts) %>%
+    rlang::set_names(
+      nm = as.character(1:number_of_shifts)
+    )
+
+  rand_vec <-
+    c(1:rand) %>%
+    rlang::set_names(
+      nm = as.character(1:rand)
+    )
+
+  if (
+    # is_rand_present is TRUE
+    isFALSE(is_uncertit_present)
+  ) {
+    rand_vec %>%
+      purrr::map(
+        .f = ~ purrr::map(
+          .x = shift_vec,
+          .f = ~ list(
+            data = data_merge,
+            bins = bin_dummy %>%
+              dplyr::filter(shift == .x)
+          )
+        )
+      ) %>%
+      return()
+  } else {
+    # is_uncertit_present is TRUE
+    rand_vec %>%
+      purrr::map(
+        .f = ~ {
+          data_with_random_age <-
+            data_merge %>%
+            dplyr::mutate(
+              age = random_age[[.x]]
+            )
+
+          purrr::map(
+            .x = shift_vec,
+            .f = ~ list(
+              data = data_with_random_age,
+              bins = bin_dummy %>%
+                dplyr::filter(shift == .x)
+            ) %>%
+              return()
+          ) %>%
+            return()
+        }
+      ) %>%
+      return()
+  }
+  # stop("Not a valid setting for creating bins")
+}

--- a/R/run_iteration.R
+++ b/R/run_iteration.R
@@ -14,158 +14,149 @@
 #' }
 #' @seealso [estimate_roc()]
 #' @keywords internal
-run_iteration <-
-    function(data_source_run,
-             bin_selection = "first",
-             standardise = FALSE,
-             n_individuals = 150,
-             tranform_to_proportions = TRUE,
-             dissimilarity_coefficient = "euc",
-             time_standardisation = 500,
-             verbose = FALSE) {
+run_iteration <- function(
+    data_source_run,
+    bin_selection = "first",
+    standardise = FALSE,
+    n_individuals = 150,
+    tranform_to_proportions = TRUE,
+    dissimilarity_coefficient = "euc",
+    time_standardisation = 500,
+    verbose = FALSE,
+    silence = FALSE
+) {
+    #----------------------------------------------------------#
+    # 4.1 Data subsetting -----
+    #----------------------------------------------------------#
 
+    # select one sample for each bin based on the age of the samples.
+    # subset data
+    data_subset <-
+        subset_samples(
+            data_source_subset = data_source_run$data,
+            data_source_bins = data_source_run$bins,
+            bin_selection = bin_selection
+        )
 
-        #----------------------------------------------------------#
-        # 4.1 Data subsetting -----
-        #----------------------------------------------------------#
+    # reduce
+    data_subset <-
+        reduce_data_simple(
+            data_source_reduce = data_subset
+        )
 
-        # select one sample for each bin based on the age of the samples.
-        # subset data
-        data_subset <-
-            subset_samples(
-                data_source_subset = data_source_run$data,
-                data_source_bins = data_source_run$bins,
-                bin_selection = bin_selection
+    #----------------------------------------------------------#
+    # 4.2 Data Standardisation -----
+    #----------------------------------------------------------#
+
+    # standardisation of community data to n_individuals
+    if (isTRUE(standardise)) {
+        # select only community data
+        com_data_sums <-
+            rowSums(
+                subset_community(
+                    data_source = data_subset
+                ),
+                na.rm = TRUE
             )
 
-        # reduce
+        # adjust the value to a minimal of presented values
+        n_individuals <-
+            min(
+                c(
+                    com_data_sums,
+                    n_individuals
+                )
+            )
+
+        # check if all samples has n_individuals of individuals
+        data_subset <-
+            data_subset[com_data_sums >= n_individuals, ]
+
         data_subset <-
             reduce_data_simple(
                 data_source_reduce = data_subset
             )
 
-
-        #----------------------------------------------------------#
-        # 4.2 Data Standardisation -----
-        #----------------------------------------------------------#
-
-        # standardisation of community data to n_individuals
-        if (
-            isTRUE(standardise)
-        ) {
-            # select only community data
-            com_data_sums <-
-                rowSums(
-                    subset_community(
-                        data_source = data_subset
-                    ),
-                    na.rm = TRUE
-                )
-
-            # adjust the value to a minimal of presented values
-            n_individuals <-
-                min(
-                    c(
-                        com_data_sums,
-                        n_individuals
-                    )
-                )
-
-            # check if all samples has n_individuals of individuals
-            data_subset <-
-                data_subset[com_data_sums >= n_individuals, ]
-
-            data_subset <-
-                reduce_data_simple(
-                    data_source_reduce = data_subset
-                )
-
-            # standardisation
-            data_sd <-
-                standardise_community_data(
-                    data_source_standard = data_subset,
-                    n_individuals = n_individuals
-                )
-
-            if (
-                isTRUE(verbose)
-            ) {
-                assertthat::assert_that(
-                    all(
-                        n_individuals ==
-                            rowSums(
-                                subset_community(data_sd),
-                                na.rm = TRUE
-                            )
-                    ),
-                    msg = paste(
-                        "Data standardisation was unsuccesfull,",
-                        "try 'standardise' = FALSE"
-                    )
-                )
-            }
-        } else {
-            data_sd <- data_subset
-        }
-
-        # data reduce
+        # standardisation
         data_sd <-
-            reduce_data_simple(
-                data_source_reduce = data_sd
+            standardise_community_data(
+                data_source_standard = data_subset,
+                n_individuals = n_individuals
             )
 
-        if (
-            isTRUE(tranform_to_proportions)
-        ) {
-            # tunr into proportion
-            data_sd_prop <-
-                transform_into_proportions(
-                    data_source_trans = data_sd,
-                    sel_method = "proportions"
+        if (isTRUE(verbose)) {
+            assertthat::assert_that(
+                all(
+                    n_individuals ==
+                        rowSums(
+                            subset_community(data_sd),
+                            na.rm = TRUE
+                        )
+                ),
+                msg = paste(
+                    "Data standardisation was unsuccesfull,",
+                    "try 'standardise' = FALSE"
                 )
-        } else {
-            data_sd_prop <-
-                data_sd
-        }
-
-
-        #----------------------------------------------------------#
-        # 4.3 dissimilarity_coefficient Calculation -----
-        #----------------------------------------------------------#
-
-        # calculate dissimilarity_coefficient between each subsequent samples/bins
-        dc_res <-
-            estimate_dissimilarity_coefficient(
-                data_source_dc = data_sd_prop,
-                dissimilarity_coefficient = dissimilarity_coefficient,
-                verbose = verbose
             )
-
-
-        #----------------------------------------------------------#
-        # 4.4 Rate of Change -----
-        #----------------------------------------------------------#
-
-        #  calculate dissimilarity_coefficient standardise by time
-        roc_res <-
-            data_sd_prop[seq_along(dc_res), ] %>%
-            dplyr::mutate(
-                dc = dc_res,
-                age_diff_st = .data$age_diff / time_standardisation,
-                roc = .data$dc / .data$age_diff_st
-            ) %>%
-            dplyr::select("label", "res_age", "roc")
-
-
-        #----------------------------------------------------------#
-        # 4.6 Result of a single randomisation run -----
-        #----------------------------------------------------------#
-
-        if (
-            nrow(roc_res) < 1
-        ) {
-            stop("Estimation not succesfull")
         }
-
-        return(roc_res)
+    } else {
+        data_sd <- data_subset
     }
+
+    # data reduce
+    data_sd <-
+        reduce_data_simple(
+            data_source_reduce = data_sd
+        )
+
+    if (isTRUE(tranform_to_proportions)) {
+        # tunr into proportion
+        data_sd_prop <-
+            transform_into_proportions(
+                data_source_trans = data_sd,
+                sel_method = "proportions",
+                verbose = verbose,
+                silence = silence
+            )
+    } else {
+        data_sd_prop <-
+            data_sd
+    }
+
+    #----------------------------------------------------------#
+    # 4.3 dissimilarity_coefficient Calculation -----
+    #----------------------------------------------------------#
+
+    # calculate dissimilarity_coefficient between each subsequent samples/bins
+    dc_res <-
+        estimate_dissimilarity_coefficient(
+            data_source_dc = data_sd_prop,
+            dissimilarity_coefficient = dissimilarity_coefficient,
+            verbose = verbose,
+            silence = silence
+        )
+
+    #----------------------------------------------------------#
+    # 4.4 Rate of Change -----
+    #----------------------------------------------------------#
+
+    #  calculate dissimilarity_coefficient standardise by time
+    roc_res <-
+        data_sd_prop[seq_along(dc_res), ] %>%
+        dplyr::mutate(
+            dc = dc_res,
+            age_diff_st = .data$age_diff / time_standardisation,
+            roc = .data$dc / .data$age_diff_st
+        ) %>%
+        dplyr::select("label", "res_age", "roc")
+
+    #----------------------------------------------------------#
+    # 4.6 Result of a single randomisation run -----
+    #----------------------------------------------------------#
+
+    if (nrow(roc_res) < 1) {
+        stop("Estimation not succesfull")
+    }
+
+    return(roc_res)
+}

--- a/R/run_iteration.R
+++ b/R/run_iteration.R
@@ -15,148 +15,148 @@
 #' @seealso [estimate_roc()]
 #' @keywords internal
 run_iteration <- function(
-    data_source_run,
-    bin_selection = "first",
-    standardise = FALSE,
-    n_individuals = 150,
-    tranform_to_proportions = TRUE,
-    dissimilarity_coefficient = "euc",
-    time_standardisation = 500,
-    verbose = FALSE,
-    silence = FALSE
+  data_source_run,
+  bin_selection = "first",
+  standardise = FALSE,
+  n_individuals = 150,
+  tranform_to_proportions = TRUE,
+  dissimilarity_coefficient = "euc",
+  time_standardisation = 500,
+  verbose = FALSE,
+  silent = FALSE
 ) {
-    #----------------------------------------------------------#
-    # 4.1 Data subsetting -----
-    #----------------------------------------------------------#
+  #----------------------------------------------------------#
+  # 4.1 Data subsetting -----
+  #----------------------------------------------------------#
 
-    # select one sample for each bin based on the age of the samples.
-    # subset data
-    data_subset <-
-        subset_samples(
-            data_source_subset = data_source_run$data,
-            data_source_bins = data_source_run$bins,
-            bin_selection = bin_selection
+  # select one sample for each bin based on the age of the samples.
+  # subset data
+  data_subset <-
+    subset_samples(
+      data_source_subset = data_source_run$data,
+      data_source_bins = data_source_run$bins,
+      bin_selection = bin_selection
+    )
+
+  # reduce
+  data_subset <-
+    reduce_data_simple(
+      data_source_reduce = data_subset
+    )
+
+  #----------------------------------------------------------#
+  # 4.2 Data Standardisation -----
+  #----------------------------------------------------------#
+
+  # standardisation of community data to n_individuals
+  if (isTRUE(standardise)) {
+    # select only community data
+    com_data_sums <-
+      rowSums(
+        subset_community(
+          data_source = data_subset
+        ),
+        na.rm = TRUE
+      )
+
+    # adjust the value to a minimal of presented values
+    n_individuals <-
+      min(
+        c(
+          com_data_sums,
+          n_individuals
         )
+      )
 
-    # reduce
+    # check if all samples has n_individuals of individuals
     data_subset <-
-        reduce_data_simple(
-            data_source_reduce = data_subset
-        )
+      data_subset[com_data_sums >= n_individuals, ]
 
-    #----------------------------------------------------------#
-    # 4.2 Data Standardisation -----
-    #----------------------------------------------------------#
+    data_subset <-
+      reduce_data_simple(
+        data_source_reduce = data_subset
+      )
 
-    # standardisation of community data to n_individuals
-    if (isTRUE(standardise)) {
-        # select only community data
-        com_data_sums <-
-            rowSums(
-                subset_community(
-                    data_source = data_subset
-                ),
-                na.rm = TRUE
-            )
-
-        # adjust the value to a minimal of presented values
-        n_individuals <-
-            min(
-                c(
-                    com_data_sums,
-                    n_individuals
-                )
-            )
-
-        # check if all samples has n_individuals of individuals
-        data_subset <-
-            data_subset[com_data_sums >= n_individuals, ]
-
-        data_subset <-
-            reduce_data_simple(
-                data_source_reduce = data_subset
-            )
-
-        # standardisation
-        data_sd <-
-            standardise_community_data(
-                data_source_standard = data_subset,
-                n_individuals = n_individuals
-            )
-
-        if (isTRUE(verbose)) {
-            assertthat::assert_that(
-                all(
-                    n_individuals ==
-                        rowSums(
-                            subset_community(data_sd),
-                            na.rm = TRUE
-                        )
-                ),
-                msg = paste(
-                    "Data standardisation was unsuccesfull,",
-                    "try 'standardise' = FALSE"
-                )
-            )
-        }
-    } else {
-        data_sd <- data_subset
-    }
-
-    # data reduce
+    # standardisation
     data_sd <-
-        reduce_data_simple(
-            data_source_reduce = data_sd
-        )
+      standardise_community_data(
+        data_source_standard = data_subset,
+        n_individuals = n_individuals
+      )
 
-    if (isTRUE(tranform_to_proportions)) {
-        # tunr into proportion
-        data_sd_prop <-
-            transform_into_proportions(
-                data_source_trans = data_sd,
-                sel_method = "proportions",
-                verbose = verbose,
-                silence = silence
+    if (isTRUE(verbose)) {
+      assertthat::assert_that(
+        all(
+          n_individuals ==
+            rowSums(
+              subset_community(data_sd),
+              na.rm = TRUE
             )
-    } else {
-        data_sd_prop <-
-            data_sd
-    }
-
-    #----------------------------------------------------------#
-    # 4.3 dissimilarity_coefficient Calculation -----
-    #----------------------------------------------------------#
-
-    # calculate dissimilarity_coefficient between each subsequent samples/bins
-    dc_res <-
-        estimate_dissimilarity_coefficient(
-            data_source_dc = data_sd_prop,
-            dissimilarity_coefficient = dissimilarity_coefficient,
-            verbose = verbose,
-            silence = silence
+        ),
+        msg = paste(
+          "Data standardisation was unsuccesfull,",
+          "try 'standardise' = FALSE"
         )
-
-    #----------------------------------------------------------#
-    # 4.4 Rate of Change -----
-    #----------------------------------------------------------#
-
-    #  calculate dissimilarity_coefficient standardise by time
-    roc_res <-
-        data_sd_prop[seq_along(dc_res), ] %>%
-        dplyr::mutate(
-            dc = dc_res,
-            age_diff_st = .data$age_diff / time_standardisation,
-            roc = .data$dc / .data$age_diff_st
-        ) %>%
-        dplyr::select("label", "res_age", "roc")
-
-    #----------------------------------------------------------#
-    # 4.6 Result of a single randomisation run -----
-    #----------------------------------------------------------#
-
-    if (nrow(roc_res) < 1) {
-        stop("Estimation not succesfull")
+      )
     }
+  } else {
+    data_sd <- data_subset
+  }
 
-    return(roc_res)
+  # data reduce
+  data_sd <-
+    reduce_data_simple(
+      data_source_reduce = data_sd
+    )
+
+  if (isTRUE(tranform_to_proportions)) {
+    # tunr into proportion
+    data_sd_prop <-
+      transform_into_proportions(
+        data_source_trans = data_sd,
+        sel_method = "proportions",
+        verbose = verbose,
+        silent = silent
+      )
+  } else {
+    data_sd_prop <-
+      data_sd
+  }
+
+  #----------------------------------------------------------#
+  # 4.3 dissimilarity_coefficient Calculation -----
+  #----------------------------------------------------------#
+
+  # calculate dissimilarity_coefficient between each subsequent samples/bins
+  dc_res <-
+    estimate_dissimilarity_coefficient(
+      data_source_dc = data_sd_prop,
+      dissimilarity_coefficient = dissimilarity_coefficient,
+      verbose = verbose,
+      silent = silent
+    )
+
+  #----------------------------------------------------------#
+  # 4.4 Rate of Change -----
+  #----------------------------------------------------------#
+
+  #  calculate dissimilarity_coefficient standardise by time
+  roc_res <-
+    data_sd_prop[seq_along(dc_res), ] %>%
+    dplyr::mutate(
+      dc = dc_res,
+      age_diff_st = .data$age_diff / time_standardisation,
+      roc = .data$dc / .data$age_diff_st
+    ) %>%
+    dplyr::select("label", "res_age", "roc")
+
+  #----------------------------------------------------------#
+  # 4.6 Result of a single randomisation run -----
+  #----------------------------------------------------------#
+
+  if (nrow(roc_res) < 1) {
+    stop("Estimation not succesfull")
+  }
+
+  return(roc_res)
 }

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -37,7 +37,7 @@ smooth_community_data <- function(
   smooth_age_range = 500,
   round_results = FALSE,
   verbose = FALSE,
-  silence = FALSE
+  silent =FALSE
 ) {
   # ----------------------------------------------
   # SETUP -----
@@ -124,10 +124,10 @@ smooth_community_data <- function(
     msg = "'verbose' must be logical and either TRUE or FALSE"
   )
   assertthat::assert_that(
-    is.logical(silence) &&
-      length(silence) == 1 &&
-      (silence == TRUE || silence == FALSE),
-    msg = "'silence' must be logical and either TRUE or FALSE"
+    is.logical(silent) &&
+      length(silent) == 1 &&
+      (silent == TRUE || silent == FALSE),
+    msg = "'silent' must be logical and either TRUE or FALSE"
   )
 
   # Method-specific assertions:
@@ -189,7 +189,7 @@ smooth_community_data <- function(
   # Additional information -----
   # ----------------------------------------------
 
-  if (isFALSE(silence) && isTRUE(verbose)) {
+  if (isFALSE(silent) && isTRUE(verbose)) {
     switch(
       smooth_method,
       "m.avg" = {

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -29,261 +29,302 @@
 #'
 #' Wilkinson, L., 2005. The Grammar of Graphics. Springer-Verlag, New York,
 #' USA 37.
-smooth_community_data <-
-  function(data_source_smooth,
-           smooth_method = c("m.avg", "grim", "age.w", "shep"),
-           smooth_n_points = 5,
-           smooth_n_max = 9,
-           smooth_age_range = 500,
-           round_results = FALSE,
-           verbose = FALSE) {
-    # ----------------------------------------------
-    # SETUP -----
-    # ----------------------------------------------
-    # Mandatory assertions for all methods:
-    # Assert data_source_smooth is a list
-    assertthat::assert_that(
-      is.list(data_source_smooth),
-      msg = "'data_source_smooth' must be a list"
+smooth_community_data <- function(
+  data_source_smooth,
+  smooth_method = c("m.avg", "grim", "age.w", "shep"),
+  smooth_n_points = 5,
+  smooth_n_max = 9,
+  smooth_age_range = 500,
+  round_results = FALSE,
+  verbose = FALSE,
+  silence = FALSE
+) {
+  # ----------------------------------------------
+  # SETUP -----
+  # ----------------------------------------------
+  # Mandatory assertions for all methods:
+  # Assert data_source_smooth is a list
+  assertthat::assert_that(
+    is.list(data_source_smooth),
+    msg = "'data_source_smooth' must be a list"
+  )
+  # Assert that community is not empty
+  assertthat::assert_that(
+    nrow(data_source_smooth$community) > 0,
+    msg = "'community' must have at least one row"
+  )
+  assertthat::assert_that(
+    ncol(data_source_smooth$community) > 0,
+    msg = "'community' must have at least one column"
+  )
+  # Assert community and age have the same rownames
+  assertthat::assert_that(
+    identical(
+      rownames(data_source_smooth$community),
+      rownames(data_source_smooth$age)
+    ),
+    msg = "'community' and 'age' must have identical rownames"
+  )
+  # Assert all values in community are numeric
+  assertthat::assert_that(
+    all(
+      sapply(data_source_smooth$community, is.numeric)
+    ),
+    msg = "All values in 'community' must be numeric"
+  )
+  # Assert that there are no NAs
+  assertthat::assert_that(
+    !any(is.na(data_source_smooth$community)),
+    msg = "'community' must not contain any NAs"
+  )
+  assertthat::assert_that(
+    !any(is.na(data_source_smooth$age)),
+    msg = "'age' must not contain any NAs"
+  )
+
+  # Assert age is sorted
+  assertthat::assert_that(
+    is.unsorted(data_source_smooth$age$age) == FALSE,
+    msg = "'age' must be sorted in increasing order"
+  )
+  # Assert smooth_method is character and valid
+  assertthat::assert_that(
+    is.character(smooth_method),
+    msg = "'smooth_method' must be character"
+  )
+  smooth_method <-
+    match.arg(
+      smooth_method,
+      choices = c("m.avg", "grim", "age.w", "shep")
     )
-    # Assert that community is not empty
+  # Assert smooth_n_points is only 1 argument, numeric and smaller than N samples
+  assertthat::assert_that(
+    length(smooth_n_points) == 1,
+    msg = "'smooth_n_points' must be length 1"
+  )
+  assertthat::assert_that(
+    is.numeric(smooth_n_points),
+    msg = "'smooth_n_points' must be numeric"
+  )
+  assertthat::assert_that(
+    smooth_n_points <= nrow(data_source_smooth$community),
+    msg = "'smooth_n_points' must be <= number of samples in 'community'"
+  )
+  # Assert that logical parameters are logical and either TRUE or FALSE
+  assertthat::assert_that(
+    is.logical(round_results) &&
+      length(round_results) == 1 &&
+      (round_results == TRUE || round_results == FALSE),
+    msg = "'round_results' must be logical and either TRUE or FALSE"
+  )
+  assertthat::assert_that(
+    is.logical(verbose) &&
+      length(verbose) == 1 &&
+      (verbose == TRUE || verbose == FALSE),
+    msg = "'verbose' must be logical and either TRUE or FALSE"
+  )
+  assertthat::assert_that(
+    is.logical(silence) &&
+      length(silence) == 1 &&
+      (silence == TRUE || silence == FALSE),
+    msg = "'silence' must be logical and either TRUE or FALSE"
+  )
+
+  # Method-specific assertions:
+  if (smooth_method == "shep") {
+    # must be > 2
     assertthat::assert_that(
-      nrow(data_source_smooth$community) > 0,
-      msg = "'community' must have at least one row"
+      smooth_n_points > 2,
+      msg = "'smooth_n_points' must be > 2 for 'shep' smoothing"
     )
+  }
+
+  if (smooth_method %in% c("m.avg", "age.w", "grim")) {
+    # must be odd
     assertthat::assert_that(
-      ncol(data_source_smooth$community) > 0,
-      msg = "'community' must have at least one column"
-    )
-    # Assert community and age have the same rownames
-    assertthat::assert_that(
-      identical(
-        rownames(data_source_smooth$community),
-        rownames(data_source_smooth$age)
-      ),
-      msg = "'community' and 'age' must have identical rownames"
-    )
-    # Assert all values in community are numeric
-    assertthat::assert_that(
-      all(
-        sapply(data_source_smooth$community, is.numeric)
-      ),
-      msg = "All values in 'community' must be numeric"
-    )
-    # Assert that there are no NAs
-    assertthat::assert_that(
-      !any(is.na(data_source_smooth$community)),
-      msg = "'community' must not contain any NAs"
-    )
-    assertthat::assert_that(
-      !any(is.na(data_source_smooth$age)),
-      msg = "'age' must not contain any NAs"
+      smooth_n_points %% 2 != 0,
+      msg = "'smooth_n_points' must be odd"
     )
 
-    # Assert age is sorted
-    assertthat::assert_that(
-      is.unsorted(data_source_smooth$age$age) == FALSE,
-      msg = "'age' must be sorted in increasing order"
-    )
-    # Assert smooth_method is character and valid
-    assertthat::assert_that(
-      is.character(smooth_method),
-      msg = "'smooth_method' must be character"
-    )
-    smooth_method <-
-      match.arg(
-        smooth_method,
-        choices = c("m.avg", "grim", "age.w", "shep")
-      )
-    # Assert smooth_n_points is only 1 argument, numeric and smaller than N samples
-    assertthat::assert_that(
-      length(smooth_n_points) == 1,
-      msg = "'smooth_n_points' must be length 1"
-    )
-    assertthat::assert_that(
-      is.numeric(smooth_n_points),
-      msg = "'smooth_n_points' must be numeric"
-    )
-    assertthat::assert_that(
-      smooth_n_points <= nrow(data_source_smooth$community),
-      msg = "'smooth_n_points' must be <= number of samples in 'community'"
-    )
-    # Assert that logical parameters are logical and either TRUE or FALSE
-    assertthat::assert_that(
-      is.logical(round_results) && length(round_results) == 1 && (round_results == TRUE || round_results == FALSE),
-      msg = "'round_results' must be logical and either TRUE or FALSE"
-    )
-    assertthat::assert_that(
-      is.logical(verbose) && length(verbose) == 1 && (verbose == TRUE || verbose == FALSE),
-      msg = "'verbose' must be logical and either TRUE or FALSE"
-    )
-
-
-    # Method-specific assertions:
-    if (smooth_method == "shep") {
-      # must be > 2
+    if (smooth_method %in% c("age.w", "grim")) {
+      # smooth_age_range must be length 1
       assertthat::assert_that(
-        smooth_n_points > 2,
-        msg = "'smooth_n_points' must be > 2 for 'shep' smoothing"
+        length(smooth_age_range) == 1,
+        msg = "'smooth_age_range' must be length 1"
       )
-    }
-
-    if (smooth_method %in% c("m.avg", "age.w", "grim")) {
-      # must be odd
+      # smooth_age_range must be numeric
       assertthat::assert_that(
-        smooth_n_points %% 2 != 0,
-        msg = "'smooth_n_points' must be odd"
+        is.numeric(smooth_age_range),
+        msg = "'smooth_age_range' must be numeric"
       )
 
-      if (smooth_method %in% c("age.w", "grim")) {
-        # smooth_age_range must be length 1
+      if (smooth_method == "grim") {
+        # smooth_n_max must be length 1
         assertthat::assert_that(
-          length(smooth_age_range) == 1,
-          msg = "'smooth_age_range' must be length 1"
+          is.numeric(smooth_n_max),
+          msg = "'smooth_n_max' must be numeric"
         )
-        # smooth_age_range must be numeric
         assertthat::assert_that(
-          is.numeric(smooth_age_range),
-          msg = "'smooth_age_range' must be numeric"
+          smooth_n_max %% 2 != 0,
+          msg = "'smooth_n_max' must be odd"
         )
-
-        if (smooth_method == "grim") {
-          # smooth_n_max must be length 1
-          assertthat::assert_that(
-            is.numeric(smooth_n_max),
-            msg = "'smooth_n_max' must be numeric"
-          )
-          assertthat::assert_that(
-            smooth_n_max %% 2 != 0,
-            msg = "'smooth_n_max' must be odd"
-          )
-          assertthat::assert_that(
-            length(smooth_n_max) == 1,
-            msg = "'smooth_n_max' must be length 1"
-          )
-          assertthat::assert_that(
-            smooth_n_max <= nrow(data_source_smooth$community),
-            msg = "'smooth_n_max' must be <= number of samples in 'community'"
-          )
-          # smooth_n_points must be < smooth_n_max
-          assertthat::assert_that(
-            smooth_n_points < smooth_n_max,
-            msg = "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
-          )
-        }
+        assertthat::assert_that(
+          length(smooth_n_max) == 1,
+          msg = "'smooth_n_max' must be length 1"
+        )
+        assertthat::assert_that(
+          smooth_n_max <= nrow(data_source_smooth$community),
+          msg = "'smooth_n_max' must be <= number of samples in 'community'"
+        )
+        # smooth_n_points must be < smooth_n_max
+        assertthat::assert_that(
+          smooth_n_points < smooth_n_max,
+          msg = "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
+        )
       }
     }
+  }
 
-    # ----------------------------------------------
-    # Additional information -----
-    # ----------------------------------------------
+  # ----------------------------------------------
+  # Additional information -----
+  # ----------------------------------------------
 
-    if (
-      isTRUE(verbose)
-    ) {
-      switch(smooth_method,
-        "m.avg" = {
-          RUtilpol::output_comment(
-            paste(
-              "Data will be smoothed by 'moving average' over", smooth_n_points,
-              "points"
-            )
+  if (isFALSE(silence) && isTRUE(verbose)) {
+    switch(
+      smooth_method,
+      "m.avg" = {
+        RUtilpol::output_comment(
+          paste(
+            "Data will be smoothed by 'moving average' over",
+            smooth_n_points,
+            "points"
           )
-        },
-        "grim" = {
-          RUtilpol::output_comment(
-            paste(
-              "Data will be smoothed by 'Grimm method' with min samples",
-              smooth_n_points,
-              "max samples", smooth_n_max, "and max age range of",
-              smooth_age_range
-            )
+        )
+      },
+      "grim" = {
+        RUtilpol::output_comment(
+          paste(
+            "Data will be smoothed by 'Grimm method' with min samples",
+            smooth_n_points,
+            "max samples",
+            smooth_n_max,
+            "and max age range of",
+            smooth_age_range
           )
-        },
-        "age.w" = {
-          RUtilpol::output_comment(
-            paste(
-              "Data will be smoothed by 'age-weighed average' over",
-              smooth_n_points,
-              "points with a threshold of", smooth_age_range
-            )
+        )
+      },
+      "age.w" = {
+        RUtilpol::output_comment(
+          paste(
+            "Data will be smoothed by 'age-weighed average' over",
+            smooth_n_points,
+            "points with a threshold of",
+            smooth_age_range
           )
-        },
-        "shep" = {
-          RUtilpol::output_comment(
-            paste(
-              "Data will be smoothed by 'Shepard's 5-term filter'"
-            )
+        )
+      },
+      "shep" = {
+        RUtilpol::output_comment(
+          paste(
+            "Data will be smoothed by 'Shepard's 5-term filter'"
           )
-        }
-      )
-    }
+        )
+      }
+    )
+  }
 
-    # ----------------------------------------------
-    # CALCULATION -----
-    # ----------------------------------------------
+  # ----------------------------------------------
+  # CALCULATION -----
+  # ----------------------------------------------
 
-    # split data into 2 datasets
-    dat_community <- as.data.frame(data_source_smooth$community)
-    dat_age <- as.data.frame(data_source_smooth$age)
+  # split data into 2 datasets
+  dat_community <- as.data.frame(data_source_smooth$community)
+  dat_age <- as.data.frame(data_source_smooth$age)
 
-    # pre-allocate some space
-    focus_par <- matrix(data = NA, nrow = nrow(dat_age), ncol = 2)
+  # pre-allocate some space
+  focus_par <- matrix(data = NA, nrow = nrow(dat_age), ncol = 2)
 
-    # for every species
-    for (j in 1:ncol(dat_community)) {
-      # select the species
-      col_work <- .subset2(dat_community, j)
+  # for every species
+  for (j in 1:ncol(dat_community)) {
+    # select the species
+    col_work <- .subset2(dat_community, j)
 
-      # create empty vector of same lengt for values to be saved
-      col_res <- rep(0, length(col_work))
+    # create empty vector of same lengt for values to be saved
+    col_res <- rep(0, length(col_work))
 
-      for (i in 1:nrow(dat_community)) { # for each sample
+    for (i in 1:nrow(dat_community)) {
+      # for each sample
 
-        # ----------------------------------------------
-        # MOVING AVERAGE SMOOTHING -----
-        # ----------------------------------------------
-        if (
-          smooth_method == "m.avg"
-        ) {
-          # Samples near beginning (moving window truncated)
-          if (
-            i < round(0.5 * (smooth_n_points)) + 1
-          ) {
-            focus_par[i, ] <- c(1, (i + round(0.5 * (smooth_n_points))))
+      # ----------------------------------------------
+      # MOVING AVERAGE SMOOTHING -----
+      # ----------------------------------------------
+      if (smooth_method == "m.avg") {
+        # Samples near beginning (moving window truncated)
+        if (i < round(0.5 * (smooth_n_points)) + 1) {
+          focus_par[i, ] <- c(1, (i + round(0.5 * (smooth_n_points))))
+        } else {
+          # Samples near end
+          if (i > nrow(dat_age) - round(0.5 * (smooth_n_points))) {
+            focus_par[i, ] <-
+              c(
+                (i - round(0.5 * (smooth_n_points))),
+                nrow(dat_age)
+              )
           } else {
-            # Samples near end
-            if (
-              i > nrow(dat_age) - round(0.5 * (smooth_n_points))
-            ) {
-              focus_par[i, ] <-
-                c(
-                  (i - round(0.5 * (smooth_n_points))),
-                  nrow(dat_age)
-                )
-            } else {
-              focus_par[i, ] <-
-                c(
-                  (i - round(0.5 * (smooth_n_points))),
-                  (i + round(0.5 * (smooth_n_points)))
-                )
-            }
+            focus_par[i, ] <-
+              c(
+                (i - round(0.5 * (smooth_n_points))),
+                (i + round(0.5 * (smooth_n_points)))
+              )
           }
-          col_res[i] <-
-            mean(col_work[focus_par[i, 1]:focus_par[i, 2]])
         }
+        col_res[i] <-
+          mean(col_work[focus_par[i, 1]:focus_par[i, 2]])
+      }
 
-        # ----------------------------------------------
-        # GRIMMM SMOOTHING -----
-        # ----------------------------------------------
-        if (
-          smooth_method == "grim"
-        ) {
-          # Samples near beginning (moving window truncated)
-          if (
-            i < round(0.5 * (smooth_n_max)) + 1
-          ) {
-            focus_par[i, 1] <- 1
+      # ----------------------------------------------
+      # GRIMMM SMOOTHING -----
+      # ----------------------------------------------
+      if (smooth_method == "grim") {
+        # Samples near beginning (moving window truncated)
+        if (i < round(0.5 * (smooth_n_max)) + 1) {
+          focus_par[i, 1] <- 1
+
+          focus_par[i, 2] <-
+            (i + round(0.5 * (smooth_n_points)))
+
+          focus_par[i, ] <-
+            util_search_parameter(
+              focus_par[i, 1],
+              focus_par[i, 2],
+              smooth_age_range,
+              smooth_n_max,
+              smooth_n_points,
+              dat_age,
+              dat_community
+            )
+        } else {
+          # Samples near end
+          if (i > nrow(dat_age) - round(0.5 * (smooth_n_points))) {
+            focus_par[i, 1] <-
+              (i - round(0.5 * (smooth_n_points)))
+
+            focus_par[i, 2] <-
+              nrow(dat_age)
+
+            focus_par[i, ] <-
+              util_search_parameter(
+                focus_par[i, 1],
+                focus_par[i, 2],
+                smooth_age_range,
+                smooth_n_max,
+                smooth_n_points,
+                dat_age,
+                dat_community
+              )
+          } else {
+            focus_par[i, 1] <-
+              (i - round(0.5 * (smooth_n_points)))
 
             focus_par[i, 2] <-
               (i + round(0.5 * (smooth_n_points)))
@@ -298,153 +339,101 @@ smooth_community_data <-
                 dat_age,
                 dat_community
               )
-          } else {
-            # Samples near end
-            if (
-              i > nrow(dat_age) - round(0.5 * (smooth_n_points))
-            ) {
-              focus_par[i, 1] <-
-                (i - round(0.5 * (smooth_n_points)))
-
-              focus_par[i, 2] <-
-                nrow(dat_age)
-
-              focus_par[i, ] <-
-                util_search_parameter(
-                  focus_par[i, 1],
-                  focus_par[i, 2],
-                  smooth_age_range,
-                  smooth_n_max,
-                  smooth_n_points,
-                  dat_age,
-                  dat_community
-                )
-            } else {
-              focus_par[i, 1] <-
-                (i - round(0.5 * (smooth_n_points)))
-
-              focus_par[i, 2] <-
-                (i + round(0.5 * (smooth_n_points)))
-
-              focus_par[i, ] <-
-                util_search_parameter(
-                  focus_par[i, 1],
-                  focus_par[i, 2],
-                  smooth_age_range,
-                  smooth_n_max,
-                  smooth_n_points,
-                  dat_age,
-                  dat_community
-                )
-            }
           }
-          col_res[i] <-
-            mean(col_work[focus_par[i, 1]:focus_par[i, 2]])
         }
+        col_res[i] <-
+          mean(col_work[focus_par[i, 1]:focus_par[i, 2]])
+      }
 
-        # ----------------------------------------------
-        # AGE-WEIGHTED SMOOTHING -----
-        # ----------------------------------------------
-        if (
-          smooth_method == "age.w"
-        ) {
-          # Samples near beginning (moving window truncated)
-          if (
-            i < round(0.5 * (smooth_n_points)) + 1
-          ) {
+      # ----------------------------------------------
+      # AGE-WEIGHTED SMOOTHING -----
+      # ----------------------------------------------
+      if (smooth_method == "age.w") {
+        # Samples near beginning (moving window truncated)
+        if (i < round(0.5 * (smooth_n_points)) + 1) {
+          focus_par[i, ] <-
+            c(
+              1,
+              (i + round(0.5 * (smooth_n_points)))
+            )
+        } else {
+          # Samples near end
+          if (i > nrow(dat_age) - round(0.5 * (smooth_n_points))) {
             focus_par[i, ] <-
               c(
-                1,
-                (i + round(0.5 * (smooth_n_points)))
+                (i - round(0.5 * (smooth_n_points))),
+                nrow(dat_age)
               )
           } else {
-            # Samples near end
-            if (
-              i > nrow(dat_age) - round(0.5 * (smooth_n_points))
-            ) {
-              focus_par[i, ] <-
-                c(
-                  (i - round(0.5 * (smooth_n_points))),
-                  nrow(dat_age)
-                )
-            } else {
-              focus_par[i, ] <-
-                c(
-                  (i - round(0.5 * (smooth_n_points))),
-                  (i + round(0.5 * (smooth_n_points)))
-                )
-            }
+            focus_par[i, ] <-
+              c(
+                (i - round(0.5 * (smooth_n_points))),
+                (i + round(0.5 * (smooth_n_points)))
+              )
           }
-
-          # create small df with values around observed sample
-          #   (in range of offset)
-          df_work <-
-            data.frame(
-              values = col_work[focus_par[i, 1]:focus_par[i, 2]],
-              age = dat_age$age[focus_par[i, 1]:focus_par[i, 2]],
-              weight = 1
-            )
-
-          # Weith of points is calculated as smooth_age_range / distance
-          #   bewtween oldest and youngest points.
-          # If cannot be smaller than 1. Values very far away from the point
-          F_age_dist <- abs(df_work$age - dat_age$age[i])
-
-          const <- smooth_age_range / F_age_dist
-
-          const[const > 1] <- 1
-
-          df_work$weight <- const
-
-          col_res[i] <-
-            stats::weighted.mean(df_work$values, df_work$weight)
         }
 
-        # ----------------------------------------------
-        # Shepard's 5-term filter -----
-        # ----------------------------------------------
-        if (
-          smooth_method == "shep"
-        ) {
-          if (
-            i < round(0.5 * (smooth_n_points)) + 1
-          ) {
+        # create small df with values around observed sample
+        #   (in range of offset)
+        df_work <-
+          data.frame(
+            values = col_work[focus_par[i, 1]:focus_par[i, 2]],
+            age = dat_age$age[focus_par[i, 1]:focus_par[i, 2]],
+            weight = 1
+          )
+
+        # Weith of points is calculated as smooth_age_range / distance
+        #   bewtween oldest and youngest points.
+        # If cannot be smaller than 1. Values very far away from the point
+        F_age_dist <- abs(df_work$age - dat_age$age[i])
+
+        const <- smooth_age_range / F_age_dist
+
+        const[const > 1] <- 1
+
+        df_work$weight <- const
+
+        col_res[i] <-
+          stats::weighted.mean(df_work$values, df_work$weight)
+      }
+
+      # ----------------------------------------------
+      # Shepard's 5-term filter -----
+      # ----------------------------------------------
+      if (smooth_method == "shep") {
+        if (i < round(0.5 * (smooth_n_points)) + 1) {
+          col_res[i] <- col_work[i]
+        } else {
+          if (i > nrow(dat_age) - round(0.5 * (smooth_n_points))) {
             col_res[i] <- col_work[i]
           } else {
-            if (
-              i > nrow(dat_age) - round(0.5 * (smooth_n_points))
-            ) {
-              col_res[i] <- col_work[i]
-            } else {
-              w.value <-
-                (17 * .subset(col_work, i) +
-                  12 * (.subset(col_work, i + 1) + .subset(col_work, i - 1)) -
-                  3 * (.subset(col_work, i + 2) + .subset(col_work, i - 2))) / 35
-              if (
-                w.value < 0
-              ) {
-                w.value <- 0
-              }
-              col_res[i] <- w.value
+            w.value <-
+              (17 *
+                .subset(col_work, i) +
+                12 * (.subset(col_work, i + 1) + .subset(col_work, i - 1)) -
+                3 * (.subset(col_work, i + 2) + .subset(col_work, i - 2))) /
+              35
+            if (w.value < 0) {
+              w.value <- 0
             }
+            col_res[i] <- w.value
           }
         }
       }
-      dat_community[, j] <- col_res
     }
-
-    if (
-      isTRUE(round_results)
-    ) {
-      dat_community <- round(dat_community)
-    }
-
-    final_list <-
-      list(
-        community = dat_community,
-        age = dat_age,
-        age_un = data_source_smooth$age_un
-      )
-
-    return(final_list)
+    dat_community[, j] <- col_res
   }
+
+  if (isTRUE(round_results)) {
+    dat_community <- round(dat_community)
+  }
+
+  final_list <-
+    list(
+      community = dat_community,
+      age = dat_age,
+      age_un = data_source_smooth$age_un
+    )
+
+  return(final_list)
+}

--- a/R/transform_into_proportions.r
+++ b/R/transform_into_proportions.r
@@ -1,4 +1,3 @@
-
 #' @title Transform community data into proportions
 #' @param data_source_trans
 #' Data.frame with `label`, `res_age`, and all community data
@@ -8,43 +7,46 @@
 #' @param verbose Logical. Should additional information be output?
 #' @description Tranform pollen data into proportions (or percentages)
 #' @keywords internal
-transform_into_proportions <-
-    function(data_source_trans,
-             sel_method = c("proportions", "percentages"),
-             verbose = FALSE) {
-        RUtilpol::check_class("data_source_trans", "data.frame")
+transform_into_proportions <- function(
+  data_source_trans,
+  sel_method = c("proportions", "percentages"),
+  verbose = FALSE,
+  silence = FALSE
+) {
+  RUtilpol::check_class("data_source_trans", "data.frame")
 
-        RUtilpol::check_class("sel_method", "character")
+  RUtilpol::check_class("sel_method", "character")
 
-        RUtilpol::check_vector_values("sel_method", c("percentages", "proportions"))
+  RUtilpol::check_vector_values(
+    "sel_method",
+    c("percentages", "proportions")
+  )
 
-        sel_method <- match.arg(sel_method)
+  sel_method <- match.arg(sel_method)
 
-        RUtilpol::check_class("verbose", "logical")
+  RUtilpol::check_class("verbose", "logical")
 
-        if (
-            isTRUE(verbose)
-        ) {
-            RUtilpol::output_comment(
-                "Community data values are being converted to proportions"
-            )
-        }
+  RUtilpol::check_class("silence", "logical")
 
-        data_com <-
-            subset_community(data_source_trans)
+  if (isFALSE(silence) && isTRUE(verbose)) {
+    RUtilpol::output_comment(
+      "Community data values are being converted to proportions"
+    )
+  }
 
-        # convert the values community data to proportion of sum of each sample
-        data_rowsums <-
-            rowSums(data_com, na.rm = TRUE)
+  data_com <-
+    subset_community(data_source_trans)
 
-        data_com <-
-            data_com / data_rowsums *
-                switch(sel_method,
-                    "percentages" = 100,
-                    "proportions" = 1
-                )
-        data_source_trans[, names(data_com)] <-
-            data_com
+  # convert the values community data to proportion of sum of each sample
+  data_rowsums <-
+    rowSums(data_com, na.rm = TRUE)
 
-        return(data_source_trans)
-    }
+  data_com <-
+    data_com /
+    data_rowsums *
+    switch(sel_method, "percentages" = 100, "proportions" = 1)
+  data_source_trans[, names(data_com)] <-
+    data_com
+
+  return(data_source_trans)
+}

--- a/R/transform_into_proportions.r
+++ b/R/transform_into_proportions.r
@@ -11,7 +11,7 @@ transform_into_proportions <- function(
   data_source_trans,
   sel_method = c("proportions", "percentages"),
   verbose = FALSE,
-  silence = FALSE
+  silent =FALSE
 ) {
   RUtilpol::check_class("data_source_trans", "data.frame")
 
@@ -26,9 +26,9 @@ transform_into_proportions <- function(
 
   RUtilpol::check_class("verbose", "logical")
 
-  RUtilpol::check_class("silence", "logical")
+  RUtilpol::check_class("silent", "logical")
 
-  if (isFALSE(silence) && isTRUE(verbose)) {
+  if (isFALSE(silent) && isTRUE(verbose)) {
     RUtilpol::output_comment(
       "Community data values are being converted to proportions"
     )

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -6,7 +6,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     class(data_source_check) <-
@@ -15,6 +15,7 @@ test_that(
     expect_error(
       check_data(
         data_source_check,
+        silent = TRUE,
         "'data_source_check' must be one of the following: 'list'"
       )
     )
@@ -39,12 +40,13 @@ test_that(
         data_community_extract = empty_community,
         data_age_extract = empty_age,
         age_uncertainty = empty_uncertainty,
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
       check_data(
-        result_empty
+        result_empty,
+        silent = TRUE
       ),
       "Object 'data_source_check' was supplied with empty elements: 'community' and 'age'"
     )
@@ -85,7 +87,8 @@ test_that(
     msg <-
       capture.output(
         check_data(
-          result_NA
+          result_NA,
+          silent = FALSE
         ),
         type = "message"
       )

--- a/tests/testthat/test-detect_peak_points.R
+++ b/tests/testthat/test-detect_peak_points.R
@@ -117,7 +117,7 @@ test_that("detect_peak_points() uses default sel_method 'trend_linear' when not 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -145,7 +145,7 @@ test_that("detect_peak_points() errors if sel_method is NULL: expects character 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -174,7 +174,7 @@ test_that("detect_peak_points() errors if sel_method is invalid character: expec
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -203,7 +203,7 @@ test_that("detect_peak_points() errors if sel_method is a vector of multiple val
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -232,7 +232,7 @@ test_that("detect_peak_points() errors if sel_method is numeric: expects charact
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -261,7 +261,7 @@ test_that("detect_peak_points() errors if sel_method is zero: expects character 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -290,7 +290,7 @@ test_that("detect_peak_points() errors if sel_method is NA: expects character ty
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -319,7 +319,7 @@ test_that("detect_peak_points() errors if sel_method is an empty list: expects c
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -348,7 +348,7 @@ test_that("detect_peak_points() errors if sel_method is an empty data.frame: exp
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -377,7 +377,7 @@ test_that("detect_peak_points() uses default sd_threshold=2 when not supplied: e
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -405,7 +405,7 @@ test_that("detect_peak_points() errors if sd_threshold is NULL: expects numeric 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -434,7 +434,7 @@ test_that("detect_peak_points() errors if sd_threshold is character: expects num
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -463,7 +463,7 @@ test_that("detect_peak_points() errors if sd_threshold is zero: expects value gr
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -492,7 +492,7 @@ test_that("detect_peak_points() errors if sd_threshold is NA: expects numeric ty
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -521,7 +521,7 @@ test_that("detect_peak_points() errors if sd_threshold is an empty list: expects
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -550,7 +550,7 @@ test_that("detect_peak_points() errors if sd_threshold is an empty data.frame: e
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -579,7 +579,7 @@ test_that("detect_peak_points() errors if sd_threshold is a vector of multiple v
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -609,7 +609,7 @@ test_that("detect_peak_points() returns a data.frame output with valid input and
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -641,7 +641,7 @@ test_that("detect_peak_points() returns output with expected column names for va
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -675,7 +675,7 @@ test_that("detect_peak_points() returns output with expected columns for sel_met
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -707,7 +707,7 @@ test_that("detect_peak_points() returns output with expected columns for sel_met
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -739,7 +739,7 @@ test_that("detect_peak_points() returns output with expected columns for sel_met
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -771,7 +771,7 @@ test_that("detect_peak_points() returns output with expected columns for sel_met
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -806,7 +806,7 @@ test_that("detect_peak_points() with method 'threshold' correctly identifies pea
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Create a version with artificially high ROC_dw values to ensure peaks
@@ -849,7 +849,7 @@ test_that("detect_peak_points() with method 'trend_linear' correctly identifies 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Create a version with artificially high ROC values to ensure peaks
@@ -896,7 +896,7 @@ test_that("detect_peak_points() with method 'trend_non_linear' correctly identif
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Create a version with artificially high ROC values to ensure peaks
@@ -948,7 +948,7 @@ test_that("detect_peak_points() with method 'GAM_deriv' correctly processes the 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   result <-
@@ -981,7 +981,7 @@ test_that("detect_peak_points() with method 'SNI' correctly processes the data",
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   result <-
@@ -1014,7 +1014,7 @@ test_that("detect_peak_points() correctly responds to different sd_threshold val
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Test with different sd_threshold values
@@ -1055,7 +1055,7 @@ test_that("detect_peak_points() methods give different results", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Test with different methods
@@ -1108,7 +1108,7 @@ test_that("detect_peak_points() preserves original data structure with Peak colu
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   original_cols <-
@@ -1153,7 +1153,7 @@ test_that("detect_peak_points() works without error for non-smoothed data with w
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1181,7 +1181,7 @@ test_that("detect_peak_points() works without error for m.avg-smoothed data with
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1209,7 +1209,7 @@ test_that("detect_peak_points() works without error for grim-smoothed data with 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1237,7 +1237,7 @@ test_that("detect_peak_points() works without error for age.w-smoothed data with
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1265,7 +1265,7 @@ test_that("detect_peak_points() works without error for shep-smoothed data with 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1294,7 +1294,7 @@ test_that("detect_peak_points() works without error for non-smoothed data with w
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1322,7 +1322,7 @@ test_that("detect_peak_points() works without error for m.avg-smoothed data with
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1350,7 +1350,7 @@ test_that("detect_peak_points() works without error for grim-smoothed data with 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1378,7 +1378,7 @@ test_that("detect_peak_points() works without error for age.w-smoothed data with
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1406,7 +1406,7 @@ test_that("detect_peak_points() works without error for shep-smoothed data with 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1435,7 +1435,7 @@ test_that("detect_peak_points() works without error for non-smoothed data with w
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1463,7 +1463,7 @@ test_that("detect_peak_points() works without error for m.avg-smoothed data with
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1491,7 +1491,7 @@ test_that("detect_peak_points() works without error for grim-smoothed data with 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1519,7 +1519,7 @@ test_that("detect_peak_points() works without error for age.w-smoothed data with
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1547,7 +1547,7 @@ test_that("detect_peak_points() works without error for shep-smoothed data with 
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -1577,7 +1577,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1615,7 +1615,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1653,7 +1653,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1691,7 +1691,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1729,7 +1729,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1768,7 +1768,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1806,7 +1806,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1844,7 +1844,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1882,7 +1882,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1920,7 +1920,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1959,7 +1959,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -1997,7 +1997,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -2035,7 +2035,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -2073,7 +2073,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -2111,7 +2111,7 @@ test_that("detect_peak_points() returns data.frame with Peak column and preserve
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -2146,7 +2146,7 @@ test_that("detect_peak_points() works with standardised data", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE,
+      silent = TRUE,
       rand = 10
     )
 
@@ -2161,7 +2161,7 @@ test_that("detect_peak_points() works with standardised data", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE,
+      silent = TRUE,
       rand = 10
     )
 

--- a/tests/testthat/test-detect_sni.R
+++ b/tests/testthat/test-detect_sni.R
@@ -134,7 +134,7 @@ test_that("detect_sni rejects missing BandWidth input", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -178,7 +178,7 @@ test_that("detect_sni rejects NULL BandWidth input", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -222,7 +222,7 @@ test_that("detect_sni rejects character BandWidth input", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -266,7 +266,7 @@ test_that("detect_sni throws error with negative BandWidth input", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -309,7 +309,7 @@ test_that("detect_sni handles zero BandWidth input", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -357,7 +357,7 @@ test_that("detect_sni rejects CharData with incorrect number of columns", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Create input for detect_sni with only 2 columns instead of required 3
@@ -394,7 +394,7 @@ test_that("detect_sni handles CharData with NAs in ages column", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -443,7 +443,7 @@ test_that("detect_sni handles CharData with NAs in ROC column", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -492,7 +492,7 @@ test_that("detect_sni handles CharData with NAs in threshold column", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -545,7 +545,7 @@ test_that("detect_sni returns a list with expected elements", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -594,7 +594,7 @@ test_that("detect_sni returns SNI as numeric vector with proper length", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -647,7 +647,7 @@ test_that("detect_sni returns winInd as matrix with proper dimensions", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -698,7 +698,7 @@ test_that("detect_sni returns popN and popS as lists with proper length", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -755,7 +755,7 @@ test_that("detect_sni returns meanN, stdN, CF as numeric vectors with proper len
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -828,7 +828,7 @@ test_that("detect_sni produces SNI values within expected range", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -880,7 +880,7 @@ test_that("detect_sni produces different results with different bandwidth", {
       dissimilarity_coefficient = "euc",
       tranform_to_proportions = TRUE,
       use_parallel = FALSE,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -941,7 +941,7 @@ test_that("detect_sni produces a list output", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -991,7 +991,7 @@ test_that("detect_sni returns correct names in list elements", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-
@@ -1040,7 +1040,7 @@ test_that("detect_sni produces output with no NA values", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   pred_gam <-

--- a/tests/testthat/test-estimate_dissimilarity_coefficient.R
+++ b/tests/testthat/test-estimate_dissimilarity_coefficient.R
@@ -661,7 +661,7 @@ test_that(
 #       transform_into_proportions(
 #         data_source_trans = .,
 #         sel_method = "proportions",
-#         verbose = FALSE
+#         silent = TRUE
 #       )
 #     expect_warning(
 #       dc_res <-
@@ -747,7 +747,7 @@ test_that(
 #       transform_into_proportions(
 #         data_source_trans = .,
 #         sel_method = "percentages",
-#         verbose = FALSE
+#         silent = TRUE
 #       )
 #     expect_warning(
 #       dc_res <-
@@ -834,7 +834,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -920,7 +920,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1007,7 +1007,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1093,7 +1093,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1180,7 +1180,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1266,7 +1266,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1353,7 +1353,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1439,7 +1439,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1526,7 +1526,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1612,7 +1612,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1699,7 +1699,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1785,7 +1785,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       dc_res <-
@@ -1874,7 +1874,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -1983,7 +1983,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2093,7 +2093,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2242,7 +2242,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2392,7 +2392,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2501,7 +2501,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2611,7 +2611,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2721,7 +2721,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2831,7 +2831,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -2939,7 +2939,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3048,7 +3048,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3158,7 +3158,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3271,7 +3271,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3358,7 +3358,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3446,7 +3446,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3533,7 +3533,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3621,7 +3621,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3708,7 +3708,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3796,7 +3796,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3883,7 +3883,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -3971,7 +3971,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -4058,7 +4058,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -4146,7 +4146,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(
@@ -4233,7 +4233,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = .,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     dc_res <-
       estimate_dissimilarity_coefficient(

--- a/tests/testthat/test-estimate_roc.R
+++ b/tests/testthat/test-estimate_roc.R
@@ -30,7 +30,7 @@ test_that("estimate_roc returns dataframe with valid inputs", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -76,7 +76,7 @@ test_that("data_source_community: Missing argument throws error indicating requi
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Object 'data_source_community' must be included as a 'data.frame'"
   )
@@ -110,7 +110,7 @@ test_that("data_source_community: NULL value throws error indicating data.frame 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_community' must be one of the following: 'data.frame'"
   )
@@ -145,7 +145,7 @@ test_that("data_source_community: Character string instead of data.frame throws 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_community' must be one of the following: 'data.frame'"
   )
@@ -181,7 +181,7 @@ test_that("data_source_community: Numeric value instead of data.frame throws err
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_community' must be one of the following: 'data.frame'"
   )
@@ -216,7 +216,7 @@ test_that("data_source_community: Zero value instead of data.frame throws error"
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_community' must be one of the following: 'data.frame'"
   )
@@ -251,7 +251,7 @@ test_that("data_source_community: NA value instead of data.frame throws error", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_community' must be one of the following: 'data.frame'"
   )
@@ -287,7 +287,7 @@ test_that("data_source_community: Empty list instead of data.frame throws error"
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_community' must be one of the following: 'data.frame'"
   )
@@ -323,7 +323,7 @@ test_that("data_source_community: Empty data.frame throws error about missing re
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_community_extract' must contains following columns: 'sample_id'"
   )
@@ -358,7 +358,7 @@ test_that("data_source_age: Missing argument throws error indicating required da
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Object 'data_source_age' must be included as a 'data.frame'"
   )
@@ -392,7 +392,7 @@ test_that("data_source_age: NULL value throws error indicating data.frame requir
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_age' must be one of the following: 'data.frame'"
   )
@@ -427,7 +427,7 @@ test_that("data_source_age: Character string instead of data.frame throws error"
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_age' must be one of the following: 'data.frame'"
   )
@@ -463,7 +463,7 @@ test_that("data_source_age: Numeric value instead of data.frame throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_age' must be one of the following: 'data.frame'"
   )
@@ -498,7 +498,7 @@ test_that("data_source_age: Zero value instead of data.frame throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_age' must be one of the following: 'data.frame'"
   )
@@ -533,7 +533,7 @@ test_that("data_source_age: NA value instead of data.frame throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_age' must be one of the following: 'data.frame'"
   )
@@ -569,7 +569,7 @@ test_that("data_source_age: Empty list instead of data.frame throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_source_age' must be one of the following: 'data.frame'"
   )
@@ -605,7 +605,7 @@ test_that("data_source_age: Empty data.frame throws error about missing required
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'data_age_extract' must contains following columns: 'sample_id'"
   )
@@ -644,7 +644,7 @@ test_that("age_uncertainty: NULL value is valid and function completes without e
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -688,7 +688,7 @@ test_that("age_uncertainty: Missing argument is valid and function completes wit
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -730,7 +730,7 @@ test_that("age_uncertainty: Character string instead of matrix throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -765,7 +765,7 @@ test_that("age_uncertainty: Numeric value instead of matrix throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -800,7 +800,7 @@ test_that("age_uncertainty: Zero value instead of matrix throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -835,7 +835,7 @@ test_that("age_uncertainty: NA value instead of matrix throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -870,7 +870,7 @@ test_that("age_uncertainty: Empty list instead of matrix throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -905,7 +905,7 @@ test_that("age_uncertainty: Empty data.frame instead of matrix throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -943,7 +943,7 @@ test_that("smooth_method: NULL value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -982,7 +982,7 @@ test_that("smooth_method: Missing argument uses default value 'none' without err
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -1020,7 +1020,7 @@ test_that("smooth_method: NULL value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -1057,7 +1057,7 @@ test_that("smooth_method: Multiple values throw error as only single value allow
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'arg' must be of length 1"
   )
@@ -1094,7 +1094,7 @@ test_that("smooth_method: Invalid character value throws error listing allowed o
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must contains one of the following values: 'none', 'm.avg', 'grim', 'age.w', 'shep'"
   )
@@ -1131,7 +1131,7 @@ test_that("smooth_method: Numeric value throws error requiring character input",
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -1168,7 +1168,7 @@ test_that("smooth_method: Zero value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -1205,7 +1205,7 @@ test_that("smooth_method: NA value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -1242,7 +1242,7 @@ test_that("smooth_method: Empty list throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -1279,7 +1279,7 @@ test_that("smooth_method: Empty data.frame throws error requiring character inpu
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_method' must be one of the following: 'character'"
   )
@@ -1319,7 +1319,7 @@ test_that("smooth_n_points: Missing argument uses default value 5 without error"
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -1357,7 +1357,7 @@ test_that("smooth_n_points: NULL value throws error requiring numeric value", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -1394,7 +1394,7 @@ test_that("smooth_n_points: Multiple values throw error as only single value all
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "length of assertion is not 1"
   )
@@ -1431,7 +1431,7 @@ test_that("smooth_n_points: Character value throws error requiring numeric input
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "non-numeric argument to binary operator"
   )
@@ -1468,7 +1468,7 @@ test_that("smooth_n_points: Even number throws error as odd number required", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_n_points' must be an odd number"
   )
@@ -1505,7 +1505,7 @@ test_that("smooth_n_points: Zero value throws error as odd number required", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_n_points' must be an odd number"
   )
@@ -1541,7 +1541,7 @@ test_that("smooth_n_points: NA value throws error requiring non-missing value", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: missing values present in assertion"
   )
@@ -1578,7 +1578,7 @@ test_that("smooth_n_points: Empty list throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "non-numeric argument to binary operator"
   )
@@ -1614,7 +1614,7 @@ test_that("smooth_n_points: Empty data.frame throws error requiring single value
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -1654,7 +1654,7 @@ test_that("smooth_age_range: Missing argument uses default value 500 without err
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -1692,7 +1692,7 @@ test_that("smooth_age_range: NULL value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_age_range' must be one of the following: 'numeric'"
   )
@@ -1730,7 +1730,7 @@ test_that("smooth_age_range: Multiple values causes error in internal function",
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = 500,
-        verbose = FALSE
+        silent = TRUE
       )
     ),
     # none programmed into the function yet
@@ -1769,7 +1769,7 @@ test_that("smooth_age_range: Character value throws error requiring numeric inpu
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_age_range' must be one of the following: 'numeric'"
   )
@@ -1806,7 +1806,7 @@ test_that("smooth_age_range: Zero value causes error in internal calculations", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "`age_diff` must be size 1, not 2"
   )
@@ -1843,7 +1843,7 @@ test_that("smooth_age_range: NA value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_age_range' must be one of the following: 'numeric'"
   )
@@ -1880,7 +1880,7 @@ test_that("smooth_age_range: Empty list throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_age_range' must be one of the following: 'numeric'"
   )
@@ -1916,7 +1916,7 @@ test_that("smooth_age_range: Empty data.frame throws error requiring numeric inp
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_age_range' must be one of the following: 'numeric'"
   )
@@ -1957,7 +1957,7 @@ test_that("smooth_n_max: Missing argument uses default value 9 without error", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -1995,7 +1995,7 @@ test_that("smooth_n_max: NULL value throws error requiring single value", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "length of assertion is not 1"
   )
@@ -2032,7 +2032,7 @@ test_that("smooth_n_max: Multiple values throw error as only single value allowe
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -2069,7 +2069,7 @@ test_that("smooth_n_max: Character value throws error requiring numeric input", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "non-numeric argument to binary operator"
   )
@@ -2107,7 +2107,7 @@ test_that("smooth_n_max: Even number throws error as odd number required", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_n_max' must be an odd number"
   )
@@ -2143,7 +2143,7 @@ test_that("smooth_n_max: Value not larger than smooth_n_points throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_n_max' must be bigger than 'smooth_n_points"
   )
@@ -2180,7 +2180,7 @@ test_that("smooth_n_max: Zero value throws error as odd number required", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'smooth_n_max' must be an odd number"
   )
@@ -2217,7 +2217,7 @@ test_that("smooth_n_max: NA value throws error requiring non-missing value", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: missing values present in assertion"
   )
@@ -2254,7 +2254,7 @@ test_that("smooth_n_max: Empty list throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "non-numeric argument to binary operator"
   )
@@ -2291,7 +2291,7 @@ test_that("smooth_n_max: Empty data.frame throws error requiring single value", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -2329,7 +2329,7 @@ test_that("working_units: Missing argument uses default value 'levels' without e
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -2365,7 +2365,7 @@ test_that("working_units: NULL value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must be one of the following: 'character'"
   )
@@ -2400,7 +2400,7 @@ test_that("working_units: Multiple values throw error as only single value allow
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'arg' must be of length 1"
   )
@@ -2435,7 +2435,7 @@ test_that("working_units: Invalid character value throws error listing allowed o
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
   )
@@ -2470,7 +2470,7 @@ test_that("working_units: Numeric value throws error requiring character input",
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must be one of the following: 'character'"
   )
@@ -2505,7 +2505,7 @@ test_that("working_units: Zero value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must be one of the following: 'character'"
   )
@@ -2540,7 +2540,7 @@ test_that("working_units: NA value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must be one of the following: 'character'"
   )
@@ -2575,7 +2575,7 @@ test_that("working_units: Empty list throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must be one of the following: 'character'"
   )
@@ -2610,7 +2610,7 @@ test_that("working_units: Empty data.frame throws error requiring character inpu
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'working_units' must be one of the following: 'character'"
   )
@@ -2648,7 +2648,7 @@ test_that("bin_size: Missing argument uses default value 500 without error", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -2683,7 +2683,7 @@ test_that("bin_size: NULL value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_size' must be one of the following: 'numeric'"
   )
@@ -2718,7 +2718,7 @@ test_that("bin_size: Multiple numeric values throws error requiring single argum
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -2753,7 +2753,7 @@ test_that("bin_size: Character value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_size' must be one of the following: 'numeric'"
   )
@@ -2788,7 +2788,7 @@ test_that("bin_size: Zero value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid"
   )
@@ -2823,7 +2823,7 @@ test_that("bin_size: NA value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_size' must be one of the following: 'numeric'"
   )
@@ -2858,7 +2858,7 @@ test_that("bin_size: Empty list throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_size' must be one of the following: 'numeric'"
   )
@@ -2893,7 +2893,7 @@ test_that("bin_size: Empty data.frame throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_size' must be one of the following: 'numeric'"
   )
@@ -2932,7 +2932,7 @@ test_that("number_of_shifts: Missing argument uses default value 5 without error
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -2967,7 +2967,7 @@ test_that("number_of_shifts: NULL value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'number_of_shifts' must be one of the following: 'numeric'"
   )
@@ -3002,7 +3002,7 @@ test_that("number_of_shifts: Multiple values throw error as only single value al
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -3037,7 +3037,7 @@ test_that("number_of_shifts: Character value throws error requiring numeric inpu
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'number_of_shifts' must be one of the following: 'numeric'"
   )
@@ -3074,7 +3074,7 @@ test_that("number_of_shifts: Valid numeric value works without error", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -3112,7 +3112,7 @@ test_that("number_of_shifts: Zero value is overwritten with 1 without error", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -3148,7 +3148,7 @@ test_that("number_of_shifts: NA value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'number_of_shifts' must be one of the following: 'numeric'"
   )
@@ -3183,7 +3183,7 @@ test_that("number_of_shifts: Empty list throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'number_of_shifts' must be one of the following: 'numeric'"
   )
@@ -3218,7 +3218,7 @@ test_that("estimate_roc throws error when smooth_method is NULL (invalid empty i
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'number_of_shifts' must be one of the following: 'numeric'"
   )
@@ -3256,7 +3256,7 @@ test_that("estimate_roc throws error when smooth_method is NULL (invalid empty i
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
   )
 })
@@ -3292,7 +3292,7 @@ test_that("bin_selection: NULL value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must be one of the following: 'character'"
   )
@@ -3329,7 +3329,7 @@ test_that("bin_selection: Multiple values throw error as only single value allow
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'arg' must be of length 1"
   )
@@ -3366,7 +3366,7 @@ test_that("bin_selection: Invalid character value throws error listing allowed o
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must contains one of the following values: 'first', 'random'"
   )
@@ -3403,7 +3403,7 @@ test_that("bin_selection: Numeric value throws error requiring character input",
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must be one of the following: 'character'"
   )
@@ -3440,7 +3440,7 @@ test_that("bin_selection: Zero value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must be one of the following: 'character'"
   )
@@ -3477,7 +3477,7 @@ test_that("bin_selection: NA value throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must be one of the following: 'character'"
   )
@@ -3514,7 +3514,7 @@ test_that("bin_selection: Empty list throws error requiring character input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must be one of the following: 'character'"
   )
@@ -3551,7 +3551,7 @@ test_that("bin_selection: Empty data.frame throws error requiring character inpu
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'bin_selection' must be one of the following: 'character'"
   )
@@ -3592,7 +3592,7 @@ test_that("standardise: Missing argument uses default value FALSE without error"
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -3630,7 +3630,7 @@ test_that("standardise: NULL value throws error requiring logical input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'standardise' must be one of the following: 'logical'"
   )
@@ -3667,7 +3667,7 @@ test_that("standardise: Multiple values throw error as only single value allowed
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into function yet. will use first element in vector
     # e.g., "assert_that: length of assertion is not 1"
@@ -3705,7 +3705,7 @@ test_that("standardise: Character value throws error requiring logical input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'standardise' must be one of the following: 'logical'"
   )
@@ -3742,7 +3742,7 @@ test_that("standardise: Numeric value throws error requiring logical input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'standardise' must be one of the following: 'logical'"
   )
@@ -3779,7 +3779,7 @@ test_that("standardise: Zero value throws error requiring logical input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'standardise' must be one of the following: 'logical'"
   )
@@ -3816,7 +3816,7 @@ test_that("standardise: NA value throws error instead of using FALSE silently", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into the function yet. Skips standardising
     # e.g., "'standardise' must be one of the following: c(TRUE, FALSE)"
@@ -3854,7 +3854,7 @@ test_that("standardise: Empty list throws error requiring logical input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'standardise' must be one of the following: 'logical'"
   )
@@ -3891,7 +3891,7 @@ test_that("standardise: Empty data.frame throws error requiring logical input", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'standardise' must be one of the following: 'logical'"
   )
@@ -3932,7 +3932,7 @@ test_that("n_individuals: Missing argument uses default value 150 without error"
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -3970,7 +3970,7 @@ test_that("n_individuals: NULL value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'n_individuals' must be one of the following: 'numeric'"
   )
@@ -4007,7 +4007,7 @@ test_that("n_individuals: Multiple values throw error as only single value allow
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -4044,7 +4044,7 @@ test_that("n_individuals: Character value throws error requiring numeric input",
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'n_individuals' must be one of the following: 'numeric'"
   )
@@ -4082,7 +4082,7 @@ test_that("n_individuals: Zero value throws error in internal calculations", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid 'length' argument"
   )
@@ -4119,7 +4119,7 @@ test_that("n_individuals: NA value throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'n_individuals' must be one of the following: 'numeric'"
   )
@@ -4156,7 +4156,7 @@ test_that("n_individuals: Empty list throws error requiring numeric input", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'n_individuals' must be one of the following: 'numeric'"
   )
@@ -4193,7 +4193,7 @@ test_that("n_individuals: Empty dataframe throws error requiring numeric input",
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'n_individuals' must be one of the following: 'numeric'"
   )
@@ -4233,7 +4233,7 @@ test_that("dissimilarity_coefficient: Missing argument uses default value 'euc' 
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -4271,7 +4271,7 @@ test_that("dissimilarity_coefficient: NULL value throws error requiring characte
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must be one of the following: 'character'"
   )
@@ -4308,7 +4308,7 @@ test_that("dissimilarity_coefficient: Multiple values throw error as only single
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'arg' must be of length 1"
   )
@@ -4344,7 +4344,7 @@ test_that("dissimilarity_coefficient: invalid character values throw error as on
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must contains one of the following values: 'euc', 'euc.sd', 'chord', 'chisq', 'gower', 'bray'"
   )
@@ -4381,7 +4381,7 @@ test_that("dissimilarity_coefficient: Numeric value throws error requiring chara
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must be one of the following: 'character'"
   )
@@ -4418,7 +4418,7 @@ test_that("dissimilarity_coefficient: Zero value throws error requiring characte
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must be one of the following: 'character'"
   )
@@ -4455,7 +4455,7 @@ test_that("dissimilarity_coefficient: NA value throws error requiring character 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must be one of the following: 'character'"
   )
@@ -4492,7 +4492,7 @@ test_that("dissimilarity_coefficient: Empty list throws error requiring characte
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must be one of the following: 'character'"
   )
@@ -4529,7 +4529,7 @@ test_that("estimate_roc throws error when smooth_method is NULL (invalid empty i
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'dissimilarity_coefficient' must be one of the following: 'character'"
   )
@@ -4567,7 +4567,7 @@ test_that("estimate_roc throws error when smooth_method is NULL (invalid empty i
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
   )
 })
@@ -4603,7 +4603,7 @@ test_that("tranform_to_proportions: NULL value throws error requiring logical in
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'tranform_to_proportions' must be one of the following: 'logical'"
   )
@@ -4640,7 +4640,7 @@ test_that("tranform_to_proportions: Multiple values throw error as only single v
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into function yet
     "'arg' must be of length 1"
@@ -4678,7 +4678,7 @@ test_that("tranform_to_proportions: Character value throws error requiring logic
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'tranform_to_proportions' must be one of the following: 'logical'"
   )
@@ -4715,7 +4715,7 @@ test_that("tranform_to_proportions: Numeric value throws error requiring logical
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'tranform_to_proportions' must be one of the following: 'logical'"
   )
@@ -4752,7 +4752,7 @@ test_that("tranform_to_proportions: Zero value throws error requiring logical in
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'tranform_to_proportions' must be one of the following: 'logical'"
   )
@@ -4789,7 +4789,7 @@ test_that("tranform_to_proportions: NA value throws error requiring non-missing 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: missing values present in assertion"
   )
@@ -4825,7 +4825,7 @@ test_that("tranform_to_proportions: Empty list throws error requiring logical in
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'tranform_to_proportions' must be one of the following: 'logical'"
   )
@@ -4861,7 +4861,7 @@ test_that("tranform_to_proportions: Empty data.frame throws error requiring logi
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'tranform_to_proportions' must be one of the following: 'logical'"
   )
@@ -4900,7 +4900,7 @@ test_that("rand: Missing argument uses default value without error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument is of length zero"
   )
@@ -4937,7 +4937,7 @@ test_that("rand: NULL value throws error requiring non-zero input for rand", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument is of length zero"
   )
@@ -4974,7 +4974,7 @@ test_that("rand: Multiple values for tranform_to_proportions throw error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -5011,7 +5011,7 @@ test_that("rand: Character value throws error requiring numeric or NULL", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'rand' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5048,7 +5048,7 @@ test_that("rand: Zero value causes error in internal function calculation", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "subscript out of bounds"
   )
@@ -5085,7 +5085,7 @@ test_that("rand: NA value throws error requiring numeric or NULL", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'rand' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5122,7 +5122,7 @@ test_that("rand: Empty list throws error requiring numeric or NULL", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'rand' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5159,7 +5159,7 @@ test_that("rand: Empty data.frame throws error requiring numeric or NULL", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'rand' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5199,7 +5199,7 @@ test_that("use_parallel: Missing argument uses default value without error", {
           use_parallel = , # will use default FALSE
           interest_threshold = NULL,
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -5237,7 +5237,7 @@ test_that("use_parallel: NULL input throws error requiring logical or numeric", 
       use_parallel = NULL,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'use_parallel' must be one of the following: 'logical', 'numeric'"
   )
@@ -5274,7 +5274,7 @@ test_that("use_parallel: multiple input throws error", {
       use_parallel = c(TRUE, 100),
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -5311,7 +5311,7 @@ test_that("use_parallel: Character input throws error requiring logical or numer
       use_parallel = "TRUE",
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'use_parallel' must be one of the following: 'logical', 'numeric'"
   )
@@ -5348,7 +5348,7 @@ test_that("use_parallel: Zero (0) input throws error requiring more than 0 cores
       use_parallel = 0,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # this should throw an error
     # - not sure what it does if 0 cores are entered as input
@@ -5386,7 +5386,7 @@ test_that("use_parallel: NA throws error requiring non-NA input", {
       use_parallel = NA,
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # should throw an error.
     # not sure what it does if NA is entered as input
@@ -5424,7 +5424,7 @@ test_that("use_parallel: empty list input throws error requiring logical or nume
       use_parallel = list(),
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'use_parallel' must be one of the following: 'logical', 'numeric'"
   )
@@ -5460,7 +5460,7 @@ test_that("use_parallel: empty dataframe input throws error requiring logical or
       use_parallel = data.frame(),
       interest_threshold = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'use_parallel' must be one of the following: 'logical', 'numeric'"
   )
@@ -5501,7 +5501,7 @@ test_that("interest_threshold: empty input uses default with no error", {
           use_parallel = FALSE,
           interest_threshold = , # will use default NULL
           time_standardisation = 500,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -5540,7 +5540,7 @@ test_that("interest_threshold: multiple input throws error requiring single valu
         use_parallel = FALSE,
         interest_threshold = c(2000, 3000),
         time_standardisation = 500,
-        verbose = FALSE
+        silent = TRUE
       )
     ),
     # none programmed into the function yet.
@@ -5579,7 +5579,7 @@ test_that("interest_threshold: Character input throws error requiring numeric", 
       use_parallel = FALSE,
       interest_threshold = "3000",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "interest_threshold' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5616,7 +5616,7 @@ test_that("interest_threshold: NA input throws error requiring numeric", {
       use_parallel = FALSE,
       interest_threshold = NA,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "interest_threshold' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5653,7 +5653,7 @@ test_that("interest_threshold: list input throws error requiring numeric", {
       use_parallel = FALSE,
       interest_threshold = list(),
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "interest_threshold' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5689,7 +5689,7 @@ test_that("interest_threshold: Empty dataframe input throws error requiring nume
       use_parallel = FALSE,
       interest_threshold = data.frame(),
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "interest_threshold' must be one of the following: 'NULL', 'numeric'"
   )
@@ -5730,7 +5730,7 @@ test_that("time_standardisation: empty input uses default with no error", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = ,
-          verbose = FALSE
+          silent = TRUE
         )
       })
     )
@@ -5768,7 +5768,7 @@ test_that("time_standardisation: multiple input throws error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = c(500, 1000),
-      verbose = FALSE
+      silent = TRUE
     ),
     "assert_that: length of assertion is not 1"
   )
@@ -5805,7 +5805,7 @@ test_that("time_standardisation: Character input throws error requiring numeric"
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = "500",
-      verbose = FALSE
+      silent = TRUE
     ),
     "'time_standardisation' must be one of the following: 'numeric'"
   )
@@ -5842,7 +5842,7 @@ test_that("time_standardisation: NA input throws error requiring numeric", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NA,
-      verbose = FALSE
+      silent = TRUE
     ),
     "time_standardisation' must be one of the following: 'numeric'"
   )
@@ -5879,7 +5879,7 @@ test_that("time_standardisation: Empty list input throws error requiring numeric
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = list(),
-      verbose = FALSE
+      silent = TRUE
     ),
     "time_standardisation' must be one of the following: 'numeric'"
   )
@@ -5916,7 +5916,7 @@ test_that("time_standardisation: Empty data.frame input throws error requiring n
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = data.frame(),
-      verbose = FALSE
+      silent = TRUE
     ),
     "time_standardisation' must be one of the following: 'numeric'"
   )
@@ -5955,8 +5955,7 @@ test_that("verbose: Empty input uses default without error", {
           rand = 1,
           use_parallel = FALSE,
           interest_threshold = NULL,
-          time_standardisation = NULL,
-          verbose =
+          time_standardisation = NULL
         )
       })
     )
@@ -6292,7 +6291,7 @@ test_that("Valid data input returns a data.frame", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = NULL,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -6326,7 +6325,7 @@ test_that("Valid data input returns correct column types", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = NULL,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -6361,7 +6360,7 @@ test_that("Valid data input returns correct column types", {
           use_parallel = FALSE,
           interest_threshold = NULL,
           time_standardisation = NULL,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -6396,7 +6395,7 @@ test_that("Valid data input returns correct columns", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_identical(
@@ -6434,7 +6433,7 @@ test_that("Valid data input returns correct column types", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
   expect_identical(
     c(
@@ -6471,7 +6470,7 @@ test_that("Valid data input returns correct column types", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
   expect_identical(
     c(
@@ -6509,7 +6508,7 @@ test_that("Valid data input returns correct column types", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_type(
@@ -6557,7 +6556,7 @@ test_that("Valid data input returns correct column types", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_type(
@@ -6605,7 +6604,7 @@ test_that("Valid data input returns correct column types", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_type(
@@ -6650,7 +6649,7 @@ test_that("estimate_roc output has correct structure with required columns", {
           bin_selection = "first",
           dissimilarity_coefficient = "euc",
           rand = 1,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -6690,7 +6689,7 @@ test_that("estimate_roc output has rows sorted by Age", {
           bin_selection = "first",
           dissimilarity_coefficient = "euc",
           rand = 1,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -6729,7 +6728,7 @@ test_that("estimate_roc properly applies interest_threshold", {
       dissimilarity_coefficient = "euc",
       interest_threshold = median_age,
       rand = 1,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check that all ages in result are less than or equal to the threshold
@@ -6757,7 +6756,7 @@ test_that("estimate_roc produces different ROC values with different dissimilari
       bin_selection = "first",
       dissimilarity_coefficient = "chisq",
       rand = 1,
-      verbose = FALSE
+      silent = TRUE
     )
 
   set.seed(123)
@@ -6771,7 +6770,7 @@ test_that("estimate_roc produces different ROC values with different dissimilari
       bin_selection = "first",
       dissimilarity_coefficient = "chord",
       rand = 1,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check that ROC values differ between methods
@@ -6801,7 +6800,7 @@ test_that("estimate_roc produces more working units with MW compared to bins met
       bin_selection = "first",
       dissimilarity_coefficient = "euc",
       rand = 1,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Run with MW (moving window)
@@ -6816,7 +6815,7 @@ test_that("estimate_roc produces more working units with MW compared to bins met
       bin_selection = "first",
       dissimilarity_coefficient = "euc",
       rand = 1,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check that MW produces more working units than bins
@@ -6847,7 +6846,7 @@ test_that("estimate_roc returns ROC values within expected range for proportion 
           dissimilarity_coefficient = "euc",
           tranform_to_proportions = TRUE,
           rand = 1,
-          verbose = FALSE
+          silent = TRUE
         )
     })
   )
@@ -6875,33 +6874,41 @@ test_that("estimate_roc with time_standardisation properly scales ROC values", {
 
   # Run with different time_standardisation values
   set.seed(123)
-  result_500 <-
-    estimate_roc(
-      data_source_community = data_source_community,
-      data_source_age = data_source_age,
-      smooth_method = "none",
-      working_units = "levels",
-      bin_size = 500,
-      bin_selection = "first",
-      dissimilarity_coefficient = "euc",
-      time_standardisation = 500,
-      rand = 1,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      result_500 <-
+        estimate_roc(
+          data_source_community = data_source_community,
+          data_source_age = data_source_age,
+          smooth_method = "none",
+          working_units = "levels",
+          bin_size = 500,
+          bin_selection = "first",
+          dissimilarity_coefficient = "euc",
+          time_standardisation = 500,
+          rand = 1,
+          silent = TRUE
+        )
+    })
+  )
   set.seed(123)
-  result_1000 <-
-    estimate_roc(
-      data_source_community = data_source_community,
-      data_source_age = data_source_age,
-      smooth_method = "none",
-      working_units = "levels",
-      bin_size = 500,
-      bin_selection = "first",
-      dissimilarity_coefficient = "euc",
-      time_standardisation = 1000,
-      rand = 1,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      result_1000 <-
+        estimate_roc(
+          data_source_community = data_source_community,
+          data_source_age = data_source_age,
+          smooth_method = "none",
+          working_units = "levels",
+          bin_size = 500,
+          bin_selection = "first",
+          dissimilarity_coefficient = "euc",
+          time_standardisation = 1000,
+          rand = 1,
+          silent = TRUE
+        )
+    })
+  )
 
   # When time_standardisation is doubled, ROC values should be doubled
   # This is an approximate test due to randomization
@@ -6926,33 +6933,41 @@ test_that("estimate_roc applies smoothing correctly", {
 
   # Run with no smoothing
   set.seed(123)
-  result_none <-
-    estimate_roc(
-      data_source_community = data_source_community,
-      data_source_age = data_source_age,
-      smooth_method = "none",
-      working_units = "levels",
-      bin_size = 500,
-      bin_selection = "first",
-      dissimilarity_coefficient = "euc",
-      rand = 1,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      result_none <-
+        estimate_roc(
+          data_source_community = data_source_community,
+          data_source_age = data_source_age,
+          smooth_method = "none",
+          working_units = "levels",
+          bin_size = 500,
+          bin_selection = "first",
+          dissimilarity_coefficient = "euc",
+          rand = 1,
+          silent = TRUE
+        )
+    })
+  )
 
   # Run with Shepard smoothing
   set.seed(123)
-  result_shep <-
-    estimate_roc(
-      data_source_community = data_source_community,
-      data_source_age = data_source_age,
-      smooth_method = "shep",
-      working_units = "levels",
-      bin_size = 500,
-      bin_selection = "first",
-      dissimilarity_coefficient = "euc",
-      rand = 1,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      result_shep <-
+        estimate_roc(
+          data_source_community = data_source_community,
+          data_source_age = data_source_age,
+          smooth_method = "shep",
+          working_units = "levels",
+          bin_size = 500,
+          bin_selection = "first",
+          dissimilarity_coefficient = "euc",
+          rand = 1,
+          silent = TRUE
+        )
+    })
+  )
 
   # Smoothing should typically result in different ROC values
   # and often lower variance in the results
@@ -7002,35 +7017,43 @@ test_that("estimate_roc confidence intervals (ROC_up, ROC_dw) widen with higher 
 
   # Run with original uncertainty
   set.seed(123)
-  result_orig <-
-    estimate_roc(
-      data_source_community = data_source_community,
-      data_source_age = data_source_age,
-      age_uncertainty = age_uncertainty,
-      smooth_method = "none",
-      working_units = "levels",
-      bin_size = 500,
-      bin_selection = "first",
-      dissimilarity_coefficient = "euc",
-      rand = 10,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      result_orig <-
+        estimate_roc(
+          data_source_community = data_source_community,
+          data_source_age = data_source_age,
+          age_uncertainty = age_uncertainty,
+          smooth_method = "none",
+          working_units = "levels",
+          bin_size = 500,
+          bin_selection = "first",
+          dissimilarity_coefficient = "euc",
+          rand = 10,
+          silent = TRUE
+        )
+    })
+  )
 
   # Run with increased uncertainty
   set.seed(123)
-  result_high <-
-    estimate_roc(
-      data_source_community = data_source_community,
-      data_source_age = data_source_age,
-      age_uncertainty = increased_uncertainty,
-      smooth_method = "none",
-      working_units = "levels",
-      bin_size = 500,
-      bin_selection = "first",
-      dissimilarity_coefficient = "euc",
-      rand = 10,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      result_high <-
+        estimate_roc(
+          data_source_community = data_source_community,
+          data_source_age = data_source_age,
+          age_uncertainty = increased_uncertainty,
+          smooth_method = "none",
+          working_units = "levels",
+          bin_size = 500,
+          bin_selection = "first",
+          dissimilarity_coefficient = "euc",
+          rand = 10,
+          silent = TRUE
+        )
+    })
+  )
 
   # Calculate confidence interval width
   ci_width_orig <-
@@ -7071,29 +7094,33 @@ test_that("Community data with all-zero samples drops samples correctly", {
   community[1:5, -1] <-
     0 # first five rows all zero (sample_id = 392671:392675)
 
-  res <-
-    estimate_roc(
-      data_source_community = community,
-      data_source_age = age,
-      age_uncertainty = age_uncertainty,
-      smooth_method = "grim",
-      smooth_n_points = 5,
-      smooth_age_range = 500,
-      smooth_n_max = 9,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 1,
-      bin_selection = "first",
-      standardise = TRUE,
-      n_individuals = 150,
-      dissimilarity_coefficient = "euc",
-      tranform_to_proportions = TRUE,
-      rand = 1,
-      use_parallel = FALSE,
-      interest_threshold = NULL,
-      time_standardisation = NULL,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      res <-
+        estimate_roc(
+          data_source_community = community,
+          data_source_age = age,
+          age_uncertainty = age_uncertainty,
+          smooth_method = "grim",
+          smooth_n_points = 5,
+          smooth_age_range = 500,
+          smooth_n_max = 9,
+          working_units = "levels",
+          bin_size = 500,
+          number_of_shifts = 1,
+          bin_selection = "first",
+          standardise = TRUE,
+          n_individuals = 150,
+          dissimilarity_coefficient = "euc",
+          tranform_to_proportions = TRUE,
+          rand = 1,
+          use_parallel = FALSE,
+          interest_threshold = NULL,
+          time_standardisation = NULL,
+          silent = TRUE
+        )
+    })
+  )
   expect_false(
     any(
       grepl(
@@ -7140,7 +7167,7 @@ test_that("All zero community data input returns error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     ),
     "subscript out of bounds"
   )
@@ -7158,29 +7185,33 @@ test_that("Community data with all-NA samples drops samples correctly", {
   community[1:5, -1] <-
     NA # first five rows all NA (sample_id = 392671:392675)
 
-  res <-
-    estimate_roc(
-      data_source_community = community,
-      data_source_age = age,
-      age_uncertainty = age_uncertainty,
-      smooth_method = "grim",
-      smooth_n_points = 5,
-      smooth_age_range = 500,
-      smooth_n_max = 9,
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 1,
-      bin_selection = "first",
-      standardise = TRUE,
-      n_individuals = 150,
-      dissimilarity_coefficient = "euc",
-      tranform_to_proportions = TRUE,
-      rand = 1,
-      use_parallel = FALSE,
-      interest_threshold = NULL,
-      time_standardisation = NULL,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      res <-
+        estimate_roc(
+          data_source_community = community,
+          data_source_age = age,
+          age_uncertainty = age_uncertainty,
+          smooth_method = "grim",
+          smooth_n_points = 5,
+          smooth_age_range = 500,
+          smooth_n_max = 9,
+          working_units = "levels",
+          bin_size = 500,
+          number_of_shifts = 1,
+          bin_selection = "first",
+          standardise = TRUE,
+          n_individuals = 150,
+          dissimilarity_coefficient = "euc",
+          tranform_to_proportions = TRUE,
+          rand = 1,
+          use_parallel = FALSE,
+          interest_threshold = NULL,
+          time_standardisation = NULL,
+          silent = TRUE
+        )
+    })
+  )
   expect_false(
     any(
       grepl(
@@ -7227,7 +7258,7 @@ test_that("All NA community data input returns error", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     ),
     "subscript out of bounds"
   )
@@ -7248,26 +7279,30 @@ test_that("estimate_roc() correctly handles age data with NAs", {
   age_uncertainty[, 1:5] <-
     NA
 
-  res <-
-    estimate_roc(
-      data_source_community = community,
-      data_source_age = age,
-      age_uncertainty = age_uncertainty,
-      smooth_method = "none",
-      working_units = "levels",
-      bin_size = 500,
-      number_of_shifts = 1,
-      bin_selection = "first",
-      standardise = TRUE,
-      n_individuals = 150,
-      dissimilarity_coefficient = "euc",
-      tranform_to_proportions = TRUE,
-      rand = 1,
-      use_parallel = FALSE,
-      interest_threshold = NULL,
-      time_standardisation = NULL,
-      verbose = FALSE
-    )
+  invisible(
+    capture.output({
+      res <-
+        estimate_roc(
+          data_source_community = community,
+          data_source_age = age,
+          age_uncertainty = age_uncertainty,
+          smooth_method = "none",
+          working_units = "levels",
+          bin_size = 500,
+          number_of_shifts = 1,
+          bin_selection = "first",
+          standardise = TRUE,
+          n_individuals = 150,
+          dissimilarity_coefficient = "euc",
+          tranform_to_proportions = TRUE,
+          rand = 1,
+          use_parallel = FALSE,
+          interest_threshold = NULL,
+          time_standardisation = NULL,
+          silent = TRUE
+        )
+    })
+  )
 
   expect_false(
     any(
@@ -7309,7 +7344,7 @@ test_that("estimate_roc() correctly handles age data with NAs", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into the function yet
     # e.g., "No valid age data available (all NA)"

--- a/tests/testthat/test-extract_data.R
+++ b/tests/testthat/test-extract_data.R
@@ -11,7 +11,7 @@ test_that("extract_data works with default parameters (age_uncertainty = NULL)",
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = NULL,
-        verbose = FALSE
+        silent = TRUE
       )
   )
 
@@ -110,7 +110,7 @@ test_that("extract_data works with default parameters (with age_uncertainty)", {
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
   )
 
@@ -539,7 +539,7 @@ test_that("extract_data() handles community data with character columns - return
     extract_data(
       data_community_extract = char_community,
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     ),
     "'x' must be numeric"
   )
@@ -1114,7 +1114,7 @@ test_that("extract_data() throws error if sample_id is numeric in community data
     extract_data(
       data_community_extract = community_numeric_id,
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'sample_id' in 'data_community' must.*be a 'character'"
   )
@@ -1131,7 +1131,7 @@ test_that("extract_data() throws error if sample_id is factor in community data"
     extract_data(
       data_community_extract = community_factor_id,
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'sample_id' in 'data_community' must.*be a 'character'"
   )
@@ -1148,7 +1148,7 @@ test_that("extract_data() throws error if sample_id is numeric in age data", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = age_numeric_id,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'sample_id' must have same values in.*'data_age' and 'data_community'"
   )
@@ -1168,7 +1168,7 @@ test_that("extract_data() throws error if age column is missing in age data", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = age_no_age_col,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'age' in 'data_source_age' must be a 'numeric'"
   )
@@ -1185,7 +1185,7 @@ test_that("extract_data() throws error if age column is character", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = age_char_age,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'age' in 'data_source_age' must be a 'numeric'"
   )
@@ -1202,7 +1202,7 @@ test_that("extract_data() throws error if age column is factor", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = age_factor_age,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'age' in 'data_source_age' must be a 'numeric'"
   )
@@ -1222,7 +1222,7 @@ test_that("extract_data() throws error if age_uncertainty has wrong number of co
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = age_un_wrong_size,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Object 'data_source_age' and 'age_uncertainty' must have.*the same number of levels"
   )
@@ -1241,7 +1241,7 @@ test_that("extract_data() throws error if age_uncertainty has too many columns",
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = age_un_extra,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Object 'data_source_age' and 'age_uncertainty' must have.*the same number of levels"
   )
@@ -1257,7 +1257,7 @@ test_that("extract_data() throws error if age_uncertainty is data.frame instead 
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = age_un_df,
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -1270,7 +1270,7 @@ test_that("extract_data() throws error if age_uncertainty is character vector", 
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = "uncertainty_data",
-      verbose = FALSE
+      silent = TRUE
     ),
     "'age_uncertainty' must be one of the following: 'NULL', 'matrix'"
   )
@@ -1297,7 +1297,7 @@ test_that("extract_data() throws error if community has additional samples (rows
     extract_data(
       data_community_extract = extra_sample_in_community,
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'sample_id' must have same values in.*'data_age' and 'data_community'"
   )
@@ -1315,7 +1315,7 @@ test_that("extract_data() throws error if age has more rows than community data"
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = extra_age,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Variable 'sample_id' must have same values in.*'data_age' and 'data_community'"
   )
@@ -1336,7 +1336,7 @@ test_that("extract_data() throws error if data comunity and age is empty", {
     extract_data(
       data_community_extract = empty_community,
       data_age_extract = empty_age,
-      verbose = FALSE
+      silent = TRUE
     ),
 
     # none programmed into the function yet
@@ -1354,7 +1354,7 @@ test_that("extract_data() handles single row data - returns list", {
     extract_data(
       data_community_extract = single_community,
       data_age_extract = single_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_type(result, "list")
@@ -1371,7 +1371,7 @@ test_that("extract_data() handles single row data - returns named list", {
     extract_data(
       data_community_extract = single_community,
       data_age_extract = single_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_named(result, c("community", "age", "age_un"))
@@ -1388,7 +1388,7 @@ test_that("extract_data() handles single row data - community has 1 row", {
     extract_data(
       data_community_extract = single_community,
       data_age_extract = single_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_equal(nrow(result$community), 1)
@@ -1405,7 +1405,7 @@ test_that("extract_data() handles single row data - age has 1 row", {
     extract_data(
       data_community_extract = single_community,
       data_age_extract = single_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_equal(nrow(result$age), 1)
@@ -1420,7 +1420,7 @@ test_that("extract_data() handles minimal community data - returns list", {
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_type(result, "list")
@@ -1435,7 +1435,7 @@ test_that("extract_data() throws error if community has 0 columns", {
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into function yet
   )
@@ -1462,7 +1462,7 @@ test_that("extract_data() throws error with duplicate sample_id in community dat
       extract_data(
         data_community_extract = dup_community,
         data_age_extract = dup_age,
-        verbose = FALSE
+        silent = TRUE
       )
     ),
     "duplicate 'row.names' are not allowed"
@@ -1496,7 +1496,7 @@ test_that("extract_data() sorts unsorted age data", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = unsorted_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check that result ages are sorted
@@ -1513,7 +1513,7 @@ test_that("extract_data() maintains sorted age data", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = sorted_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_true(is.unsorted(result$age$age) == FALSE)
@@ -1535,7 +1535,7 @@ test_that("extract_data() handles partial NA in age data - produces message", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = partial_na_age,
-      verbose = FALSE
+      silent = TRUE
     ),
     "Missing 'age' values"
   )
@@ -1554,7 +1554,7 @@ test_that("extract_data() handles some NA in age data - filters out NA rows", {
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = partial_na_age,
-        verbose = FALSE
+        silent = TRUE
       )
     )
 
@@ -1575,7 +1575,7 @@ test_that("extract_data() handles partial NA in age data - no remaining NAs", {
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = partial_na_age,
-        verbose = FALSE
+        silent = TRUE
       )
     )
 
@@ -1598,7 +1598,7 @@ test_that("extract_data() returns correct structure with minimal data - returns 
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_type(result, "list")
@@ -1616,7 +1616,7 @@ test_that("extract_data() returns correct structure with minimal data - named co
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_named(result, c("community", "age", "age_un"))
@@ -1634,7 +1634,7 @@ test_that("extract_data() returns correct structure with minimal data - communit
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_s3_class(result$community, "data.frame")
@@ -1652,7 +1652,7 @@ test_that("extract_data() returns correct structure with minimal data - age is d
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_s3_class(result$age, "data.frame")
@@ -1670,7 +1670,7 @@ test_that("extract_data() returns correct structure with minimal data - age_un i
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_null(result$age_un)
@@ -1688,7 +1688,7 @@ test_that("extract_data() returns correct structure with minimal data - communit
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_equal(rownames(result$community), minimal_community$sample_id)
@@ -1706,7 +1706,7 @@ test_that("extract_data() returns correct structure with minimal data - age rown
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_equal(rownames(result$age), minimal_age$sample_id)
@@ -1724,7 +1724,7 @@ test_that("extract_data() returns correct structure with minimal data - communit
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_equal(
@@ -1745,7 +1745,7 @@ test_that("extract_data() returns correct structure with minimal data - age valu
     extract_data(
       data_community_extract = minimal_community,
       data_age_extract = minimal_age,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_equal(result$age$age, minimal_age$age)
@@ -1758,7 +1758,7 @@ test_that("extract_data() correctly assigns column names to age uncertainty", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   expected_names <-

--- a/tests/testthat/test-make_bins.R
+++ b/tests/testthat/test-make_bins.R
@@ -14,7 +14,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     data_source_bins$age <-
@@ -38,7 +38,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     class(
@@ -119,7 +119,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     data_source_bins <-
@@ -156,7 +156,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_no_error(
@@ -206,7 +206,7 @@ test_that(
         data_community_extract = community,
         data_age_extract = age,
         age_uncertainty = age_un,
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_no_error(
@@ -233,7 +233,7 @@ test_that(
         data_community_extract = community,
         data_age_extract = age,
         age_uncertainty = age_un,
-        verbose = FALSE
+        silent = TRUE
       )
 
 
@@ -262,7 +262,7 @@ test_that(
         data_community_extract = community,
         data_age_extract = age,
         age_uncertainty = age_un,
-        verbose = FALSE
+        silent = TRUE
       )
 
 
@@ -289,7 +289,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -309,7 +309,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -329,7 +329,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -349,7 +349,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -369,7 +369,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -389,7 +389,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -411,7 +411,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
     expect_error(
       bins <-
@@ -433,7 +433,7 @@ test_that(
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -459,7 +459,7 @@ test_that(
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
     expect_no_error(
       make_bins(
@@ -483,7 +483,7 @@ test_that(
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
     expect_no_error(
       make_bins(
@@ -504,7 +504,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -528,7 +528,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -554,7 +554,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_no_error(
@@ -577,7 +577,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -601,7 +601,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -625,7 +625,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -650,7 +650,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -677,7 +677,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -702,7 +702,7 @@ test_that(
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_no_error(
@@ -724,7 +724,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
 
@@ -750,7 +750,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -774,7 +774,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
 
@@ -799,7 +799,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     bins_res <-
@@ -828,7 +828,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -851,7 +851,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -874,7 +874,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -897,7 +897,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_no_error(
@@ -919,7 +919,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -942,7 +942,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -965,7 +965,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -989,7 +989,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_error(
@@ -1016,7 +1016,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     bins <-
@@ -1087,7 +1087,7 @@ test_that(
       extract_data(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     bins <-
@@ -1157,7 +1157,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     bins <-
@@ -1231,7 +1231,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     bins <-
@@ -1301,7 +1301,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
     bins <-
@@ -1375,7 +1375,7 @@ test_that(
         data_community_extract = RRatepol::example_data$pollen_data[[1]],
         data_age_extract = RRatepol::example_data$sample_age[[1]],
         age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        silent = TRUE
       )
 
 
@@ -1447,7 +1447,7 @@ test_that("make_bins and 'levels' works within the workflow of estimate_roc()", 
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_smooth <-
@@ -1479,7 +1479,7 @@ test_that("make_bins and 'MW' works within the workflow of estimate_roc()", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_smooth <-
@@ -1513,7 +1513,7 @@ test_that("make_bins and 'bins' works within the workflow of estimate_roc()", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_smooth <-

--- a/tests/testthat/test-make_trend.R
+++ b/tests/testthat/test-make_trend.R
@@ -201,7 +201,7 @@ test_that("make_trend uses default 'linear' when sel_method is missing and data_
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -235,7 +235,7 @@ test_that("make_trend errors when sel_method is NULL and data_source is valid", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -270,7 +270,7 @@ test_that("make_trend errors when sel_method is invalid character and data_sourc
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -305,7 +305,7 @@ test_that("make_trend errors when sel_method is numeric and data_source is valid
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -340,7 +340,7 @@ test_that("make_trend errors when sel_method is zero and data_source is valid", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -376,7 +376,7 @@ test_that("make_trend errors when sel_method is NA and data_source is valid", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -412,7 +412,7 @@ test_that("make_trend errors when sel_method is length > 1 and data_source is va
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -448,7 +448,7 @@ test_that("make_trend errors when sel_method is an empty list and data_source is
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -484,7 +484,7 @@ test_that("make_trend errors when sel_method is an empty data.frame and data_sou
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_error(
@@ -520,7 +520,7 @@ test_that("make_trend produces different results for 'linear' and 'non_linear' s
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res_linear <-
@@ -566,7 +566,7 @@ test_that("make_trend returns a numeric vector when data_source is valid and sel
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -602,7 +602,7 @@ test_that("make_trend returns a numeric vector when data_source is valid and sel
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -641,7 +641,7 @@ test_that("make_trend with 'linear' handles NA values in ROC column appropriatel
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_source$ROC[2] <- NA # Introduce NA value in ROC column
@@ -680,7 +680,7 @@ test_that("make_trend with 'non_linear' handles NA values in ROC column appropri
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_source$ROC[2] <- NA # Introduce NA value in ROC column
@@ -720,7 +720,7 @@ test_that("make_trend with 'linear' handles NA values in Age column appropriatel
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_source$Age[2] <- NA # Introduce NA value in Age column
@@ -759,7 +759,7 @@ test_that("make_trend with 'non_linear' handles NA values in Age column appropri
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_source$Age[2] <- NA # Introduce NA value in Age column
@@ -799,7 +799,7 @@ test_that("make_trend with 'linear' throws warning with single row data frame", 
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
   data_source <-
     data_source[1, ] # Keep only the first row
@@ -836,7 +836,7 @@ test_that("make_trend with 'non_linear' throws error with single row data frame"
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
   data_source <-
     data_source[1, ] # Keep only the first row
@@ -874,7 +874,7 @@ test_that("make_trend with 'linear' rejects negative ROC values", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_source$ROC <-
@@ -914,7 +914,7 @@ test_that("make_trend with 'non_linear' rejects negative ROC values", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   data_source$ROC <-
@@ -955,7 +955,7 @@ test_that("make_trend output length matches input rows with 'linear'", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-
@@ -992,7 +992,7 @@ test_that("make_trend output length matches input rows with 'non_linear'", {
       use_parallel = FALSE,
       interest_threshold = NULL,
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     )
 
   res <-

--- a/tests/testthat/test-plot_roc.R
+++ b/tests/testthat/test-plot_roc.R
@@ -188,7 +188,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -230,7 +230,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -273,7 +273,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -316,7 +316,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -358,7 +358,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -403,7 +403,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -446,7 +446,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -489,7 +489,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -533,7 +533,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -575,7 +575,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -617,7 +617,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -660,7 +660,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -703,7 +703,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -748,7 +748,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -791,7 +791,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -836,7 +836,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -877,7 +877,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -921,7 +921,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -964,7 +964,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1007,7 +1007,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1051,7 +1051,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1098,7 +1098,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1141,7 +1141,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1186,7 +1186,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1228,7 +1228,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1270,7 +1270,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1313,7 +1313,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1356,7 +1356,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1399,7 +1399,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1441,7 +1441,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1484,7 +1484,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1526,7 +1526,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1572,7 +1572,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"
@@ -1637,7 +1637,7 @@ test_that(
         dissimilarity_coefficient = "euc",
         tranform_to_proportions = TRUE,
         use_parallel = FALSE,
-        verbose = FALSE
+        silent = TRUE
       )
 
     # Define test parameters
@@ -1698,7 +1698,7 @@ test_that(
         dissimilarity_coefficient = "euc",
         tranform_to_proportions = TRUE,
         use_parallel = FALSE,
-        verbose = FALSE
+        silent = TRUE
       )
 
     # Add peaks
@@ -1752,7 +1752,7 @@ test_that(
         use_parallel = FALSE,
         interest_threshold = NULL,
         time_standardisation = NULL,
-        verbose = FALSE
+        silent = TRUE
       ) %>%
       detect_peak_points(
         sel_method = "trend_linear"

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -4,1547 +4,1384 @@
 # ---------------------------------------------------------- #
 # 1.1 data_source_prep = NULL
 # i) levels
-test_that(
-  "prepare_data, working_units = 'levels' throws error for NULL input for data_source",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = NULL,
-        working_units = "levels",
-        rand = NULL
-      ), "'data_source_prep' must be one of the following: 'list'"
-    )
-  }
-)
+test_that("prepare_data, working_units = 'levels' throws error for NULL input for data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = NULL,
+      working_units = "levels",
+      rand = NULL
+    ),
+    "'data_source_prep' must be one of the following: 'list'"
+  )
+})
 
 # ii) bins
-test_that(
-  "prepare_data, working_units = 'bins' throws error for NULL input for data_source",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = NULL,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      ), "'data_source_prep' must be one of the following: 'list'"
-    )
-  }
-)
+test_that("prepare_data, working_units = 'bins' throws error for NULL input for data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = NULL,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
+    ),
+    "'data_source_prep' must be one of the following: 'list'"
+  )
+})
 
 # iii) MW
-test_that(
-  "prepare_data, working_units = 'MW' throws error for NULL input for data_source",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = NULL,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ), "'data_source_prep' must be one of the following: 'list'"
-    )
-  }
-)
+test_that("prepare_data, working_units = 'MW' throws error for NULL input for data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = NULL,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'data_source_prep' must be one of the following: 'list'"
+  )
+})
 
 # --------------------------------------------------- #
 
 # 1.2 data_source_prep = empty list with data = zero
 # (these fail because there is no error programmed into the function yet)
 # i) levels
-test_that(
-  "prepare_data, working_units = 'levels' throws error for data_source_prep = empty named list",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep =
-          list(
-            community = data.frame(
-              0
-            ),
-            age = data.frame(
-              age = 0
-            ),
-            age_un = data.frame(0)
-          ),
-        working_units = "levels",
-        rand = NULL
+test_that("prepare_data, working_units = 'levels' throws error for data_source_prep = empty named list", {
+  expect_error(
+    prepare_data(
+      data_source_prep = list(
+        community = data.frame(
+          0
+        ),
+        age = data.frame(
+          age = 0
+        ),
+        age_un = data.frame(0)
       ),
-      # none programmed into the function yet.
-      # e.g., "'data_source_prep' must be non-empty"
-    )
-  }
-)
+      working_units = "levels",
+      rand = NULL
+    ),
+    # none programmed into the function yet.
+    # e.g., "'data_source_prep' must be non-empty"
+  )
+})
 
 # ii) bins
-test_that(
-  "prepare_data, working_units = 'bins' throws error for data_source_prep = empty named list",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep =
-          list(
-            community = data.frame(
-              0
-            ),
-            age = data.frame(
-              age = 0
-            ),
-            age_un = data.frame(0)
-          ),
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
+test_that("prepare_data, working_units = 'bins' throws error for data_source_prep = empty named list", {
+  expect_error(
+    prepare_data(
+      data_source_prep = list(
+        community = data.frame(
+          0
+        ),
+        age = data.frame(
+          age = 0
+        ),
+        age_un = data.frame(0)
       ),
-      # none programmed into the function yet.
-      # e.g., "'data_source_prep' must be non-empty"
-    )
-  }
-)
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
+    ),
+    # none programmed into the function yet.
+    # e.g., "'data_source_prep' must be non-empty"
+  )
+})
 
 # iii) MW
-test_that(
-  "prepare_data, working_units = 'MW' throws error for data_source_prep = empty named list",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep =
-          list(
-            community = data.frame(
-              0
-            ),
-            age = data.frame(
-              age = 0
-            ),
-            age_un = data.frame(0)
-          ),
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      # none programmed into the function yet.
-      # e.g., "'data_source_prep' must be non-empty"
-    )
-  }
-)
-
-# ----------------------------------------------------------------- #
-# ----------------------------------------------------------------- #
-
-
-test_that(
-  "prepare_data rejects NULL data_source",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = NULL,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ), "'data_source_prep' must be one of the following: 'list'"
-    )
-  }
-)
-
-test_that(
-  "prepare_data rejects incomplete list(data.frame) in data_source",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = RRatepol::example_data$pollen_data[[1]],
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ), "'data_source_prep' must be one of the following: 'list'"
-    )
-  }
-)
-
-test_that(
-  "prepare_data throws error with empty data_source_prep list",
-  {
-    expect_error(
-      prepare_data(
-        data_source_prep = list(),
-        working_units = "levels"
-      ),
-      "argument of length 0"
-    )
-  }
-)
-
-test_that(
-  "prepare_data throws error with data_source_prep with wrong structure",
-  {
-    wrong_structure <-
-      list(
-        wrong_name = data.frame(
-          x = 1:5
+test_that("prepare_data, working_units = 'MW' throws error for data_source_prep = empty named list", {
+  expect_error(
+    prepare_data(
+      data_source_prep = list(
+        community = data.frame(
+          0
         ),
-        another_wrong = data.frame(y = 1:5)
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = wrong_structure,
-        working_units = "levels"
+        age = data.frame(
+          age = 0
+        ),
+        age_un = data.frame(0)
       ),
-      "argument of length 0"
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    # none programmed into the function yet.
+    # e.g., "'data_source_prep' must be non-empty"
+  )
+})
+
+# ----------------------------------------------------------------- #
+# ----------------------------------------------------------------- #
+
+test_that("prepare_data rejects NULL data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = NULL,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'data_source_prep' must be one of the following: 'list'"
+  )
+})
+
+test_that("prepare_data rejects incomplete list(data.frame) in data_source", {
+  expect_error(
+    prepare_data(
+      data_source_prep = RRatepol::example_data$pollen_data[[1]],
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'data_source_prep' must be one of the following: 'list'"
+  )
+})
+
+test_that("prepare_data throws error with empty data_source_prep list", {
+  expect_error(
+    prepare_data(
+      data_source_prep = list(),
+      working_units = "levels"
+    ),
+    "argument of length 0"
+  )
+})
+
+test_that("prepare_data throws error with data_source_prep with wrong structure", {
+  wrong_structure <-
+    list(
+      wrong_name = data.frame(
+        x = 1:5
+      ),
+      another_wrong = data.frame(y = 1:5)
     )
-  }
-)
+
+  expect_error(
+    prepare_data(
+      data_source_prep = wrong_structure,
+      working_units = "levels"
+    ),
+    "argument of length 0"
+  )
+})
 
 # ----------------------------------------------------------------- #
 #                 input data internal structure validation
 # ----------------------------------------------------------------- #
 
 # no error without age_uncertainty
-test_that(
-  "prepare_data works if no age_uncertainty in data_source",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = NULL,
-        verbose = FALSE
-      )
-
-    expect_no_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = c("levels", "bins", "MW"),
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
+test_that("prepare_data works if no age_uncertainty in data_source", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = NULL,
+      silent = TRUE
     )
-  }
-)
+
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("levels", "bins", "MW"),
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+  )
+})
 
 # ----------------------------------------------------------------- #
 #   More specific tests for 1) community 2) age and 3) age_un       #
 # ----------------------------------------------------------------- #
 
 ## Community data
-test_that(
-  "prepare_data handles single-row community data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]][1, , drop = FALSE],
-        data_age_extract = RRatepol::example_data$sample_age[[1]][1, , drop = FALSE],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]][, 1, drop = FALSE],
-        verbose = FALSE
+test_that("prepare_data handles single-row community data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]][
+        1,
+        ,
+        drop = FALSE
+      ],
+      data_age_extract = RRatepol::example_data$sample_age[[1]][
+        1,
+        ,
+        drop = FALSE
+      ],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]][,
+        1,
+        drop = FALSE
+      ],
+      silent = TRUE
+    )
+
+  expect_no_error(
+    result <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels"
       )
+  )
 
-    expect_no_error(
-      result <-
-        prepare_data(
-          data_source_prep = example_data,
-          working_units = "levels"
-        )
+  expect_equal(
+    nrow(
+      result[[1]][[1]]$bins
+    ),
+    1
+  )
+})
+
+test_that("prepare_data handles single-column community data", {
+  community_single <-
+    RRatepol::example_data$pollen_data[[1]][, 1:2] # sample_id + 1 species
+
+  example_data <-
+    extract_data(
+      data_community_extract = community_single,
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      silent = TRUE
     )
 
-    expect_equal(
-      nrow(
-        result[[1]][[1]]$bins
-      ),
-      1
-    )
-  }
-)
-
-test_that(
-  "prepare_data handles single-column community data",
-  {
-    community_single <-
-      RRatepol::example_data$pollen_data[[1]][, 1:2] # sample_id + 1 species
-
-    example_data <-
-      extract_data(
-        data_community_extract = community_single,
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
+  expect_no_error(
+    result <-
+      prepare_data(
+        data_source_prep = example_data,
+        working_units = "levels"
       )
+  )
 
-    expect_no_error(
-      result <-
-        prepare_data(
-          data_source_prep = example_data,
-          working_units = "levels"
-        )
-    )
-
-    expect_equal(
-      ncol(result[[1]][[1]]$data) - 1, # -1 for age column
-      1
-    )
-  }
-)
+  expect_equal(
+    ncol(result[[1]][[1]]$data) - 1, # -1 for age column
+    1
+  )
+})
 
 # ---------------------------------------------------------- #
 #                  Working Units Input Tests                 #
 # ---------------------------------------------------------- #
 
-test_that(
-  "prepare_data validates working_units is one of the three valid options",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "invalid",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+test_that("prepare_data validates working_units is one of the three valid options", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates working_units parameter is not numeric",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "invalid",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = 123,
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "'working_units' must be one of the following: 'character'"
+test_that("prepare_data validates working_units parameter is not numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates working_units parameter is not NA",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = 123,
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = NA,
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "'working_units' must be one of the following: 'character'"
+test_that("prepare_data validates working_units parameter is not NA", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates working_units parameter is not a vector of parameters",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = NA,
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = c("MW", "bins", "levels"),
-        rand = NULL
-      ),
-      "'arg' must be of length 1"
+test_that("prepare_data validates working_units parameter is not a vector of parameters", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates working_units parameter is not a vector of parameters",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("MW", "bins", "levels"),
+      rand = NULL
+    ),
+    "'arg' must be of length 1"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = c("MW", "bins")
-      ),
-      "'arg' must be of length 1"
+test_that("prepare_data validates working_units parameter is not a vector of parameters", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = c("MW", "bins")
+    ),
+    "'arg' must be of length 1"
+  )
+})
 
 # --------------------------------------------------- #
 
 # 1.3 working_units = NULL
 # 1.3.1 m.avg
-test_that(
-  "prepare_data, smooth_method = 'm.avg' throws error for working_units = NULL",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'm.avg' throws error for working_units = NULL", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data()
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = NULL,
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must be one of the following: 'character'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = NULL,
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
 # 1.3.2. shep
-test_that(
-  "prepare_data, smooth_method = 'shep' throws error for working_units = NULL",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'shep' throws error for working_units = NULL", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep"
-      ) %>%
-      reduce_data()
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = NULL,
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must be one of the following: 'character'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = NULL,
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
 # 1.3.3. age.w
-test_that(
-  "prepare_data, smooth_method = 'age.w' throws error for working_units = NULL",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'age.w' throws error for working_units = NULL", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data()
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = NULL,
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must be one of the following: 'character'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = NULL,
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
 # 1.3.4. grim
-test_that(
-  "prepare_data, smooth_method = 'grim' throws error for working_units = NULL",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'grim' throws error for working_units = NULL", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data()
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = NULL,
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must be one of the following: 'character'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = NULL,
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
 # --------------------------------------------------- #
 # 1.4 working_units = invalid character
 # 1.4.1 m.avg
-test_that(
-  "prepare_data, smooth_method = 'm.avg' throws error for working_units = invalid character",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'm.avg' throws error for working_units = invalid character", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data()
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "invalid_unit",
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "invalid_unit",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
 
 # 1.4.2. shep
-test_that(
-  "prepare_data, smooth_method = 'shep' throws error for working_units = invalid character",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'shep' throws error for working_units = invalid character", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep"
-      ) %>%
-      reduce_data()
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "invalid_unit",
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "invalid_unit",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
 
 # 1.4.3. age.w
-test_that(
-  "prepare_data, smooth_method = 'age.w' throws error for working_units = invalid character",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'age.w' throws error for working_units = invalid character", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data()
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "invalid_unit",
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "invalid_unit",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
 
 # 1.4.4. grim
-test_that(
-  "prepare_data, smooth_method = 'grim' throws error for working_units = invalid character",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'grim' throws error for working_units = invalid character", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data()
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "invalid_unit",
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      ), "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "invalid_unit",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'working_units' must contains one of the following values: 'levels', 'bins', 'MW'"
+  )
+})
 
 # --------------------------------------------------- #
 # 1.5 working_units = multiple
 # 1.5.1 m.avg
-test_that(
-  "prepare_data, smooth_method = 'm.avg' throws error for working_units = multiple values",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'm.avg' throws error for working_units = multiple values", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data()
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = c("levels", "bins"),
-        bin_size = 500,
-        rand = NULL
-      ), "'arg' must be of length 1"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = c("levels", "bins"),
+      bin_size = 500,
+      rand = NULL
+    ),
+    "'arg' must be of length 1"
+  )
+})
 
 # 1.4.2. shep
-test_that(
-  "prepare_data, smooth_method = 'shep' throws error for working_units = multiple values",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'shep' throws error for working_units = multiple values", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep"
-      ) %>%
-      reduce_data()
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = c("levels", "bins"),
-        bin_size = 500,
-        rand = NULL
-      ), "'arg' must be of length 1"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = c("levels", "bins"),
+      bin_size = 500,
+      rand = NULL
+    ),
+    "'arg' must be of length 1"
+  )
+})
 
 # 1.4.3. age.w
-test_that(
-  "prepare_data, smooth_method = 'age.w' throws error for working_units = multiple values",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'age.w' throws error for working_units = multiple values", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data()
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = c("levels", "bins"),
-        bin_size = 500,
-        rand = NULL
-      ), "'arg' must be of length 1"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = c("levels", "bins"),
+      bin_size = 500,
+      rand = NULL
+    ),
+    "'arg' must be of length 1"
+  )
+})
 
 # 1.4.4. grim
-test_that(
-  "prepare_data, smooth_method = 'grim' throws error for working_units = multiple values",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, smooth_method = 'grim' throws error for working_units = multiple values", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data()
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data()
 
-    expect_error(
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = c("levels", "bins"),
-        bin_size = 500,
-        rand = NULL
-      ), "'arg' must be of length 1"
+  expect_error(
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = c("levels", "bins"),
+      bin_size = 500,
+      rand = NULL
+    ),
+    "'arg' must be of length 1"
+  )
+})
+
+test_that("prepare_data validates working_units parameter is not 0", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates working_units parameter is not 0",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = 0
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = 0
-      ),
-      "'working_units' must be one of the following: 'character'"
+test_that("prepare_data validates working_units parameter is not NULL", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates working_units parameter is not NULL",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = NULL
-      ),
-      "'working_units' must be one of the following: 'character'"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = NULL
+    ),
+    "'working_units' must be one of the following: 'character'"
+  )
+})
 # ---------------------------------------------------------- #
 #                   Bin_size Input Tests                     #
 # ---------------------------------------------------------- #
 
 # 1.1 "levels"
-test_that(
-  "prepare_data takes bin_size=NULL if working_units = levels",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_silent(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      )
+test_that("prepare_data takes bin_size=NULL if working_units = levels", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
+
+  expect_silent(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
+    )
+  )
+})
 
 # 1.2 "bins"
-test_that(
-  "prepare_data validates bin_size is numeric",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = "500",
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'bin_size' must be one of the following: 'numeric'"
+test_that("prepare_data validates bin_size is numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is not Inf",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = "500",
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = Inf,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'to' must be a finite number"
+test_that("prepare_data validates bin_size is not Inf", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is not negative",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = Inf,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'to' must be a finite number"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = -500,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "wrong sign in 'by' argument"
+test_that("prepare_data validates bin_size is not negative", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is not NA",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = -500,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "wrong sign in 'by' argument"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = NA,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'bin_size' must be one of the following: 'numeric'"
+test_that("prepare_data validates bin_size is not NA", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is integer",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = 500.5,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "' bin_size ' must be a an integer"
-    )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = NA,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
 
-test_that(
-  "prepare_data validates bin_size is not 0",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = 0,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "invalid"
+test_that("prepare_data validates bin_size is integer", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 500.5,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "' bin_size ' must be a an integer"
+  )
+})
 
-test_that(
-  "prepare_data works with minimum bin_size (1)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_no_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = 1,
-        number_of_shifts = NULL,
-        rand = NULL
-      )
+test_that("prepare_data validates bin_size is not 0", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 0,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "invalid"
+  )
+})
+
+test_that("prepare_data works with minimum bin_size (1)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 1,
+      number_of_shifts = NULL,
+      rand = NULL
+    )
+  )
+})
 
 # 1.3 "MW"
-test_that(
-  "prepare_data validates bin_size is numeric (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = "500",
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "'bin_size' must be one of the following: 'numeric'"
+test_that("prepare_data validates bin_size is numeric (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is not Inf (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = "500",
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = Inf,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "'to' must be a finite number"
+test_that("prepare_data validates bin_size is not Inf (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is not negative (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = Inf,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'to' must be a finite number"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = -500,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "wrong sign in 'by' argument"
+test_that("prepare_data validates bin_size is not negative (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is not NA (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = -500,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "wrong sign in 'by' argument"
+  )
+})
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = NA,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "'bin_size' must be one of the following: 'numeric'"
+test_that("prepare_data validates bin_size is not NA (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data validates bin_size is integer (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500.5,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "' bin_size ' must be a an integer"
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = NA,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "'bin_size' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates bin_size is integer (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500.5,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "' bin_size ' must be a an integer"
+  )
+})
 
-test_that(
-  "prepare_data validates bin_size is not 0 (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 0,
-        number_of_shifts = 5,
-        rand = NULL
-      ),
-      "invalid"
+test_that("prepare_data validates bin_size is not 0 (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 0,
+      number_of_shifts = 5,
+      rand = NULL
+    ),
+    "invalid"
+  )
+})
 
-test_that(
-  "prepare_data works with minimum bin_size (1) and MW",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_no_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 1,
-        number_of_shifts = 5,
-        rand = NULL
-      )
+test_that("prepare_data works with minimum bin_size (1) and MW", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
-
-
-test_that(
-  "prepare_data handles extremely large bin_size",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
-      )
-
-    age_range <-
-      max(example_data$age$age) - min(example_data$age$age)
-    huge_bin_size <-
-      age_range * 10
-
-    expect_no_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = huge_bin_size
-      )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 1,
+      number_of_shifts = 5,
+      rand = NULL
     )
-  }
-)
+  )
+})
+
+
+test_that("prepare_data handles extremely large bin_size", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      silent = TRUE
+    )
+
+  age_range <-
+    max(example_data$age$age) - min(example_data$age$age)
+  huge_bin_size <-
+    age_range * 10
+
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = huge_bin_size
+    )
+  )
+})
 
 # ---------------------------------------------------------- #
 #                Number of shifts Input Tests                #
 # ---------------------------------------------------------- #
 
-test_that(
-  "prepare_data validates number_of_shifts is present (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+test_that("prepare_data validates number_of_shifts is present (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
 
-    expect_error(
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = NULL,
+      rand = NULL
+    ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+test_that("prepare_data validates number_of_shifts is not Inf (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = Inf,
+      rand = NULL
+    ),
+    "result would be too long a vector"
+  )
+})
+
+test_that("prepare_data validates number_of_shifts is not negative (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = -5,
+      rand = NULL
+    ),
+    "invalid 'times' argument"
+  )
+})
+
+test_that("prepare_data validates number_of_shifts is not NA (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = NA,
+      rand = NULL
+    ),
+    "'number_of_shifts' must be one of the following: 'numeric'"
+  )
+})
+
+
+test_that("prepare_data validates number_of_shifts is integer (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5.5,
+      rand = NULL
+    ),
+    "' number_of_shifts ' must be a an integer"
+  )
+})
+
+test_that("prepare_data works with number_of_shifts = 0 (working_units=WM)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+  expect_no_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 0,
+      rand = NULL
+    ),
+  )
+})
+
+test_that("prepare_data handles very large number_of_shifts", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      silent = TRUE
+    )
+
+  expect_no_error(
+    result <-
       prepare_data(
         data_source_prep = example_data,
         working_units = "MW",
         bin_size = 500,
-        number_of_shifts = NULL,
-        rand = NULL
-      ),
-      "'number_of_shifts' must be one of the following: 'numeric'"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates number_of_shifts is not Inf (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
+        number_of_shifts = 100
       )
+  )
 
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = Inf,
-        rand = NULL
-      ),
-      "result would be too long a vector"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates number_of_shifts is not negative (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = -5,
-        rand = NULL
-      ),
-      "invalid 'times' argument"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates number_of_shifts is not NA (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = NA,
-        rand = NULL
-      ),
-      "'number_of_shifts' must be one of the following: 'numeric'"
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data validates number_of_shifts is integer (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5.5,
-        rand = NULL
-      ),
-      "' number_of_shifts ' must be a an integer"
-    )
-  }
-)
-
-test_that(
-  "prepare_data works with number_of_shifts = 0 (working_units=WM)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-    expect_no_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 0,
-        rand = NULL
-      ),
-    )
-  }
-)
-
-test_that(
-  "prepare_data handles very large number_of_shifts",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
-      )
-
-    expect_no_error(
-      result <-
-        prepare_data(
-          data_source_prep = example_data,
-          working_units = "MW",
-          bin_size = 500,
-          number_of_shifts = 100
-        )
-    )
-
-    # Should create 100 different shifts
-    expect_equal(length(result[[1]]), 100)
-  }
-)
+  # Should create 100 different shifts
+  expect_equal(length(result[[1]]), 100)
+})
 
 # ---------------------------------------------------------- #
 #                 Rand Input Tests                           #
 # ---------------------------------------------------------- #
 
-test_that(
-  "prepare_data validates rand parameter when provided",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = "invalid"
-      ),
-      "'rand' must be one of the following: 'NULL', 'numeric'"
-    )
-  }
-)
-
-test_that(
-  "prepare_data validates rand is integer when numeric",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 5.5
-      ),
-      "' rand ' must be a an integer"
-    )
-  }
-)
-
-test_that(
-  "prepare_data produces N = rand random samples",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_no_error(
-      dat_5 <-
-        prepare_data(
-          data_source_prep = example_data,
-          working_units = "levels",
-          bin_size = 500,
-          number_of_shifts = 5,
-          rand = 5
-        )
+test_that("prepare_data validates rand parameter when provided", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
 
-    dat_3 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 3
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = "invalid"
+    ),
+    "'rand' must be one of the following: 'NULL', 'numeric'"
+  )
+})
 
-    expect_equal(length(dat_3), 3)
-    expect_equal(length(dat_5), 5)
-  }
-)
+test_that("prepare_data validates rand is integer when numeric", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
 
-test_that(
-  "prepare_data produces randomized samples with every trial",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5.5
+    ),
+    "' rand ' must be a an integer"
+  )
+})
 
+test_that("prepare_data produces N = rand random samples", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  expect_no_error(
     dat_5 <-
       prepare_data(
         data_source_prep = example_data,
@@ -1553,257 +1390,265 @@ test_that(
         number_of_shifts = 5,
         rand = 5
       )
+  )
 
-    dat_3 <-
+  dat_3 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 3
+    )
+
+  expect_equal(length(dat_3), 3)
+  expect_equal(length(dat_5), 5)
+})
+
+test_that("prepare_data produces randomized samples with every trial", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  dat_5 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5
+    )
+
+  dat_3 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 3
+    )
+  expect_false(identical(dat_3, dat_5[1:3]))
+})
+
+test_that("prepare_data throws error with rand = 0", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      rand = 0
+    ),
+    "subscript out of bounds"
+  )
+})
+
+
+test_that("prepare_data throws error with negative rand", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  expect_error(
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      rand = -5
+    ),
+    "invalid 'size' argument"
+  )
+})
+
+test_that("prepare_data throws warning if age_uncertainty has all identical values", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  # Make all age uncertainty values identical
+  example_data$age_un[] <-
+    1000
+
+  expect_warning(
+    result <-
       prepare_data(
         data_source_prep = example_data,
         working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 3
-      )
-    expect_false(identical(dat_3, dat_5[1:3]))
-  }
-)
-
-test_that(
-  "prepare_data throws error with rand = 0",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        rand = 0
+        rand = 10
       ),
-      "subscript out of bounds"
-    )
-  }
-)
+    # none programmed into the function yet
+    # e.g.,
+    # "Warning: age_uncertainty has only 1 unique value.
+    # randomizations will result in identical results"
+  )
 
-
-test_that(
-  "prepare_data throws error with negative rand",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    expect_error(
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        rand = -5
-      ),
-      "invalid 'size' argument"
-    )
-  }
-)
-
-test_that(
-  "prepare_data throws warning if age_uncertainty has all identical values",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    # Make all age uncertainty values identical
-    example_data$age_un[] <-
-      1000
-
-    expect_warning(
-      result <-
-        prepare_data(
-          data_source_prep = example_data,
-          working_units = "levels",
-          rand = 10
-        ),
-      # none programmed into the function yet
-      # e.g.,
-      # "Warning: age_uncertainty has only 1 unique value.
-      # randomizations will result in identical results"
-    )
-
-    # All randomizations should be identical
-    # (returns identical age across randomizations)
-    expect_true(
-      all(
-        sapply(
-          result[-1], function(x) {
-            identical(x[[1]]$data$age, result[[1]][[1]]$data$age)
-          }
-        )
+  # All randomizations should be identical
+  # (returns identical age across randomizations)
+  expect_true(
+    all(
+      sapply(
+        result[-1],
+        function(x) {
+          identical(x[[1]]$data$age, result[[1]][[1]]$data$age)
+        }
       )
     )
-  }
-)
+  )
+})
 
 
 # ------------------------------------------ #
 #         Reproducibility tests              #
 # ------------------------------------------ #
 
-test_that(
-  "prepare_data samples reproducibly if rand > 1 and seed set manually",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
+test_that("prepare_data samples reproducibly if rand > 1 and seed set manually", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
 
-    set.seed(123)
-    res1 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 5
-      )
+  set.seed(123)
+  res1 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5
+    )
 
-    set.seed(123)
-    res2 <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = 5
-      )
+  set.seed(123)
+  res2 <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = 5
+    )
 
-    expect_identical(res1, res2)
-  }
-)
+  expect_identical(res1, res2)
+})
 
 
-test_that(
-  "prepare_data does not change age if no age_uncertainty in data",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = NULL,
-        verbose = FALSE
-      )
+test_that("prepare_data does not change age if no age_uncertainty in data", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = NULL,
+      silent = TRUE
+    )
 
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 1,
-        rand = 1
-      )
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 1,
+      rand = 1
+    )
 
-    expect_identical(
+  expect_identical(
+    res[[1]][[1]]$data$age,
+    example_data$age$age
+  )
+})
+
+test_that("prepare_data changes age if age_uncertainty is in data and working_units = MW", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 1,
+      rand = 1
+    )
+
+  expect_false(
+    identical(
       res[[1]][[1]]$data$age,
       example_data$age$age
     )
-  }
-)
+  )
+})
 
-test_that(
-  "prepare_data changes age if age_uncertainty is in data and working_units = MW",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 1,
-        rand = 1
-      )
-
-    expect_false(
-      identical(
-        res[[1]][[1]]$data$age,
-        example_data$age$age
-      )
+test_that("prepare_data changes age if age_uncertainty is in data and working_units = levels", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data changes age if age_uncertainty is in data and working_units = levels",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        rand = 1
-      )
-
-    expect_false(
-      identical(
-        res[[1]][[1]]$data$age,
-        example_data$age$age
-      )
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      rand = 1
     )
-  }
-)
 
-test_that(
-  "prepare_data changes age if age_uncertainty is in data and working_units = bins",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = 500,
-        rand = 1
-      )
-
-    expect_false(
-      identical(
-        res[[1]][[1]]$data$age,
-        example_data$age$age
-      )
+  expect_false(
+    identical(
+      res[[1]][[1]]$data$age,
+      example_data$age$age
     )
-  }
-)
+  )
+})
+
+test_that("prepare_data changes age if age_uncertainty is in data and working_units = bins", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 500,
+      rand = 1
+    )
+
+  expect_false(
+    identical(
+      res[[1]][[1]]$data$age,
+      example_data$age$age
+    )
+  )
+})
 
 
 # ---------------------------------------------------------- #
@@ -1811,310 +1656,301 @@ test_that(
 # ---------------------------------------------------------- #
 
 # with valid input:
-test_that(
-  "prepare_data returns consistent structure across different working_units",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
-      )
-
-    result_levels <-
-      prepare_data(
-        example_data,
-        working_units = "levels"
-      )
-    result_bins <-
-      prepare_data(
-        example_data,
-        working_units = "bins",
-        bin_size = 500
-      )
-    result_mw <-
-      prepare_data(
-        example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 3
-      )
-
-    # All should have same top-level structure
-    expect_identical(
-      names(result_levels),
-      names(result_bins)
-    )
-    expect_identical(
-      names(result_levels),
-      names(result_mw)
+test_that("prepare_data returns consistent structure across different working_units", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      silent = TRUE
     )
 
-    # All should have same internal structure
-    expect_identical(
-      names(result_levels[[1]][[1]]),
-      names(result_bins[[1]][[1]])
+  result_levels <-
+    prepare_data(
+      example_data,
+      working_units = "levels"
     )
-    expect_identical(
-      names(result_levels[[1]][[1]]),
-      names(result_mw[[1]][[1]])
+  result_bins <-
+    prepare_data(
+      example_data,
+      working_units = "bins",
+      bin_size = 500
     )
-
-    # Bins should have same column structure
-    expect_identical(
-      names(result_levels[[1]][[1]]$bins),
-      names(result_bins[[1]][[1]]$bins)
-    )
-    expect_identical(
-      names(result_levels[[1]][[1]]$bins), names(result_mw[[1]][[1]]$bins)
-    )
-  }
-)
-
-test_that(
-  "prepare_data returns the correct output structure with default parameters (levels)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "levels",
-        # bin_size = NULL,
-        number_of_shifts = NULL,
-        rand = NULL
-      )
-
-    # General output structure tests:
-    expect_type(
-      res, "list"
+  result_mw <-
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 3
     )
 
-    # Named list elements
-    expect_identical(
-      names(
-        res[[1]][[1]]
-      ),
-      c("data", "bins")
+  # All should have same top-level structure
+  expect_identical(
+    names(result_levels),
+    names(result_bins)
+  )
+  expect_identical(
+    names(result_levels),
+    names(result_mw)
+  )
+
+  # All should have same internal structure
+  expect_identical(
+    names(result_levels[[1]][[1]]),
+    names(result_bins[[1]][[1]])
+  )
+  expect_identical(
+    names(result_levels[[1]][[1]]),
+    names(result_mw[[1]][[1]])
+  )
+
+  # Bins should have same column structure
+  expect_identical(
+    names(result_levels[[1]][[1]]$bins),
+    names(result_bins[[1]][[1]]$bins)
+  )
+  expect_identical(
+    names(result_levels[[1]][[1]]$bins),
+    names(result_mw[[1]][[1]]$bins)
+  )
+})
+
+test_that("prepare_data returns the correct output structure with default parameters (levels)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
 
-    # Named data object
-    expect_identical(
-      names(
-        res[[1]][[1]]$data
-      ),
-      c("age", names(example_data$community))
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "levels",
+      # bin_size = NULL,
+      number_of_shifts = NULL,
+      rand = NULL
     )
 
-    # Named bins object
-    expect_true(
-      all(
-        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-        %in%
-          colnames(res[[1]][[1]]$bins)
-      )
+  # General output structure tests:
+  expect_type(
+    res,
+    "list"
+  )
+
+  # Named list elements
+  expect_identical(
+    names(
+      res[[1]][[1]]
+    ),
+    c("data", "bins")
+  )
+
+  # Named data object
+  expect_identical(
+    names(
+      res[[1]][[1]]$data
+    ),
+    c("age", names(example_data$community))
+  )
+
+  # Named bins object
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label") %in%
+        colnames(res[[1]][[1]]$bins)
+    )
+  )
+
+  # $data is not all 0 or empty
+  expect_false(
+    all(
+      res[[1]][[1]]$data == 0
+    )
+  )
+  expect_false(
+    length(
+      res[[1]][[1]]$data
+    ) ==
+      0
+  )
+  # $bins is not all 0 or empty
+  expect_false(
+    all(
+      res[[1]][[1]]$bins == 0
+    )
+  )
+  expect_false(
+    nrow(res[[1]][[1]]$bins) == 0
+  )
+})
+
+test_that("prepare_data returns the correct output structure with default parameters (MW)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
 
-    # $data is not all 0 or empty
-    expect_false(
-      all(
-        res[[1]][[1]]$data == 0
-      )
-    )
-    expect_false(
-      length(
-        res[[1]][[1]]$data
-      ) == 0
-    )
-    # $bins is not all 0 or empty
-    expect_false(
-      all(
-        res[[1]][[1]]$bins == 0
-      )
-    )
-    expect_false(
-      nrow(res[[1]][[1]]$bins) == 0
-    )
-  }
-)
-
-test_that(
-  "prepare_data returns the correct output structure with default parameters (MW)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # General output structure tests:
-    expect_type(
-      res, "list"
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
     )
 
-    # Named list elements
-    expect_identical(
-      names(
-        res[[1]][[1]]
-      ),
-      c("data", "bins")
+  # General output structure tests:
+  expect_type(
+    res,
+    "list"
+  )
+
+  # Named list elements
+  expect_identical(
+    names(
+      res[[1]][[1]]
+    ),
+    c("data", "bins")
+  )
+
+  # Named data object
+  expect_identical(
+    names(
+      res[[1]][[1]]$data
+    ),
+    c("age", names(example_data$community))
+  )
+
+  # Named bins object
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label") %in%
+        colnames(res[[1]][[1]]$bins)
+    )
+  )
+
+  # Correct types
+  expect_type(res[[1]][[1]]$bins$name, "double")
+  expect_type(res[[1]][[1]]$bins$shift, "integer")
+  expect_type(res[[1]][[1]]$bins$age_diff, "double")
+  expect_type(res[[1]][[1]]$bins$start, "double")
+  expect_type(res[[1]][[1]]$bins$end, "double")
+  expect_type(res[[1]][[1]]$bins$res_age, "double")
+  expect_type(res[[1]][[1]]$bins$label, "character")
+
+  # $data is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$data == 0))
+  expect_false(length(res[[1]][[1]]$data) == 0)
+  # $bins is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$bins == 0))
+  expect_false(nrow(res[[1]][[1]]$bins) == 0)
+})
+
+test_that("prepare_data returns the correct output structure with default parameters (bins)", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
+      silent = TRUE
     )
 
-    # Named data object
-    expect_identical(
-      names(
-        res[[1]][[1]]$data
-      ),
-      c("age", names(example_data$community))
+  res <-
+    prepare_data(
+      data_source_prep = example_data,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
     )
 
-    # Named bins object
-    expect_true(
-      all(
-        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-        %in%
-          colnames(res[[1]][[1]]$bins)
-      )
+  # General output structure tests:
+  expect_type(
+    res,
+    "list"
+  )
+
+  # Named list elements
+  expect_identical(
+    names(
+      res[[1]][[1]]
+    ),
+    c("data", "bins")
+  )
+
+  # Named data object
+  expect_identical(
+    names(
+      res[[1]][[1]]$data
+    ),
+    c("age", names(example_data$community))
+  )
+
+  # Named bins object
+  expect_true(
+    all(
+      c("name", "shift", "age_diff", "start", "end", "res_age", "label") %in%
+        colnames(res[[1]][[1]]$bins)
     )
+  )
 
-    # Correct types
-    expect_type(res[[1]][[1]]$bins$name, "double")
-    expect_type(res[[1]][[1]]$bins$shift, "integer")
-    expect_type(res[[1]][[1]]$bins$age_diff, "double")
-    expect_type(res[[1]][[1]]$bins$start, "double")
-    expect_type(res[[1]][[1]]$bins$end, "double")
-    expect_type(res[[1]][[1]]$bins$res_age, "double")
-    expect_type(res[[1]][[1]]$bins$label, "character")
+  # Correct types
+  expect_type(res[[1]][[1]]$bins$name, "double")
+  expect_type(res[[1]][[1]]$bins$shift, "double")
+  expect_type(res[[1]][[1]]$bins$age_diff, "double")
+  expect_type(res[[1]][[1]]$bins$start, "double")
+  expect_type(res[[1]][[1]]$bins$end, "double")
+  expect_type(res[[1]][[1]]$bins$res_age, "double")
+  expect_type(res[[1]][[1]]$bins$label, "character")
 
-
-    # $data is not all 0 or empty
-    expect_false(all(res[[1]][[1]]$data == 0))
-    expect_false(length(res[[1]][[1]]$data) == 0)
-    # $bins is not all 0 or empty
-    expect_false(all(res[[1]][[1]]$bins == 0))
-    expect_false(nrow(res[[1]][[1]]$bins) == 0)
-  }
-)
-
-test_that(
-  "prepare_data returns the correct output structure with default parameters (bins)",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-        verbose = FALSE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = example_data,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # General output structure tests:
-    expect_type(
-      res, "list"
-    )
-
-    # Named list elements
-    expect_identical(
-      names(
-        res[[1]][[1]]
-      ),
-      c("data", "bins")
-    )
-
-    # Named data object
-    expect_identical(
-      names(
-        res[[1]][[1]]$data
-      ),
-      c("age", names(example_data$community))
-    )
-
-    # Named bins object
-    expect_true(
-      all(
-        c("name", "shift", "age_diff", "start", "end", "res_age", "label")
-        %in%
-          colnames(res[[1]][[1]]$bins)
-      )
-    )
-
-    # Correct types
-    expect_type(res[[1]][[1]]$bins$name, "double")
-    expect_type(res[[1]][[1]]$bins$shift, "double")
-    expect_type(res[[1]][[1]]$bins$age_diff, "double")
-    expect_type(res[[1]][[1]]$bins$start, "double")
-    expect_type(res[[1]][[1]]$bins$end, "double")
-    expect_type(res[[1]][[1]]$bins$res_age, "double")
-    expect_type(res[[1]][[1]]$bins$label, "character")
-
-    # $data is not all 0 or empty
-    expect_false(all(res[[1]][[1]]$data == 0))
-    expect_false(length(res[[1]][[1]]$data) == 0)
-    # $bins is not all 0 or empty
-    expect_false(all(res[[1]][[1]]$bins == 0))
-    expect_false(nrow(res[[1]][[1]]$bins) == 0)
-  }
-)
+  # $data is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$data == 0))
+  expect_false(length(res[[1]][[1]]$data) == 0)
+  # $bins is not all 0 or empty
+  expect_false(all(res[[1]][[1]]$bins == 0))
+  expect_false(nrow(res[[1]][[1]]$bins) == 0)
+})
 
 # ---------------------------------------------------------- #
 #                Integration with make_bins Tests            #
 # ---------------------------------------------------------- #
 
-test_that(
-  "prepare_data correctly calls make_bins for each working_units type",
-  {
-    example_data <-
-      extract_data(
-        data_community_extract = RRatepol::example_data$pollen_data[[1]],
-        data_age_extract = RRatepol::example_data$sample_age[[1]],
-        verbose = FALSE
-      )
+test_that("prepare_data correctly calls make_bins for each working_units type", {
+  example_data <-
+    extract_data(
+      data_community_extract = RRatepol::example_data$pollen_data[[1]],
+      data_age_extract = RRatepol::example_data$sample_age[[1]],
+      silent = TRUE
+    )
 
-    # Test that bins are created correctly for each type
-    result_levels <-
-      prepare_data(example_data, working_units = "levels")
-    result_bins <-
-      prepare_data(example_data, working_units = "bins", bin_size = 500)
-    result_mw <-
-      prepare_data(example_data, working_units = "MW", bin_size = 500, number_of_shifts = 5)
+  # Test that bins are created correctly for each type
+  result_levels <-
+    prepare_data(example_data, working_units = "levels")
+  result_bins <-
+    prepare_data(example_data, working_units = "bins", bin_size = 500)
+  result_mw <-
+    prepare_data(
+      example_data,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5
+    )
 
-    # Levels should have one bin per sample
-    expect_equal(nrow(result_levels[[1]][[1]]$bins), nrow(example_data$community))
+  # Levels should have one bin per sample
+  expect_equal(nrow(result_levels[[1]][[1]]$bins), nrow(example_data$community))
 
-    # MW should have multiple shifts
-    expect_true(max(result_mw[[1]][[1]]$bins$shift) <= 5)
-    expect_true(length(result_mw[[1]]) == 5)
+  # MW should have multiple shifts
+  expect_true(max(result_mw[[1]][[1]]$bins$shift) <= 5)
+  expect_true(length(result_mw[[1]]) == 5)
 
-    # Bins should have consistent bin_size
-    bins_result <-
-      result_bins[[1]][[1]]$bins
-    expect_true(all(bins_result$age_diff == 500))
-  }
-)
+  # Bins should have consistent bin_size
+  bins_result <-
+    result_bins[[1]][[1]]$bins
+  expect_true(all(bins_result$age_diff == 500))
+})
 
 # ------------------------------------------------- #
 # Tests using internal estimate_roc workflow:       #
@@ -2122,295 +1958,288 @@ test_that(
 # ------------------------------------------------- #
 
 # Invalid parameter combinations:
-test_that(
-  "prepare_data throws message if invalid combinations of parameters are silently overridden",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
+test_that("prepare_data throws message if invalid combinations of parameters are silently overridden", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
 
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-      )
-
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
-
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
-
-    expect_message(
-      data_prepared <-
-        prepare_data(
-          data_work,
-          working_units = "levels",
-          number_of_shifts = 5,
-          rand = 1
-        ),
-      # not programmed into the function yet.
-      # e.g.,
-      # "Invalid parameter 'number_of_shifts = 5' to working_units != 'MW'. number_of_shifts is automatically set to = 1"
+  data_extract <-
+    extract_data(
+      community,
+      age,
     )
-  }
-)
 
-test_that(
-  "prepare_data sets number_of_shifts =1 with user-supplied: 'MW' and number_of_shifts = 0",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w"
+    )
 
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
-
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
-
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
-
+  expect_message(
     data_prepared <-
       prepare_data(
         data_work,
-        working_units = "MW",
-        number_of_shifts = 0
-      )
+        working_units = "levels",
+        number_of_shifts = 5,
+        rand = 1
+      ),
+    # not programmed into the function yet.
+    # e.g.,
+    # "Invalid parameter 'number_of_shifts = 5' to working_units != 'MW'. number_of_shifts is automatically set to = 1"
+  )
+})
 
-    expect_true(
-      unique(
-        data_prepared[[1]][[1]]$bins$shift
-      ) == 1
+test_that("prepare_data sets number_of_shifts =1 with user-supplied: 'MW' and number_of_shifts = 0", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
     )
-  }
-)
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 0
+    )
+
+  expect_true(
+    unique(
+      data_prepared[[1]][[1]]$bins$shift
+    ) ==
+      1
+  )
+})
 
 # Test combinations of rand and age_un.
 # Q: is it the same whether if the user sets rand = 1 or if the function does it if rand = NULL?
 # expect identical results for rand = 1 and rand = NULL.
-test_that(
-  "Prepare data returns identical results for rand=NULL and rand=1",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
+test_that("Prepare data returns identical results for rand=NULL and rand=1", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
 
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
-
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
-
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
-
-    set.seed(123)
-    data_prepared_rand_1 <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 2,
-        rand = 1
-      )
-
-    set.seed(123)
-    data_prepared_rand_null <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 2,
-        rand = NULL
-      )
-
-    expect_true(identical(
-      data_prepared_rand_1,
-      data_prepared_rand_null
-    ))
-  }
-)
-
-test_that(
-  "Prepare data returns identical results for rand=NULL and rand=1 (without age_un)",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-
-    data_extract <-
-      extract_data(
-        community,
-        age,
-      )
-
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
-
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
-
-    data_prepared_rand_1 <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 2,
-        rand = 1
-      )
-
-    data_prepared_rand_null <-
-      prepare_data(
-        data_work,
-        working_units = "MW",
-        number_of_shifts = 2,
-        rand = NULL
-      )
-
-    expect_identical(
-      data_prepared_rand_1,
-      data_prepared_rand_null
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
     )
-  }
-)
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  set.seed(123)
+  data_prepared_rand_1 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = 1
+    )
+
+  set.seed(123)
+  data_prepared_rand_null <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = NULL
+    )
+
+  expect_true(identical(
+    data_prepared_rand_1,
+    data_prepared_rand_null
+  ))
+})
+
+test_that("Prepare data returns identical results for rand=NULL and rand=1 (without age_un)", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      silent = TRUE
+    )
+
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
+
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
+
+  data_prepared_rand_1 <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = 1
+    )
+
+  data_prepared_rand_null <-
+    prepare_data(
+      data_work,
+      working_units = "MW",
+      number_of_shifts = 2,
+      rand = NULL
+    )
+
+  expect_identical(
+    data_prepared_rand_1,
+    data_prepared_rand_null
+  )
+})
 
 # Is rand ignored if no age_un? - no. but results are identical.
-test_that(
-  "prepare_data throws warning if rand parameter is supplied but not age_un",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
+test_that("prepare_data throws warning if rand parameter is supplied but not age_un", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
 
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age
-      )
-
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
-
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
-
-    expect_warning(
-      data_prepared_rand_100 <-
-        prepare_data(
-          data_work,
-          working_units = "MW",
-          number_of_shifts = 1,
-          rand = 100
-        ),
-      # none programmed into function yet
-      # e.g.,
-      # "Warning: setting rand != NULL without age_un will result
-      # in identical randomization results."
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      silent = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data with seed produces reproducible results with rand = 100",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
 
-    # Control - compare against full uncertainty data
-    age_un_full <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_extract_full <-
-      extract_data(
-        community,
-        age,
-        age_un_full
-      )
-    data_smoothed_full <-
-      smooth_community_data(
-        data_extract_full,
-        smooth_method = "age.w"
-      )
-    data_work_full <-
-      reduce_data(
-        data_smoothed_full
-      )
-    # Test 5: Verify first sample is identical regardless of uncertainty data size
-    # (when using same random seed, first sample should use same row)
-    set.seed(123)
-    data_prep_full_seeded1 <-
+  expect_warning(
+    data_prepared_rand_100 <-
       prepare_data(
-        data_work_full,
+        data_work,
         working_units = "MW",
         number_of_shifts = 1,
         rand = 100
-      )
-    set.seed(123)
-    data_prep_full_seeded2 <-
-      prepare_data(
-        data_work_full,
-        working_units = "MW",
-        number_of_shifts = 1,
-        rand = 100
-      )
+      ),
+    # none programmed into function yet
+    # e.g.,
+    # "Warning: setting rand != NULL without age_un will result
+    # in identical randomization results."
+  )
+})
 
-    # First random sample should be from same row index
-    expect_identical(
-      data_prep_full_seeded1[[1]][[1]]$data$age,
-      data_prep_full_seeded2[[1]][[1]]$data$age
+test_that("prepare_data with seed produces reproducible results with rand = 100", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+
+  # Control - compare against full uncertainty data
+  age_un_full <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  data_extract_full <-
+    extract_data(
+      community,
+      age,
+      age_un_full,
+      silent = TRUE
     )
-  }
-)
+  data_smoothed_full <-
+    smooth_community_data(
+      data_extract_full,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
+  data_work_full <-
+    reduce_data(
+      data_smoothed_full
+    )
+  # Test 5: Verify first sample is identical regardless of uncertainty data size
+  # (when using same random seed, first sample should use same row)
+  set.seed(123)
+  data_prep_full_seeded1 <-
+    prepare_data(
+      data_work_full,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 100
+    )
+  set.seed(123)
+  data_prep_full_seeded2 <-
+    prepare_data(
+      data_work_full,
+      working_units = "MW",
+      number_of_shifts = 1,
+      rand = 100
+    )
+
+  # First random sample should be from same row index
+  expect_identical(
+    data_prep_full_seeded1[[1]][[1]]$data$age,
+    data_prep_full_seeded2[[1]][[1]]$data$age
+  )
+})
 
 # -------------------------------------------------------------------- #
 # 2. Test edge-cases with zeros and NAs in the raw data
@@ -2419,1862 +2248,1826 @@ test_that(
 # 2.1 With 0 or NA in samples
 ## 2.1.1a) one row in community 0
 # ---- levels ---- #
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "levels",
+      rand = NULL
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
 
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'age.w' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
+test_that("prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'grim' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "levels",
+      rand = NULL
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'levels', smooth_method = 'age.w' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "levels",
+      rand = NULL
+    )
+
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'levels', smooth_method = 'grim' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "levels",
+      rand = NULL
+    )
+
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
 # --- bins --- #
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
+test_that("prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
     )
-  }
-)
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
 # --- MW --- #
-test_that(
-  "prepare_data, working_units = 'MW', smooth_method = 'm.avg' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, working_units = 'MW', smooth_method = 'm.avg' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'MW', smooth_method = 'shep' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'MW', smooth_method = 'age.w' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
+test_that("prepare_data, working_units = 'MW', smooth_method = 'shep' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'MW', smooth_method = 'grim' works with one row 0 in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      0
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
     )
-  }
-)
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'MW', smooth_method = 'age.w' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'MW', smooth_method = 'grim' works with one row 0 in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    0
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
 ## 2.1.1b) one row in community NA
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, working_units = 'levels', smooth_method = 'm.avg' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-
-test_that(
-  "prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "levels",
+      rand = NULL
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
 
-test_that(
-  "prepare_data and working_units = 'levels' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
+test_that("prepare_data, working_units = 'levels', smooth_method = 'shep' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "levels",
-        rand = NULL
-      )
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
-    )
-  }
-)
-
-test_that(
-  "prepare_data and working_units = 'levels' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "levels",
-        rand = NULL
-      )
-
-    # test if result$bins has only valid samples
-    expect_identical(
-      res[[1]][[1]]$bins$name,
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "levels",
+      rand = NULL
     )
 
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data and working_units = 'levels' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "levels",
+      rand = NULL
+    )
+
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data and working_units = 'levels' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "levels",
+      rand = NULL
+    )
+
+  # test if result$bins has only valid samples
+  expect_identical(
+    res[[1]][[1]]$bins$name,
+    valid_samples
+  )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
 # --- bins --- #
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, working_units = 'bins', smooth_method = 'm.avg' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
+test_that("prepare_data, working_units = 'bins', smooth_method = 'shep' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "bins",
-        bin_size = 500,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
     )
-  }
-)
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'bins', smooth_method = 'age.w' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'bins', smooth_method = 'grim' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "bins",
+      bin_size = 500,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
 # --- MW --- #
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+test_that("prepare_data, working_units = 'MW' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    data_work_mavg <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "m.avg",
-        smooth_n_points = 5
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_mavg,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_mavg <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_shep <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "shep",
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_shep,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_mavg,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
+test_that("prepare_data, working_units = 'MW' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_work_agew <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
 
-    res <-
-      prepare_data(
-        data_source_prep = data_work_agew,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  data_work_shep <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "shep",
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
     )
-  }
-)
 
-test_that(
-  "prepare_data, working_units = 'MW' works with one row NA in community",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
-
-    community[1, -1] <-
-      NA
-    valid_samples <-
-      community[-1, 1]$sample_id
-
-    data_work_grim <-
-      extract_data(
-        data_community_extract = community,
-        data_age_extract = age,
-        age_uncertainty = age_uncertainty
-      ) %>%
-      smooth_community_data(
-        .,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        smooth_n_max = 9
-      ) %>%
-      reduce_data(
-        check_taxa = TRUE,
-        check_levels = TRUE
-      )
-
-    res <-
-      prepare_data(
-        data_source_prep = data_work_grim,
-        working_units = "MW",
-        bin_size = 500,
-        number_of_shifts = 5,
-        rand = NULL
-      )
-
-    # test if result$data has only valid samples
-    expect_identical(
-      rownames(
-        res[[1]][[1]]$data
-      ),
-      valid_samples
+  res <-
+    prepare_data(
+      data_source_prep = data_work_shep,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
     )
-  }
-)
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'MW' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_agew <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_agew,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
+
+test_that("prepare_data, working_units = 'MW' works with one row NA in community", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
+
+  community[1, -1] <-
+    NA
+  valid_samples <-
+    community[-1, 1]$sample_id
+
+  data_work_grim <-
+    extract_data(
+      data_community_extract = community,
+      data_age_extract = age,
+      age_uncertainty = age_uncertainty,
+      silent = TRUE
+    ) %>%
+    smooth_community_data(
+      .,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      smooth_n_max = 9,
+      silent = TRUE
+    ) %>%
+    reduce_data(
+      check_taxa = TRUE,
+      check_levels = TRUE
+    )
+
+  res <-
+    prepare_data(
+      data_source_prep = data_work_grim,
+      working_units = "MW",
+      bin_size = 500,
+      number_of_shifts = 5,
+      rand = NULL
+    )
+
+  # test if result$data has only valid samples
+  expect_identical(
+    rownames(
+      res[[1]][[1]]$data
+    ),
+    valid_samples
+  )
+})
 
 
 # ---------------- Check for NAs in output ------------------ #
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "shep"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    # empty working_units uses 'levels'
-    data_prepared <-
-      prepare_data(
-        data_work
-      )
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "m.avg"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    # empty working_units uses 'levels'
-    data_prepared <-
-      prepare_data(
-        data_work
-      )
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "grim"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    # empty working_units uses 'levels'
-    data_prepared <-
-      prepare_data(
-        data_work
-      )
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    # empty working_units uses 'levels'
-    data_prepared <-
-      prepare_data(
-        data_work
-      )
+  # empty working_units uses 'levels'
+  data_prepared <-
+    prepare_data(
+      data_work
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "shep"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "bins"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "m.avg"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "bins"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "grim"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "bins"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "bins"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "bins"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "shep"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "shep",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "MW"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "m.avg"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "m.avg",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "MW"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "grim"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "grim",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "MW"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})
 
 # NAs in age (known issue)
-test_that(
-  "prepare_data works correctly within estimate_roc() workflow with NAs in age",
-  {
-    community <-
-      RRatepol::example_data$pollen_data[[1]]
-    age <-
-      RRatepol::example_data$sample_age[[1]]
+test_that("prepare_data works correctly within estimate_roc() workflow with NAs in age", {
+  community <-
+    RRatepol::example_data$pollen_data[[1]]
+  age <-
+    RRatepol::example_data$sample_age[[1]]
 
-    age$age[1:10] <-
-      NA
-    age_uncertainty <-
-      RRatepol::example_data$age_uncertainty[[1]]
+  age$age[1:10] <-
+    NA
+  age_uncertainty <-
+    RRatepol::example_data$age_uncertainty[[1]]
 
-    data_extract <-
-      extract_data(
-        community,
-        age,
-        age_uncertainty
-      )
+  data_extract <-
+    extract_data(
+      community,
+      age,
+      age_uncertainty,
+      silent = TRUE
+    )
 
-    data_smoothed <-
-      smooth_community_data(
-        data_extract,
-        smooth_method = "age.w"
-      )
+  data_smoothed <-
+    smooth_community_data(
+      data_extract,
+      smooth_method = "age.w",
+      silent = TRUE
+    )
 
-    data_work <-
-      reduce_data(
-        data_smoothed
-      )
+  data_work <-
+    reduce_data(
+      data_smoothed
+    )
 
-    data_prepared <-
-      prepare_data(
-        data_work,
-        working_units = "MW"
-      )
+  data_prepared <-
+    prepare_data(
+      data_work,
+      working_units = "MW"
+    )
 
-    # expect no more NAs in bins
-    expect_false(
-      isTRUE(
-        any(
-          is.na(
-            data_prepared[[1]][[1]]$bins
-          )
+  # expect no more NAs in bins
+  expect_false(
+    isTRUE(
+      any(
+        is.na(
+          data_prepared[[1]][[1]]$bins
         )
       )
     )
-  }
-)
+  )
+})

--- a/tests/testthat/test-reduce_data.R
+++ b/tests/testthat/test-reduce_data.R
@@ -75,7 +75,7 @@ test_that("reduce_data rejects invalid check_taxa argument", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
   expect_error(
     reduce_data(
@@ -92,7 +92,7 @@ test_that("reduce_data rejects invalid check_taxa argument", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
   expect_error(
     reduce_data(
@@ -109,7 +109,7 @@ test_that("reduce_data rejects invalid check_taxa argument", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
   expect_error(
     reduce_data(
@@ -127,7 +127,7 @@ test_that("reduce_data rejects invalid check_levels argument", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
   expect_error(
     reduce_data(
@@ -144,7 +144,7 @@ test_that("reduce_data rejects invalid check_levels argument", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
   expect_error(
     reduce_data(
@@ -161,7 +161,7 @@ test_that("reduce_data rejects invalid check_levels argument", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
   expect_error(
     reduce_data(
@@ -179,7 +179,7 @@ test_that("reduce_data rejects missing community component", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   incomplete_data <-
@@ -201,7 +201,7 @@ test_that("reduce_data rejects missing age component", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   incomplete_data <-
@@ -223,7 +223,7 @@ test_that("reduce_data rejects community as matrix", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community <-
@@ -242,7 +242,7 @@ test_that("reduce_data rejects age as matrix", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$age <-
@@ -262,7 +262,7 @@ test_that("reduce_data rejects community as list", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community <-
@@ -282,7 +282,7 @@ test_that("reduce_data rejects age as list", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$age <-
@@ -302,7 +302,7 @@ test_that("reduce_data validates age_un is not a list", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$age_un <-
@@ -323,7 +323,7 @@ test_that("reduce_data rejects community with non-numeric columns", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community$text_col <-
@@ -342,7 +342,7 @@ test_that("reduce_data validates community must have colnames", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   colnames(raw_data$community) <-
@@ -364,7 +364,7 @@ test_that("reduce_data validates community must have colnames", {
 #       data_community_extract = RRatepol::example_data$pollen_data[[1]],
 #       data_age_extract = RRatepol::example_data$sample_age[[1]],
 #       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#       verbose = FALSE
+#       silent = TRUE
 #     )
 #
 #   rownames(raw_data$community) <-
@@ -383,7 +383,7 @@ test_that("reduce_data validates community must have colnames", {
 #       data_community_extract = RRatepol::example_data$pollen_data[[1]],
 #       data_age_extract = RRatepol::example_data$sample_age[[1]],
 #       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-#       verbose = FALSE
+#       silent = TRUE
 #     )
 #
 #   rownames(raw_data$age) <-
@@ -404,7 +404,7 @@ test_that("reduce_data with no filtering returns identical data", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -434,7 +434,7 @@ test_that("taxa filtering drops taxa with zero column sums", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column/taxa in community
@@ -459,7 +459,7 @@ test_that("check_levels = FALSE preserves rownames / sample ids", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -487,7 +487,7 @@ test_that("taxa filtering removes all-NA taxa", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community$na_taxon <-
@@ -513,7 +513,7 @@ test_that("levels filtering removes zero-sum levels from community and age", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -547,7 +547,7 @@ test_that("levels filtering preserves community colnames/taxa", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -576,7 +576,7 @@ test_that("levels filtering maintains matching rownames between community and ag
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -609,7 +609,7 @@ test_that("levels filtering works with NULL age_un", {
     extract_data(
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community[1, ] <-
@@ -630,7 +630,7 @@ test_that("levels filtering removes all-NA sample", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   first_level <-
@@ -658,7 +658,7 @@ test_that("both filtering removes zero-sum taxa", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -685,7 +685,7 @@ test_that("both filtering removes zero-sum levels", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   first_level <-
@@ -718,7 +718,7 @@ test_that("both filtering removes samples with zero taxa", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -744,7 +744,7 @@ test_that("both filtering maintains matching rownames between community and age 
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -771,7 +771,7 @@ test_that("both filtering handles NULL age_un", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -809,7 +809,7 @@ test_that("reduce_data works with a single sample in community", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community <-
@@ -830,7 +830,7 @@ test_that("reduce_data works with a single taxon in community", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]][1:2],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_no_error(
@@ -850,7 +850,7 @@ test_that("taxa filtering with all-zero community data throws error", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community[,] <-
@@ -872,7 +872,7 @@ test_that("levels filtering with all zero levels throws error", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community[,] <-
@@ -897,7 +897,7 @@ test_that("both filtering with all zero data throws error", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # all zero in community
@@ -920,7 +920,7 @@ test_that("reduce_data throws error if community has no columns", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # 0 columns in community
@@ -942,7 +942,7 @@ test_that("both filtering throws error if all data are NA", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   raw_data$community[,] <-
@@ -970,7 +970,7 @@ test_that("reduce_data produces valid output structure", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -1004,7 +1004,7 @@ test_that("reduce_data produces valid community structure", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -1054,7 +1054,7 @@ test_that("reduce_data produces valid age structure", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community
@@ -1100,7 +1100,7 @@ test_that("reduce_data produces valid age_un structure", {
       data_community_extract = RRatepol::example_data$pollen_data[[1]],
       data_age_extract = RRatepol::example_data$sample_age[[1]],
       age_uncertainty = RRatepol::example_data$age_uncertainty[[1]],
-      verbose = FALSE
+      silent = TRUE
     )
 
   # one zero column in community

--- a/tests/testthat/test-run_iteration.R
+++ b/tests/testthat/test-run_iteration.R
@@ -16,7 +16,7 @@ test_that("run_iteration throws error when data_source_run argument is missing (
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     'argument "data_source_run" is missing, with no default'
   )
@@ -32,7 +32,7 @@ test_that("run_iteration throws error when data_source_run is NULL (invalid empt
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument of length 0"
   )
@@ -49,7 +49,7 @@ test_that("run_iteration throws error when data_source_run is a character string
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid for atomic vectors"
   )
@@ -66,7 +66,7 @@ test_that("run_iteration throws error when data_source_run is a numeric value (1
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid for atomic vectors"
   )
@@ -83,7 +83,7 @@ test_that("run_iteration throws error when data_source_run is zero (numeric 0) i
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid for atomic vectors"
   )
@@ -100,7 +100,7 @@ test_that("run_iteration throws error when data_source_run is NA (missing value)
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid for atomic vectors"
   )
@@ -117,7 +117,7 @@ test_that("run_iteration throws error when data_source_run is an empty list (lis
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument of length 0"
   )
@@ -134,7 +134,7 @@ test_that("run_iteration throws error when data_source_run is an empty data fram
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument of length 0"
   )
@@ -182,7 +182,7 @@ test_that("run_iteration throws error when bin_selection is an invalid string ('
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid 'length' argument"
   )
@@ -225,7 +225,7 @@ test_that("run_iteration throws error when bin_selection is a numeric value (1) 
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid 'length' argument"
   )
@@ -268,7 +268,7 @@ test_that("run_iteration throws error when bin_selection contains multiple value
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "the condition has length > 1"
   )
@@ -311,7 +311,7 @@ test_that("run_iteration throws error when bin_selection contains multiple value
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "the condition has length > 1"
   )
@@ -354,7 +354,7 @@ test_that("run_iteration throws error when bin_selection contains multiple value
 #                 tranform_to_proportions = TRUE,
 #                 dissimilarity_coefficient = "euc",
 #                 time_standardisation = 500,
-#                 verbose = FALSE
+#                 silent = TRUE
 #             ),
 #             # none programmed into the function yet.
 #             # e.g., "Warning: No bin_selection supplied.Using default 'first' instead"
@@ -399,7 +399,7 @@ test_that("run_iteration throws error when bin_selection is NULL instead of a va
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument is of length zero"
   )
@@ -450,7 +450,7 @@ test_that("run_iteration throws error with NULL in standardise parameter", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # No error programmed into the fuction for standardise != TRUE
     # gets ignored - i.e., equivalent to standardise = FALSE
@@ -495,7 +495,7 @@ test_that("run_iteration treats non-boolean value for standardise as FALSE", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_s3_class(result, "data.frame")
@@ -543,7 +543,7 @@ test_that("run_iteration throws error when n_individuals is zero with standardis
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "invalid 'length' argument"
   )
@@ -586,7 +586,7 @@ test_that("run_iteration throws warning for invalid combinations of standardise=
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     # this scenario silently uses the minimum count available
     # instead of user supplied n_individuals
@@ -635,7 +635,7 @@ test_that("run_iteration throws error for non-boolian tranform_to_proportions = 
       tranform_to_proportions = 0,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
     # None programmed into the function yet since it only recognizes TRUE
     # gets ignored - i.e., equivalent to tranform_to_proportions = FALSE
@@ -686,7 +686,7 @@ test_that("run_iteration throws error for non-boolian tranform_to_proportions = 
 #                 tranform_to_proportions = TRUE,
 #                 dissimilarity_coefficient = ,
 #                 time_standardisation = 500,
-#                 verbose = FALSE
+#                 silent = TRUE
 #             ),
 #             # none programmed into the function yet.
 #             # e.g., "No dissimilarity_coefficient supplied. Defaulting to to 'euc'."
@@ -730,7 +730,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is NULL ins
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument is of length zero"
   )
@@ -773,7 +773,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is an inval
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "my_choice",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "object 'corrmat' not found"
   )
@@ -816,7 +816,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is a numeri
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = 123,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "object 'corrmat' not found"
   )
@@ -859,7 +859,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient contains mu
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = c("euc", "euc.sd"),
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "the condition has length > 1"
   )
@@ -902,7 +902,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is zero (nu
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = 0,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "object 'corrmat' not found"
   )
@@ -945,7 +945,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is NA (miss
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = NA,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "missing value where TRUE/FALSE needed"
   )
@@ -994,7 +994,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is NA (miss
 #                 tranform_to_proportions = TRUE,
 #                 dissimilarity_coefficient = "euc",
 #                 time_standardisation = ,
-#                 verbose = FALSE
+#                 silent = TRUE
 #             ),
 #             # none programmed into the function yet.
 #             # e.g., "No time_standardization supplied.
@@ -1040,7 +1040,7 @@ test_that("run_iteration throws error when time_standardisation is NULL", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = NULL,
-      verbose = FALSE
+      silent = TRUE
     ),
     "`age_diff_st` must be size" # 16 or 1, not 0.
   )
@@ -1083,7 +1083,7 @@ test_that("run_iteration throws error when time_standardisation is a character s
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = "123",
-      verbose = FALSE
+      silent = TRUE
     ),
     "non-numeric argument to binary operator"
     # none programmed into the function yet.
@@ -1128,7 +1128,7 @@ test_that("run_iteration throws error when time_standardisation is zero", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 0,
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into the function yet.
     # e.g., "Error: time_standardisation = 0 results in zero roc."
@@ -1171,7 +1171,7 @@ test_that("run_iteration throws error when time_standardisation is NA", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = NA,
-      verbose = FALSE
+      silent = TRUE
     ),
     # none programmed into the function yet.
     # e.g.,
@@ -1226,7 +1226,7 @@ test_that("run_iteration handles community data with all zeros when using euc di
           tranform_to_proportions = TRUE,
           dissimilarity_coefficient = "euc",
           time_standardisation = TRUE,
-          verbose = FALSE
+          silent = TRUE
         )
     ),
     "subscript out of bounds"
@@ -1274,7 +1274,7 @@ test_that("run_iteration handles community data with all zeros when using euc.sd
           tranform_to_proportions = TRUE,
           dissimilarity_coefficient = "euc.sd",
           time_standardisation = TRUE,
-          verbose = FALSE
+          silent = TRUE
         )
     ),
     "subscript out of bounds"
@@ -1320,7 +1320,7 @@ test_that("run_iteration treats non-boolean value for tranform_to_proportions as
       tranform_to_proportions = 1,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_s3_class(result, "data.frame")
@@ -1363,7 +1363,7 @@ test_that("run_iteration handles boolean TRUE for time_standardisation as 1", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = TRUE, # TRUE is coerced to 1
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_s3_class(result, "data.frame")
@@ -1457,7 +1457,7 @@ test_that("run_iteration throws no message if standardisation failed if verbose 
         tranform_to_proportions = TRUE,
         dissimilarity_coefficient = "euc",
         time_standardisation = 500,
-        verbose = FALSE
+        silent = TRUE
       )
   )
 })
@@ -1500,7 +1500,7 @@ test_that("run_iteration throws error with numeric zero for tranform_to_proporti
       tranform_to_proportions = 0,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
     # None programmed into the function yet
     # e.g., "invalid argument supplied to 'tranform_to_proportions'"
@@ -1545,7 +1545,7 @@ test_that("run_iteration throws error with numeric zero for tranform_to_proporti
 #                 tranform_to_proportions = TRUE,
 #                 dissimilarity_coefficient = ,
 #                 time_standardisation = 500,
-#                 verbose = FALSE
+#                 silent = TRUE
 #             ),
 #             # none programmed into the function yet.
 #             # e.g., "No dissimilarity_coefficient supplied. Defaulting to to 'euc'."
@@ -1590,7 +1590,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is NULL", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = NULL,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "argument is of length zero"
   )
@@ -1633,7 +1633,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is an inval
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "my_choice",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "object 'corrmat' not found"
   )
@@ -1676,7 +1676,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is a numeri
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = 123,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "object 'corrmat' not found"
   )
@@ -1719,7 +1719,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient contains mu
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = c("euc", "euc.sd"),
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "the condition has length > 1"
   )
@@ -1762,7 +1762,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is zero", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = 0,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "object 'corrmat' not found"
   )
@@ -1805,7 +1805,7 @@ test_that("run_iteration throws error when dissimilarity_coefficient is NA", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = NA,
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     ),
     "missing value where TRUE/FALSE needed"
   )
@@ -1990,7 +1990,7 @@ test_that("run_iteration output has non-NA values in expected columns", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check for NA values
@@ -2036,7 +2036,7 @@ test_that("run_iteration RoC values are numeric and positive", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check RoC values
@@ -2092,7 +2092,7 @@ test_that("run_iteration with different time_standardisation gives proportional 
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   set.seed(123)
@@ -2105,7 +2105,7 @@ test_that("run_iteration with different time_standardisation gives proportional 
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 1000, # Double the time standardization
-      verbose = FALSE
+      silent = TRUE
     )
 
   # With double time_standardisation, RoC should be doubled
@@ -2150,7 +2150,7 @@ test_that("run_iteration with standardise=TRUE produces valid output", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check output with standardization
@@ -2197,7 +2197,7 @@ test_that("run_iteration with different dissimilarity_coefficient produces diffe
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   set.seed(123)
@@ -2210,7 +2210,7 @@ test_that("run_iteration with different dissimilarity_coefficient produces diffe
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc.sd",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Different dissimilarity coefficients should produce different results
@@ -2254,7 +2254,7 @@ test_that("run_iteration output is deterministic with fixed seed for random bin_
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   set.seed(123)
@@ -2267,7 +2267,7 @@ test_that("run_iteration output is deterministic with fixed seed for random bin_
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Same seed should produce identical results with random bin selection
@@ -2311,7 +2311,7 @@ test_that("run_iteration output has valid label column", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check that labels are valid
@@ -2366,7 +2366,7 @@ test_that("run_iteration handles very small time_standardisation correctly", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 0.001, # Very small value to test division behavior
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check that results are still valid (not Inf)
@@ -2410,7 +2410,7 @@ test_that("run_iteration output age values match input data range", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # Check age range consistency
@@ -2467,7 +2467,7 @@ test_that("run_iteration output has reasonable RoC values for typical inputs", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   # RoC values should be in a reasonable range for ecological data
@@ -2514,7 +2514,7 @@ test_that("run_iteration executes successfully with all valid parameters", {
       tranform_to_proportions = TRUE,
       dissimilarity_coefficient = "euc",
       time_standardisation = 500,
-      verbose = FALSE
+      silent = TRUE
     )
 
   expect_s3_class(result, "data.frame")

--- a/tests/testthat/test-smooth_community_data.R
+++ b/tests/testthat/test-smooth_community_data.R
@@ -3,1209 +3,1068 @@
 # ----------------------------------------------------------- #
 
 ## 1.1 Test required parameter validation - wrong type -----
-test_that(
-  "smooth_community_data() throws error if data_source_smooth is not list",
-  {
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = "not_a_list",
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "'data_source_smooth' must be a list"
-    )
-  }
-)
+test_that("smooth_community_data() throws error if data_source_smooth is not list", {
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = "not_a_list",
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "'data_source_smooth' must be a list"
+  )
+})
 
 ## 1.2 Test required parameter validation - NULL input -----
-test_that(
-  "smooth_community_data() throws error if data_source_smooth is NULL",
-  {
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = NULL,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "'data_source_smooth' must be a list"
-    )
-  }
-)
+test_that("smooth_community_data() throws error if data_source_smooth is NULL", {
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = NULL,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "'data_source_smooth' must be a list"
+  )
+})
 
 ## 1.3 Test optional parameter validation - wrong type -----
-test_that(
-  "smooth_community_data() throws error if smooth_method is not character",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = 123,
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "'smooth_method' must be character"
+test_that("smooth_community_data() throws error if smooth_method is not character", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = 123,
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "'smooth_method' must be character"
+  )
+})
 
 ## 1.4 Test smooth_n_points type validation -----
-test_that(
-  "smooth_community_data() throws error if smooth_n_points is not numeric",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = "not_numeric",
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be numeric"
+test_that("smooth_community_data() throws error if smooth_n_points is not numeric", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = "not_numeric",
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be numeric"
+  )
+})
 
 ## 1.5 Test smooth_n_max type validation -----
-test_that(
-  "smooth_community_data() throws error if smooth_n_max is not numeric",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_n_max = "not_numeric",
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'smooth_n_max' must be numeric"
+test_that("smooth_community_data() throws error if smooth_n_max is not numeric", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_n_max = "not_numeric",
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'smooth_n_max' must be numeric"
+  )
+})
 
 ## 1.6 Test smooth_age_range type validation for grim -----
-test_that(
-  "smooth_community_data() throws error if smooth_age_range is not numeric for grim",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_n_max = 9,
-        smooth_age_range = "not_numeric",
-        verbose = FALSE
-      ),
-      "'smooth_age_range' must be numeric"
+test_that("smooth_community_data() throws error if smooth_age_range is not numeric for grim", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_n_max = 9,
+      smooth_age_range = "not_numeric",
+      silent = TRUE
+    ),
+    "'smooth_age_range' must be numeric"
+  )
+})
 
 ## 1.7 Test smooth_age_range type validation for age.w -----
-test_that(
-  "smooth_community_data() throws error if smooth_age_range is not numeric for age.w",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = "not_numeric",
-        verbose = FALSE
-      ),
-      "'smooth_age_range' must be numeric"
+test_that("smooth_community_data() throws error if smooth_age_range is not numeric for age.w", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = "not_numeric",
+      silent = TRUE
+    ),
+    "'smooth_age_range' must be numeric"
+  )
+})
 
 ## 1.8 Test round_results type validation -----
-test_that(
-  "smooth_community_data() throws error if round_results is not logical",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        round_results = "TRUE",
-        verbose = FALSE
-      ),
-      "'round_results' must be logical and either TRUE or FALSE"
+test_that("smooth_community_data() throws error if round_results is not logical", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      round_results = "TRUE",
+      silent = TRUE
+    ),
+    "'round_results' must be logical and either TRUE or FALSE"
+  )
+})
 
 ## 1.9 Test verbose type validation -----
-test_that(
-  "smooth_community_data() throws error if verbose is not logical",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = "not_logical"
-      ),
-      "'verbose' must be logical and either TRUE or FALSE"
+test_that("smooth_community_data() throws error if verbose is not logical", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      verbose = "not_logical"
+    ),
+    "'verbose' must be logical and either TRUE or FALSE"
+  )
+})
 
 # ----------------------------------------------------------- #
 # 2. INPUT PARAMETER VALUE VALIDATION -----
 # ----------------------------------------------------------- #
 
 ## 2.1 Test parameter bounds - invalid smooth_method -----
-test_that(
-  "smooth_community_data() throws error if smooth_method is invalid",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "invalid_method",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      'should be one of "m.avg", "grim", "age.w", "shep"'
+test_that("smooth_community_data() throws error if smooth_method is invalid", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "invalid_method",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    'should be one of "m.avg", "grim", "age.w", "shep"'
+  )
+})
 
 # ----------------------------------------------------------- #
 # 3. INPUT DATA STRUCTURE VALIDATION -----
 # ----------------------------------------------------------- #
 
 ## 3.1 Test required components presence -----
-test_that(
-  "smooth_community_data() throws error if community component is missing",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    invalid_data <-
-      data_source_smooth
-    invalid_data$community <-
-      NULL
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = invalid_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "assert_that: length of assertion is not 1"
+test_that("smooth_community_data() throws error if community component is missing", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  invalid_data <-
+    data_source_smooth
+  invalid_data$community <-
+    NULL
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = invalid_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "assert_that: length of assertion is not 1"
+  )
+})
 
 ## 3.2 Test component data types -----
-test_that(
-  "smooth_community_data() throws warning if community component is a character matrix",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    invalid_data <-
-      data_source_smooth
-    invalid_data$community <-
-      as.character(
-        invalid_data$community
-      )
-
-    # Capture all warnings to verify the expected warning occurs
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = invalid_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "assert_that: length of assertion is not 1"
+test_that("smooth_community_data() throws warning if community component is a character matrix", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  invalid_data <-
+    data_source_smooth
+  invalid_data$community <-
+    as.character(
+      invalid_data$community
+    )
+
+  # Capture all warnings to verify the expected warning occurs
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = invalid_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "assert_that: length of assertion is not 1"
+  )
+})
 
 ## 3.3 Test data dimensions - empty data -----
-test_that(
-  "smooth_community_data() handles empty community data",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    empty_data <-
-      data_source_smooth
-    empty_data$community <-
-      data.frame()
-    empty_data$age <-
-      data.frame()
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = empty_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "'community' must have at least one row"
+test_that("smooth_community_data() handles empty community data", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  empty_data <-
+    data_source_smooth
+  empty_data$community <-
+    data.frame()
+  empty_data$age <-
+    data.frame()
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = empty_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "'community' must have at least one row"
+  )
+})
 
 ## 3.4 Test data dimensions - single row -----
-test_that(
-  "smooth_community_data() handles single row data",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    single_row_data <-
-      data_source_smooth
-    single_row_data$community <-
-      single_row_data$community[1, , drop = FALSE]
-    single_row_data$age <-
-      single_row_data$age[1, , drop = FALSE]
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = single_row_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 1,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() handles single row data", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  single_row_data <-
+    data_source_smooth
+  single_row_data$community <-
+    single_row_data$community[1, , drop = FALSE]
+  single_row_data$age <-
+    single_row_data$age[1, , drop = FALSE]
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = single_row_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 1,
+      silent = TRUE
+    )
+  )
+})
 
 ## 3.5 Test relationship between data inputs - dimension mismatch -----
-test_that(
-  "smooth_community_data() throws error when community and age have incompatible dimensions",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    mismatched_data <-
-      data_source_smooth
-    mismatched_data$age <-
-      mismatched_data$age[1:5, , drop = FALSE]
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = mismatched_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      ),
-      "'community' and 'age' must have identical rownames"
+test_that("smooth_community_data() throws error when community and age have incompatible dimensions", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  mismatched_data <-
+    data_source_smooth
+  mismatched_data$age <-
+    mismatched_data$age[1:5, , drop = FALSE]
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = mismatched_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    ),
+    "'community' and 'age' must have identical rownames"
+  )
+})
 
 # ----------------------------------------------------------- #
 # 4. INPUT DATA CONTENT VALIDATION -----
 # ----------------------------------------------------------- #
 
 ## 4.4 Test extreme values handling - very large
-test_that(
-  "smooth_community_data() handles very large values in community data",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    extreme_data <-
-      data_source_smooth
-    extreme_data$community[1, 1] <-
-      1e6
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = extreme_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() handles very large values in community data", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  extreme_data <-
+    data_source_smooth
+  extreme_data$community[1, 1] <-
+    1e6
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = extreme_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+  )
+})
 
 ## 4.5 Test extreme values handling - very small -----
-test_that(
-  "smooth_community_data() handles very small values in community data",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    extreme_data <-
-      data_source_smooth
-    extreme_data$community[1, 1] <-
-      1e-6
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = extreme_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() handles very small values in community data", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  extreme_data <-
+    data_source_smooth
+  extreme_data$community[1, 1] <-
+    1e-6
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = extreme_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+  )
+})
 
 # ----------------------------------------------------------- #
 # 6. BOOLEAN/LOGICAL PARAMETER TESTING
 # ----------------------------------------------------------- #
 
 ## 6.1 Test boolean parameter - TRUE behavior
-test_that(
-  "smooth_community_data() behaves correctly when round_results = TRUE",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
+test_that("smooth_community_data() behaves correctly when round_results = TRUE", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
+    )
 
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        round_results = TRUE,
-        verbose = FALSE
-      )
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      round_results = TRUE,
+      silent = TRUE
+    )
 
-    expect_true(
-      all(
-        result$community == round(
+  expect_true(
+    all(
+      result$community ==
+        round(
           result$community
         )
-      )
     )
-  }
-)
+  )
+})
 
 ## 6.2 Test boolean parameter - FALSE behavior -----
-test_that(
-  "smooth_community_data() behaves correctly when round_results = FALSE",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
+test_that("smooth_community_data() behaves correctly when round_results = FALSE", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
+    )
 
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        round_results = FALSE,
-        verbose = FALSE
-      )
-    expect_false(
-      all(
-        result$community == round(
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      round_results = FALSE,
+      silent = TRUE
+    )
+  expect_false(
+    all(
+      result$community ==
+        round(
           result$community
         )
-      )
     )
-  }
-)
+  )
+})
 
 ## 6.3 Test verbose parameter - produces expected message -----
-test_that(
-  "smooth_community_data() produces expected message when verbose = TRUE",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_message(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = TRUE
-      ),
-      "Data will be smoothed by 'moving average'"
+test_that("smooth_community_data() produces expected message when verbose = TRUE", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_message(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      verbose = TRUE
+    ),
+    "Data will be smoothed by 'moving average'"
+  )
+})
 
 ## 6.4 Test verbose parameter - silent when FALSE -----
-test_that(
-  "smooth_community_data() produces no messages when verbose = FALSE",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_silent(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() produces no messages when verbose = FALSE", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_silent(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      verbose = FALSE
+    )
+  )
+})
 
 # ----------------------------------------------------------- #
 # 7. OUTPUT STRUCTURE VALIDATION ----
 # ----------------------------------------------------------- #
 
 ## 7.1 Test output type -----
-test_that(
-  "smooth_community_data() returns correct output type",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_type(
-      result,
-      "list"
+test_that("smooth_community_data() returns correct output type", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_type(
+    result,
+    "list"
+  )
+})
 
 ## 7.2 Test output class -----
-test_that(
-  "smooth_community_data() returns community component as data.frame",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_s3_class(
-      result$community,
-      "data.frame"
+test_that("smooth_community_data() returns community component as data.frame", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_s3_class(
+    result$community,
+    "data.frame"
+  )
+})
 
 ## 7.3 Test output names/structure -----
-test_that(
-  "smooth_community_data() returns correctly named output",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_named(
-      result,
-      c(
-        "community",
-        "age",
-        "age_un"
-      )
+test_that("smooth_community_data() returns correctly named output", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_named(
+    result,
+    c(
+      "community",
+      "age",
+      "age_un"
+    )
+  )
+})
 
 ## 7.4 Test output dimensions -----
-test_that(
-  "smooth_community_data() returns output with correct dimensions",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_equal(
-      nrow(
-        result$community
-      ),
-      nrow(data_source_smooth$community)
+test_that("smooth_community_data() returns output with correct dimensions", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
 
-test_that(
-  "smooth_community_data() returns output with correct column count",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_equal(
-      ncol(
-        result$community
-      ),
-      ncol(data_source_smooth$community)
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
     )
-  }
-)
+
+  expect_equal(
+    nrow(
+      result$community
+    ),
+    nrow(data_source_smooth$community)
+  )
+})
+
+test_that("smooth_community_data() returns output with correct column count", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
+    )
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_equal(
+    ncol(
+      result$community
+    ),
+    ncol(data_source_smooth$community)
+  )
+})
 
 ## 7.5 Test output component types -----
-test_that(
-  "smooth_community_data() returns age component with correct type",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_s3_class(
-      result$age,
-      "data.frame"
+test_that("smooth_community_data() returns age component with correct type", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_s3_class(
+    result$age,
+    "data.frame"
+  )
+})
 
 # ----------------------------------------------------------- #
 # 8. OUTPUT CONTENT VALIDATION -----
 # ----------------------------------------------------------- #
 
 ## 8.1 Test output values - value ranges -----
-test_that(
-  "smooth_community_data() produces non-negative values",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_true(
-      all(
-        result$community >= 0
-      )
+test_that("smooth_community_data() produces non-negative values", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_true(
+    all(
+      result$community >= 0
+    )
+  )
+})
 
 ## 8.2 Test output values - no missing values -----
-test_that(
-  "smooth_community_data() produces no missing values in result",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
+test_that("smooth_community_data() produces no missing values in result", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
+    )
 
-    result <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
+  result <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
 
-    expect_true(
-      all(
-        !is.na(
-          result$community
-        )
+  expect_true(
+    all(
+      !is.na(
+        result$community
       )
     )
-  }
-)
+  )
+})
 
 ## 8.3 Test output consistency - reproducible results -----
-test_that(
-  "smooth_community_data() produces consistent results across calls",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    result1 <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    result2 <-
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_true(
-      identical(
-        result1,
-        result2
-      )
+test_that("smooth_community_data() produces consistent results across calls", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
+
+  result1 <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
     )
-  }
-)
+
+  result2 <-
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_true(
+    identical(
+      result1,
+      result2
+    )
+  )
+})
 
 # ----------------------------------------------------------- #
 # 9. AGE UNCERTAINTY INTEGRATION -----
 # ----------------------------------------------------------- #
 
 ## 9.1 Test with age uncertainty preservation -----
-test_that(
-  "smooth_community_data() preserves age uncertainty structure",
-  {
-    extracted_data <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]],
-        age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
-      )
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = extracted_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    # Verify age uncertainty is preserved
-    expect_false(
-      is.null(
-        result$age_un
-      )
+test_that("smooth_community_data() preserves age uncertainty structure", {
+  extracted_data <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]],
+      age_uncertainty = RRatepol::example_data$age_uncertainty[[1]]
     )
-  }
-)
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = extracted_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  # Verify age uncertainty is preserved
+  expect_false(
+    is.null(
+      result$age_un
+    )
+  )
+})
 # ----------------------------------------------------------- #
 # 10. MOVING AVERAGE METHOD TESTS -----
 # ----------------------------------------------------------- #
 
 ## 10.1 Test m.avg method basic functionality -----
-test_that(
-  "smooth_community_data() works with m.avg method",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with m.avg method", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+  )
+})
 
 ## 10.2 Test m.avg parameter bounds - even smooth_n_points -----
-test_that(
-  "smooth_community_data() throws error if smooth_n_points is even for m.avg",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 4,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be odd"
+test_that("smooth_community_data() throws error if smooth_n_points is even for m.avg", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 4,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be odd"
+  )
+})
 
 ## 10.3 Test m.avg parameter bounds - at boundaries (valid) -----
-test_that(
-  "smooth_community_data() accepts smooth_n_points = 1 for m.avg",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 1,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() accepts smooth_n_points = 1 for m.avg", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 1,
+      silent = TRUE
+    )
+  )
+})
 
 ## 10.4 Test m.avg with uniform data -----
-test_that(
-  "smooth_community_data() produces identical values for uniform data with m.avg",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    # Create uniform data
-    uniform_data <-
-      data_source_smooth
-    uniform_data$community[, 1] <-
-      10
-
-    result <-
-      smooth_community_data(
-        data_source_smooth = uniform_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
-
-    expect_true(
-      all(
-        result$community[, 1] == 10
-      )
+test_that("smooth_community_data() produces identical values for uniform data with m.avg", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  # Create uniform data
+  uniform_data <-
+    data_source_smooth
+  uniform_data$community[, 1] <-
+    10
+
+  result <-
+    smooth_community_data(
+      data_source_smooth = uniform_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+
+  expect_true(
+    all(
+      result$community[, 1] == 10
+    )
+  )
+})
 
 ## 10.5 Test m.avg ignores optional parameters -----
-test_that(
-  "smooth_community_data() works with m.avg ignoring optional parameters",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 5,
-        smooth_n_max = 9,
-        smooth_age_range = 500,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with m.avg ignoring optional parameters", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 5,
+      smooth_n_max = 9,
+      smooth_age_range = 500,
+      silent = TRUE
+    )
+  )
+})
 
 ## 10.6 Test warning when smooth_n_points exceeds available data -----
-test_that(
-  "smooth_community_data() throws error if smooth_n_points larger than available samples",
-  {
-    # Create minimal dataset with only 3 samples
-    minimal_data <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]][1:3, ],
-        RRatepol::example_data$sample_age[[1]][1:3, ]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = minimal_data,
-        smooth_method = "m.avg",
-        smooth_n_points = 7, # More than available samples
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be <= number of samples in 'community'"
+test_that("smooth_community_data() throws error if smooth_n_points larger than available samples", {
+  # Create minimal dataset with only 3 samples
+  minimal_data <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]][1:3, ],
+      RRatepol::example_data$sample_age[[1]][1:3, ]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = minimal_data,
+      smooth_method = "m.avg",
+      smooth_n_points = 7, # More than available samples
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be <= number of samples in 'community'"
+  )
+})
 
 # ----------------------------------------------------------- #
 # 11. GRIM METHOD TESTS -----
 # ----------------------------------------------------------- #
 
 ## 11.1 Test grim method basic functionality -----
-test_that(
-  "smooth_community_data() works with grim method (no error)",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_n_max = 9,
-        smooth_age_range = 500,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with grim method (no error)", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_n_max = 9,
+      smooth_age_range = 500,
+      silent = TRUE
+    )
+  )
+})
 
 ## 11.2 Test grim parameter bounds - even smooth_n_points -----
-test_that(
-  "smooth_community_data() throws error if smooth_n_points is even for grim",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 4,
-        smooth_n_max = 8,
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be odd"
+test_that("smooth_community_data() throws error if smooth_n_points is even for grim", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 4,
+      smooth_n_max = 8,
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be odd"
+  )
+})
 
 ## 11.4 Test grim smooth_n_max must be bigger than smooth_n_points -----
-test_that(
-  "smooth_community_data() throws error if grim smooth_n_max <= smooth_n_points",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_n_max = 5,
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
+test_that("smooth_community_data() throws error if grim smooth_n_max <= smooth_n_points", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_n_max = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
+  )
+})
 
 ## 11.5 Test grim with very small age range -----
-test_that(
-  "smooth_community_data() handles very small smooth_age_range for grim",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 3,
-        smooth_n_max = 5,
-        smooth_age_range = 1, # Very small range
-        verbose = FALSE
-      )
+test_that("smooth_community_data() handles very small smooth_age_range for grim", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 3,
+      smooth_n_max = 5,
+      smooth_age_range = 1, # Very small range
+      silent = TRUE
+    )
+  )
+})
 
 ## 11.6 Test with very large smooth_n_max -----
-test_that(
-  "smooth_community_data() throws error with large smooth_n_max values",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_n_max = 65, # Large value
-        smooth_age_range = 5000,
-        verbose = FALSE
-      ),
-      "'smooth_n_max' must be <= number of samples in 'community'"
+test_that("smooth_community_data() throws error with large smooth_n_max values", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_n_max = 65, # Large value
+      smooth_age_range = 5000,
+      silent = TRUE
+    ),
+    "'smooth_n_max' must be <= number of samples in 'community'"
+  )
+})
 
 ## 11.7 Test grim minimum data requirements -----
-test_that(
-  "smooth_community_data() works with grim minimum data requirements",
-  {
-    minimal_5 <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]][1:5, ],
-        RRatepol::example_data$sample_age[[1]][1:5, ]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = minimal_5,
-        smooth_method = "grim",
-        smooth_n_points = 3,
-        smooth_n_max = 5,
-        smooth_age_range = 100,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with grim minimum data requirements", {
+  minimal_5 <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]][1:5, ],
+      RRatepol::example_data$sample_age[[1]][1:5, ]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = minimal_5,
+      smooth_method = "grim",
+      smooth_n_points = 3,
+      smooth_n_max = 5,
+      smooth_age_range = 100,
+      silent = TRUE
+    )
+  )
+})
 
 ## 11.8 Test exact error messages - grim specific validation -----
-test_that(
-  "smooth_community_data() produces exact expected error message for grim smooth_n_max",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 5,
-        smooth_n_max = 5,
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
+test_that("smooth_community_data() produces exact expected error message for grim smooth_n_max", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 5,
+      smooth_n_max = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be < 'smooth_n_max' for 'grim' smoothing"
+  )
+})
 
 # ----------------------------------------------------------- #
 # 12. AGE WEIGHTED METHOD TESTS -----
 # ----------------------------------------------------------- #
 
 ## 12.1 Test age.w method basic functionality -----
-test_that(
-  "smooth_community_data() works with age.w method (no error)",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with age.w method (no error)", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    )
+  )
+})
 
 ## 12.2 Test age.w parameter bounds - even smooth_n_points -----
-test_that(
-  "smooth_community_data() throws error if smooth_n_points is even for age.w",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "age.w",
-        smooth_n_points = 4,
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be odd"
+test_that("smooth_community_data() throws error if smooth_n_points is even for age.w", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "age.w",
+      smooth_n_points = 4,
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be odd"
+  )
+})
 
 ## 12.3 Test age.w with non-sequential age data -----
-test_that(
-  "smooth_community_data() handles non-sequential age data for age.w method",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]][1:10, ],
-        RRatepol::example_data$sample_age[[1]][1:10, ]
-      )
-
-    # Scramble age order
-    scrambled_data <-
-      data_source_smooth
-    scrambled_data$age$age <-
-      sample(
-        scrambled_data$age$age
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = scrambled_data,
-        smooth_method = "age.w",
-        smooth_n_points = 5,
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'age' must be sorted in increasing order"
+test_that("smooth_community_data() handles non-sequential age data for age.w method", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]][1:10, ],
+      RRatepol::example_data$sample_age[[1]][1:10, ]
     )
-  }
-)
 
+  # Scramble age order
+  scrambled_data <-
+    data_source_smooth
+  scrambled_data$age$age <-
+    sample(
+      scrambled_data$age$age
+    )
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = scrambled_data,
+      smooth_method = "age.w",
+      smooth_n_points = 5,
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'age' must be sorted in increasing order"
+  )
+})
 
 
 # ----------------------------------------------------------- #
@@ -1213,190 +1072,166 @@ test_that(
 # ----------------------------------------------------------- #
 
 ## 13.1 Test shep method basic functionality -----
-test_that(
-  "smooth_community_data() works with shep method (no error)",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "shep",
-        smooth_n_points = 5,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with shep method (no error)", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "shep",
+      smooth_n_points = 5,
+      silent = TRUE
+    )
+  )
+})
 
 ## 13.2 Test shep with even numbers -----
-test_that(
-  "smooth_community_data() accepts even smooth_n_points for shep",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "shep",
-        smooth_n_points = 4,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() accepts even smooth_n_points for shep", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "shep",
+      smooth_n_points = 4,
+      silent = TRUE
+    )
+  )
+})
 
 ## 13.3 Test shep minimum valid smooth_n_points -----
-test_that(
-  "smooth_community_data() handles shep method with minimum smooth_n_points requirements",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    # Test that shep fails appropriately with smooth_n_points = 2
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "shep",
-        smooth_n_points = 2,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be > 2 for 'shep' smoothing"
+test_that("smooth_community_data() handles shep method with minimum smooth_n_points requirements", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
 
-    # Test that shep works with smooth_n_points >= 3
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "shep",
-        smooth_n_points = 3,
-        verbose = FALSE
-      )
+  # Test that shep fails appropriately with smooth_n_points = 2
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "shep",
+      smooth_n_points = 2,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be > 2 for 'shep' smoothing"
+  )
+
+  # Test that shep works with smooth_n_points >= 3
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "shep",
+      smooth_n_points = 3,
+      silent = TRUE
     )
-  }
-)
+  )
+})
 
 ## 13.4 Test shep works without optional parameters -----
-test_that(
-  "smooth_community_data() works with shep without additional parameters",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "shep",
-        smooth_n_points = 5
-      )
+test_that("smooth_community_data() works with shep without additional parameters", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "shep",
+      smooth_n_points = 5
+    )
+  )
+})
 
 
 ## 13.6 Test shep minimum data requirements
-test_that(
-  "smooth_community_data() works with shep minimum data requirements",
-  {
-    minimal_3 <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]][1:3, ],
-        RRatepol::example_data$sample_age[[1]][1:3, ]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = minimal_3,
-        smooth_method = "shep",
-        smooth_n_points = 3,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() works with shep minimum data requirements", {
+  minimal_3 <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]][1:3, ],
+      RRatepol::example_data$sample_age[[1]][1:3, ]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = minimal_3,
+      smooth_method = "shep",
+      smooth_n_points = 3,
+      silent = TRUE
+    )
+  )
+})
 
 # ----------------------------------------------------------- #
 # 14. EDGE CASES AND BOUNDARY CONDITIONS -----
 # ----------------------------------------------------------- #
 
 ## 14.1 Test minimum valid input -----
-test_that(
-  "smooth_community_data() handles minimum valid input",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]][1:3, ],
-        RRatepol::example_data$sample_age[[1]][1:3, ]
-      )
-
-    expect_no_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "m.avg",
-        smooth_n_points = 1,
-        verbose = FALSE
-      )
+test_that("smooth_community_data() handles minimum valid input", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]][1:3, ],
+      RRatepol::example_data$sample_age[[1]][1:3, ]
     )
-  }
-)
+
+  expect_no_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "m.avg",
+      smooth_n_points = 1,
+      silent = TRUE
+    )
+  )
+})
 
 ## 14.2 Test exact error messages - parameter validation -----
-test_that(
-  "smooth_community_data() produces exact expected error message for even smooth_n_points",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = "grim",
-        smooth_n_points = 4,
-        smooth_n_max = 8,
-        smooth_age_range = 500,
-        verbose = FALSE
-      ),
-      "'smooth_n_points' must be odd",
-      fixed = TRUE
+test_that("smooth_community_data() produces exact expected error message for even smooth_n_points", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = "grim",
+      smooth_n_points = 4,
+      smooth_n_max = 8,
+      smooth_age_range = 500,
+      silent = TRUE
+    ),
+    "'smooth_n_points' must be odd",
+    fixed = TRUE
+  )
+})
 
 # multiple smooth_methods
-test_that(
-  "smooth_community_data fails if more than one smooth_method is supplied",
-  {
-    data_source_smooth <-
-      extract_data(
-        RRatepol::example_data$pollen_data[[1]],
-        RRatepol::example_data$sample_age[[1]],
-        RRatepol::example_data$age_uncertainty[[1]]
-      )
-
-    expect_error(
-      smooth_community_data(
-        data_source_smooth = data_source_smooth,
-        smooth_method = c("shep", "m.avg"),
-        smooth_n_points = 5
-      ),
-      "'arg' must be of length 1"
+test_that("smooth_community_data fails if more than one smooth_method is supplied", {
+  data_source_smooth <-
+    extract_data(
+      RRatepol::example_data$pollen_data[[1]],
+      RRatepol::example_data$sample_age[[1]],
+      RRatepol::example_data$age_uncertainty[[1]]
     )
-  }
-)
+
+  expect_error(
+    smooth_community_data(
+      data_source_smooth = data_source_smooth,
+      smooth_method = c("shep", "m.avg"),
+      smooth_n_points = 5
+    ),
+    "'arg' must be of length 1"
+  )
+})

--- a/tests/testthat/test-transform_into_proportions.R
+++ b/tests/testthat/test-transform_into_proportions.R
@@ -684,7 +684,7 @@ test_that(
         transform_into_proportions(
           data_source_trans = data_sd,
           sel_method = NULL,
-          verbose = FALSE
+          silent = TRUE
         ),
       "'sel_method' must be one of the following: 'character'"
     )
@@ -868,7 +868,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "proportions", # or "percentages"
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_true(
@@ -963,7 +963,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_true(
@@ -1061,7 +1061,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
 
     # Control
@@ -1170,7 +1170,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     # Control
     data_com_control <-
@@ -1279,7 +1279,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_true(
       all(
@@ -1372,7 +1372,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_true(
       all(
@@ -1466,7 +1466,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_s3_class(
       data_sd_prop,
@@ -1558,7 +1558,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
     expect_s3_class(
       data_sd_prop,
@@ -1651,7 +1651,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "proportions",
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_true(
@@ -1748,7 +1748,7 @@ test_that(
       transform_into_proportions(
         data_source_trans = data_sd,
         sel_method = "percentages",
-        verbose = FALSE
+        silent = TRUE
       )
 
     expect_true(


### PR DESCRIPTION
Introduce a 'silent' parameter to several functions to control output messages, 

Update tests to reflect this change and suppress progress bar messages where applicable.

- fix #109