### PR TITLE
Remove RUtilpol: Refactor utility checks and enhance console output control

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,11 +26,9 @@ Imports:
     pbapply,
     purrr,
     rlang,
-    RUtilpol,
     stats,
     tibble,
     tidyr,
-    usethis,
     utils,
     vegan
 Suggests: 
@@ -46,8 +44,6 @@ Suggests:
     tidyverse
 VignetteBuilder: 
     knitr
-Remotes: 
-    github::HOPE-UIB-BIO/R-Utilpol-package
 Config/testthat/edition: 3
 Config/testthat/start-first: check_data, 
     make_bins, 
@@ -71,4 +67,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -7,7 +7,7 @@
 #' @description Output summary information about the data
 #' @keywords internal
 check_data <- function(data_source_check, silent = FALSE) {
-  RUtilpol::check_class("data_source_check", "list")
+  util_check_class(data_source_check, "list")
 
   assertthat::assert_that(
     nrow(data_source_check$community) > 0,
@@ -22,7 +22,7 @@ check_data <- function(data_source_check, silent = FALSE) {
 
   if (isFALSE(silent)) {
     if (length(dims) == 3) {
-      RUtilpol::output_comment(
+      util_output_comment(
         paste(
           "Community data have",
           dims$community[2],
@@ -38,7 +38,7 @@ check_data <- function(data_source_check, silent = FALSE) {
         )
       )
     } else if (length(dims) == 2) {
-      RUtilpol::output_comment(
+      util_output_comment(
         paste(
           "Community data have",
           dims$community[2],
@@ -62,7 +62,7 @@ check_data <- function(data_source_check, silent = FALSE) {
 
   if (isFALSE(silent)) {
     if (length(nas) == 3) {
-      RUtilpol::output_comment(
+      util_output_comment(
         paste(
           "Community data has",
           nas$community,
@@ -76,7 +76,7 @@ check_data <- function(data_source_check, silent = FALSE) {
         )
       )
     } else if (length(nas) == 2) {
-      RUtilpol::output_comment(
+      util_output_comment(
         paste(
           "Community data has",
           nas$community,
@@ -90,7 +90,7 @@ check_data <- function(data_source_check, silent = FALSE) {
     }
 
     # 3. Summary of data
-    RUtilpol::output_comment(
+    util_output_comment(
       paste0(
         "Community data has a value of min ",
         round(min(rowSums(data_source_check$community, na.rm = TRUE))),
@@ -107,7 +107,7 @@ check_data <- function(data_source_check, silent = FALSE) {
       )
     )
 
-    RUtilpol::output_comment(
+    util_output_comment(
       paste0(
         "Age data has values of min ",
         round(min(data_source_check$age$age, na.rm = TRUE)),

--- a/R/detect_peak_points.R
+++ b/R/detect_peak_points.R
@@ -113,14 +113,14 @@ detect_peak_points <-
              "threshold", "GAM_deriv", "SNI"
            ),
            sd_threshold = 2) {
-    RUtilpol::check_class("data_source", "data.frame")
+    util_check_class(data_source, "data.frame")
 
-    RUtilpol::check_col_names("data_source", "ROC")
+    util_check_col_names(data_source, "ROC")
 
-    RUtilpol::check_class("sel_method", "character")
+    util_check_class(sel_method, "character")
 
-    RUtilpol::check_vector_values(
-      "sel_method",
+    util_check_vector_values(
+      sel_method,
       c(
         "trend_linear", "trend_non_linear",
         "threshold", "GAM_deriv", "SNI"
@@ -129,7 +129,7 @@ detect_peak_points <-
 
     sel_method <- match.arg(sel_method)
 
-    RUtilpol::check_class("sd_threshold", "numeric")
+    util_check_class(sd_threshold, "numeric")
 
     assertthat::assert_that(
       sd_threshold > 0,
@@ -142,7 +142,7 @@ detect_peak_points <-
     if (
       sel_method == "threshold"
     ) {
-      RUtilpol::check_col_names("data_source", "ROC_dw")
+      util_check_col_names(data_source, "ROC_dw")
 
       # threshold for RoC peaks is set as median of all RoC in dataset
       r_threshold <-
@@ -159,7 +159,7 @@ detect_peak_points <-
     if (
       sel_method == "trend_linear"
     ) {
-      RUtilpol::check_col_names("data_source", "Age")
+      util_check_col_names(data_source, "Age")
 
       # mark points that are abowe the linear model
       #   (exactly sd_threshold SD higher than prediction)
@@ -183,7 +183,7 @@ detect_peak_points <-
     if (
       sel_method == "trend_non_linear"
     ) {
-      RUtilpol::check_col_names("data_source", "Age")
+      util_check_col_names(data_source, "Age")
       # mark points that are abowe the GAM model
       #   (exactly sd_threshold SD higher than GAM prediction)
       data_source$pred_gam <-
@@ -206,7 +206,7 @@ detect_peak_points <-
     if (
       sel_method == "GAM_deriv"
     ) {
-      RUtilpol::check_col_names("data_source", "Age")
+      util_check_col_names(data_source, "Age")
       # fit gam well smother gam model and use first derivative of the function
       #   to detect signifiant increases in the function
       gam_model <-
@@ -236,7 +236,7 @@ detect_peak_points <-
     if (
       sel_method == "SNI"
     ) {
-      RUtilpol::check_col_names("data_source", "Age")
+      util_check_col_names(data_source, "Age")
       # set moving window of 5 times higher than average distance between samples
       mean_age_window <- 5 * mean(diff(data_source$Age))
 

--- a/R/estimate_dissimilarity_coefficient.R
+++ b/R/estimate_dissimilarity_coefficient.R
@@ -48,7 +48,7 @@ estimate_dissimilarity_coefficient <- function(
 
   if (dissimilarity_coefficient == "euc.sd") {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "Standardised Euclidan distance will be used as dissimilarity_coefficient"
       )
     }
@@ -110,7 +110,7 @@ estimate_dissimilarity_coefficient <- function(
 
   if (dissimilarity_coefficient == "euc") {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "Euclidan distance will be used as dissimilarity_coefficient"
       )
     }
@@ -129,7 +129,7 @@ estimate_dissimilarity_coefficient <- function(
 
   if (dissimilarity_coefficient == "chord") {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "Chord distance will be used as dissimilarity_coefficient"
       )
     }
@@ -151,7 +151,7 @@ estimate_dissimilarity_coefficient <- function(
 
   if (dissimilarity_coefficient == "chisq") {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "Chi-squared coeficient will be used as dissimilarity_coefficient"
       )
     }
@@ -173,7 +173,7 @@ estimate_dissimilarity_coefficient <- function(
 
   if (dissimilarity_coefficient == "gower") {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "Gower's distance will be used as dissimilarity_coefficient"
       )
     }
@@ -194,7 +194,7 @@ estimate_dissimilarity_coefficient <- function(
 
   if (dissimilarity_coefficient == "bray") {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "Bray-Curtis distance will be used as dissimilarity_coefficient"
       )
     }

--- a/R/estimate_roc.R
+++ b/R/estimate_roc.R
@@ -283,44 +283,44 @@ estimate_roc <- function(
     msg = "Object 'data_source_age' must be included as a 'data.frame'"
   )
 
-  RUtilpol::check_class("data_source_community", "data.frame")
+  util_check_class(data_source_community, "data.frame")
 
-  RUtilpol::check_class("data_source_age", "data.frame")
+  util_check_class(data_source_age, "data.frame")
 
-  RUtilpol::check_class("age_uncertainty", c("NULL", "matrix"))
+  util_check_class(age_uncertainty, c("NULL", "matrix"))
 
-  RUtilpol::check_class("working_units", "character")
+  util_check_class(working_units, "character")
 
-  RUtilpol::check_vector_values("working_units", c("levels", "bins", "MW"))
+  util_check_vector_values(working_units, c("levels", "bins", "MW"))
 
   working_units <- match.arg(working_units)
 
   if (is.null(time_standardisation)) {
     time_standardisation <- bin_size
   }
-  RUtilpol::check_class("time_standardisation", "numeric")
+  util_check_class(time_standardisation, "numeric")
 
-  RUtilpol::check_if_integer("time_standardisation")
+  util_check_if_integer(time_standardisation)
 
   if (working_units != "levels") {
-    RUtilpol::check_class("bin_size", "numeric")
+    util_check_class(bin_size, "numeric")
 
-    RUtilpol::check_if_integer("bin_size")
+    util_check_if_integer(bin_size)
 
-    RUtilpol::check_class("bin_selection", "character")
+    util_check_class(bin_selection, "character")
 
-    RUtilpol::check_vector_values("bin_selection", c("first", "random"))
+    util_check_vector_values(bin_selection, c("first", "random"))
 
     bin_selection <- match.arg(bin_selection)
 
     if (working_units == "MW") {
-      RUtilpol::check_class("number_of_shifts", "numeric")
+      util_check_class(number_of_shifts, "numeric")
 
-      RUtilpol::check_if_integer("number_of_shifts")
+      util_check_if_integer(number_of_shifts)
     }
   }
 
-  RUtilpol::check_class("standardise", "logical")
+  util_check_class(standardise, "logical")
 
   assertthat::assert_that(
     base::length(standardise) == 1,
@@ -328,19 +328,19 @@ estimate_roc <- function(
   )
 
   if (isTRUE(standardise)) {
-    RUtilpol::check_class("n_individuals", "numeric")
+    util_check_class(n_individuals, "numeric")
 
-    RUtilpol::check_if_integer("n_individuals")
+    util_check_if_integer(n_individuals)
   }
 
-  RUtilpol::check_class("tranform_to_proportions", "logical")
+  util_check_class(tranform_to_proportions, "logical")
 
   assertthat::assert_that(
     base::length(tranform_to_proportions) == 1,
     msg = "'tranform_to_proportions' must be a single TRUE or FALSE"
   )
 
-  RUtilpol::check_class("interest_threshold", c("NULL", "numeric"))
+  util_check_class(interest_threshold, c("NULL", "numeric"))
 
   if (!base::is.null(interest_threshold)) {
     assertthat::assert_that(
@@ -349,10 +349,10 @@ estimate_roc <- function(
     )
   }
 
-  RUtilpol::check_class("smooth_method", "character")
+  util_check_class(smooth_method, "character")
 
-  RUtilpol::check_vector_values(
-    "smooth_method",
+  util_check_vector_values(
+    smooth_method,
     c("none", "m.avg", "grim", "age.w", "shep")
   )
 
@@ -365,7 +365,7 @@ estimate_roc <- function(
     )
 
     if (smooth_method != "m.avg") {
-      RUtilpol::check_class("smooth_age_range", "numeric")
+      util_check_class(smooth_age_range, "numeric")
 
       if (smooth_method == "grim") {
         assertthat::assert_that(
@@ -381,25 +381,25 @@ estimate_roc <- function(
     }
   }
 
-  RUtilpol::check_class("dissimilarity_coefficient", "character")
+  util_check_class(dissimilarity_coefficient, "character")
 
-  RUtilpol::check_vector_values(
-    "dissimilarity_coefficient",
+  util_check_vector_values(
+    dissimilarity_coefficient,
     c("euc", "euc.sd", "chord", "chisq", "gower", "bray")
   )
 
   dissimilarity_coefficient <- match.arg(dissimilarity_coefficient)
 
-  RUtilpol::check_class("rand", c("NULL", "numeric"))
+  util_check_class(rand, c("NULL", "numeric"))
 
   if (isFALSE(is.null(rand))) {
-    RUtilpol::check_if_integer("rand")
+    util_check_if_integer(rand)
   }
 
-  RUtilpol::check_class("use_parallel", c("logical", "numeric"))
+  util_check_class(use_parallel, c("logical", "numeric"))
 
   if (is.numeric(use_parallel)) {
-    RUtilpol::check_if_integer("use_parallel")
+    util_check_if_integer(use_parallel)
 
     assertthat::assert_that(
       !base::is.na(use_parallel) && use_parallel != 0,
@@ -407,14 +407,14 @@ estimate_roc <- function(
     )
   }
 
-  RUtilpol::check_class("verbose", "logical")
+  util_check_class(verbose, "logical")
 
   assertthat::assert_that(
     base::length(verbose) == 1,
     msg = "'verbose' must be a single TRUE or FALSE"
   )
 
-  RUtilpol::check_class("silent", "logical")
+  util_check_class(silent, "logical")
 
   #--------------------------------------------------#
   # 0.1. Report to user -----
@@ -423,7 +423,7 @@ estimate_roc <- function(
   start_time <- Sys.time()
 
   if (isFALSE(silent)) {
-    RUtilpol::output_heading(
+    util_output_heading(
       paste("RRatepol started", start_time),
       size = "h1"
     )
@@ -431,14 +431,14 @@ estimate_roc <- function(
 
   if (isFALSE(is.null(age_uncertainty))) {
     if (isFALSE(silent)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         "'age_uncertainty' will be used for in the RoC estimation"
       )
     }
 
     if (rand < 100) {
       if (isFALSE(silent)) {
-        RUtilpol::output_warning(
+        util_output_warning(
           paste(
             "'age_uncertainty' was selected to be used with low number",
             "of replication. Recommend to increase 'rand'"
@@ -452,12 +452,12 @@ estimate_roc <- function(
     switch(
       working_units,
       "levels" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           "RoC will be estimated between individual subsequent levels"
         )
       },
       "bins" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           paste(
             "RoC will be estimated using selective binning with",
             bin_size,
@@ -466,7 +466,7 @@ estimate_roc <- function(
         )
       },
       "MW" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           paste(
             "RoC will be estimated using 'binning with the mowing window' of",
             bin_size,
@@ -482,14 +482,14 @@ estimate_roc <- function(
   if (working_units != "levels") {
     if (bin_selection == "random") {
       if (isFALSE(silent)) {
-        RUtilpol::output_comment(
+        util_output_comment(
           "Sample will randomly selected for each bin"
         )
       }
 
       if (rand < 100) {
         if (isFALSE(silent)) {
-          RUtilpol::output_warning(
+          util_output_warning(
             paste(
               "'bin_selection' was selected as 'random' with low number",
               "of replication. Recommend to increase 'rand'"
@@ -499,7 +499,7 @@ estimate_roc <- function(
       }
     } else {
       if (isFALSE(silent)) {
-        RUtilpol::output_comment(
+        util_output_comment(
           "First sample of each time bin will selected"
         )
       }
@@ -507,7 +507,7 @@ estimate_roc <- function(
   }
 
   if (isFALSE(silent)) {
-    RUtilpol::output_comment(
+    util_output_comment(
       paste(
         "'time_standardisation' =",
         time_standardisation,
@@ -521,7 +521,7 @@ estimate_roc <- function(
 
   if (working_units != "levels" && time_standardisation != bin_size) {
     if (isFALSE(silent)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         paste(
           "RoC values will be reported in different units than size of bin.",
           "Recommend to keep 'time_standardisation'",
@@ -533,7 +533,7 @@ estimate_roc <- function(
 
   if (isTRUE(standardise)) {
     if (isFALSE(silent)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         paste(
           "Data will be standardise in each Working unit to",
           n_individuals,
@@ -544,7 +544,7 @@ estimate_roc <- function(
 
     if (rand < 100) {
       if (isFALSE(silent)) {
-        RUtilpol::output_warning(
+        util_output_warning(
           paste(
             "'standardise' was selected as 'TRUE' with low number of replication.",
             "Recommend to increase 'rand'"
@@ -571,7 +571,7 @@ estimate_roc <- function(
 
   if (ncol(data_extract$community) == 1 && isTRUE(tranform_to_proportions)) {
     if (isFALSE(silent)) {
-      RUtilpol::output_warning(
+      util_output_warning(
         msg = paste(
           "Community data has only 1 variable and `tranform_to_proportions`",
           "is set to `TRUE`.",
@@ -626,7 +626,7 @@ estimate_roc <- function(
       (working_units == "levels" || bin_selection == "first")
   ) {
     if (isFALSE(silent) && isTRUE(verbose)) {
-      RUtilpol::output_comment(
+      util_output_comment(
         msg = paste(
           "There is no need for randomisation.",
           "Changing `rand` to NULL"
@@ -647,19 +647,19 @@ estimate_roc <- function(
     )
 
   data_to_run <-
-    RUtilpol::flatten_list_by_one(data_prepared)
+    util_flatten_list_by_one(data_prepared)
 
   #----------------------------------------------------------#
   # 4. Estimation -----
   #----------------------------------------------------------#
 
   if (isFALSE(silent) && isTRUE(verbose)) {
-    RUtilpol::output_heading(
+    util_output_heading(
       msg = "Start of estimation",
       size = "h2"
     )
 
-    RUtilpol::output_comment(
+    util_output_comment(
       msg = paste(
         "Number of estimation set to",
         length(data_to_run)
@@ -770,7 +770,7 @@ estimate_roc <- function(
   time_duration <- end_time - start_time
 
   if (isFALSE(silent)) {
-    RUtilpol::output_heading(
+    util_output_heading(
       paste(
         "RRatepol finished",
         end_time,

--- a/R/extract_data.R
+++ b/R/extract_data.R
@@ -34,12 +34,12 @@ extract_data <- function(
 
   # 1.1 Data types -----
 
-  RUtilpol::check_class("verbose", "logical")
+  util_check_class(verbose, "logical")
 
-  RUtilpol::check_class("silent", "logical")
+  util_check_class(silent, "logical")
 
   if (isFALSE(silent) && isTRUE(verbose)) {
-    RUtilpol::output_heading(
+    util_output_heading(
       paste(
         "Data extraction started",
         Sys.time()
@@ -48,18 +48,18 @@ extract_data <- function(
     )
   }
 
-  RUtilpol::check_class("data_community_extract", "data.frame")
+  util_check_class(data_community_extract, "data.frame")
 
-  RUtilpol::check_class("data_age_extract", "data.frame")
+  util_check_class(data_age_extract, "data.frame")
 
-  RUtilpol::check_class("age_uncertainty", c("NULL", "matrix"))
+  util_check_class(age_uncertainty, c("NULL", "matrix"))
 
   # 1.2. Sample id -----
   # community
 
   if ("sample.id" %in% names(data_community_extract)) {
     if (isFALSE(silent)) {
-      usethis::ui_oops(
+      util_output_warning(
         paste(
           "'sample.id' was detected in 'data_community'",
           "but 'sample_id' is prefered.",
@@ -73,7 +73,7 @@ extract_data <- function(
       dplyr::rename(sample_id = .data$sample.id)
   }
 
-  RUtilpol::check_col_names("data_community_extract", "sample_id")
+  util_check_col_names(data_community_extract, "sample_id")
 
   assertthat::assert_that(
     "character" %in% class(data_community_extract$sample_id),
@@ -84,7 +84,7 @@ extract_data <- function(
   # age
   if ("sample.id" %in% names(data_age_extract)) {
     if (isFALSE(silent)) {
-      usethis::ui_oops(
+      util_output_warning(
         paste(
           "'sample.id' was detected in 'data_age' but 'sample_id' is prefered.",
           "Recomend renaming your data"
@@ -97,7 +97,7 @@ extract_data <- function(
       dplyr::rename(sample_id = .data$sample.id)
   }
 
-  RUtilpol::check_col_names("data_age_extract", "sample_id")
+  util_check_col_names(data_age_extract, "sample_id")
 
   assertthat::assert_that(
     all(data_community_extract$sample_id %in% data_age_extract$sample_id) &&
@@ -108,7 +108,7 @@ extract_data <- function(
 
   # 1.3. Age test -----
 
-  RUtilpol::check_col_names("data_age_extract", "sample_id")
+  util_check_col_names(data_age_extract, "sample_id")
 
   assertthat::assert_that(
     "numeric" %in% class(data_age_extract$age),
@@ -169,7 +169,7 @@ extract_data <- function(
 
   # if age_uncertainty is used
   if (isFALSE(is.null(age_uncertainty))) {
-    RUtilpol::check_class("age_uncertainty", "matrix")
+    util_check_class(age_uncertainty, "matrix")
 
     n_samples_un <- ncol(age_uncertainty)
 
@@ -203,7 +203,7 @@ extract_data <- function(
   # 2.4 Missing values ---
   if (any(is.na(dat_community))) {
     if (isFALSE(silent)) {
-      RUtilpol::output_warning(
+      util_output_warning(
         paste(
           "Missing data has been detected in community data",
           "and automatically replaces with '0'"
@@ -223,7 +223,7 @@ extract_data <- function(
 
   if (any(is.na(dat_age$age))) {
     if (isFALSE(silent)) {
-      RUtilpol::output_warning(
+      util_output_warning(
         paste(
           "Missing 'age' values has detected in age data",
           "Such levels has been filtered out"
@@ -260,7 +260,7 @@ extract_data <- function(
       silent = silent
     )
 
-    RUtilpol::output_heading(
+    util_output_heading(
       paste(
         "Data extraction completed",
         Sys.time()

--- a/R/make_bins.R
+++ b/R/make_bins.R
@@ -10,12 +10,12 @@ make_bins <- function(
   bin_size = 500,
   number_of_shifts = 5
 ) {
-  RUtilpol::check_class("data_source_bins", "list")
+  util_check_class(data_source_bins, "list")
 
-  RUtilpol::check_class("working_units", "character")
+  util_check_class(working_units, "character")
 
-  RUtilpol::check_vector_values(
-    "working_units",
+  util_check_vector_values(
+    working_units,
     c("levels", "bins", "MW")
   )
 
@@ -66,9 +66,9 @@ make_bins <- function(
     return(res)
   }
 
-  RUtilpol::check_class("bin_size", "numeric")
+  util_check_class(bin_size, "numeric")
 
-  RUtilpol::check_if_integer("bin_size")
+  util_check_if_integer(bin_size)
 
   bin_oldest <-
     ceiling(
@@ -94,9 +94,9 @@ make_bins <- function(
         shift = 1
       )
   } else {
-    RUtilpol::check_class("number_of_shifts", "numeric")
+    util_check_class(number_of_shifts, "numeric")
 
-    RUtilpol::check_if_integer("number_of_shifts")
+    util_check_if_integer(number_of_shifts)
   }
 
   if (working_units == "MW") {

--- a/R/make_trend.R
+++ b/R/make_trend.R
@@ -16,13 +16,13 @@
 make_trend <-
     function(data_source,
              sel_method = c("linear", "non_linear")) {
-        RUtilpol::check_class("data_source", "data.frame")
+        util_check_class(data_source, "data.frame")
 
-        RUtilpol::check_col_names("data_source", c("ROC", "Age"))
+        util_check_col_names(data_source, c("ROC", "Age"))
 
-        RUtilpol::check_class("sel_method", "character")
+        util_check_class(sel_method, "character")
 
-        RUtilpol::check_vector_values("sel_method", c("linear", "non_linear"))
+        util_check_vector_values(sel_method, c("linear", "non_linear"))
 
         assertthat::assert_that(
             base::length(sel_method) == 1,

--- a/R/plot_roc.R
+++ b/R/plot_roc.R
@@ -28,6 +28,8 @@
 #'  calculated from all the residuals. A peak is considered significant if it
 #'  is 2 SD higher than the model.
 #'  }
+#' @param silent
+#' Logical. If `TRUE`, suppress all console outputs. Useful for testing.
 #' @description Plot Rate-of-Change sequence with a error estimate and trend
 #' and/or peak-points in present.
 #' @export
@@ -86,7 +88,7 @@ plot_roc <- function(
   roc_threshold = NULL,
   peaks = FALSE,
   trend = NULL,
-  silent =FALSE
+  silent = FALSE
 ) {
   # age_threshold
   util_check_class(data_source, "data.frame")
@@ -147,7 +149,7 @@ plot_roc <- function(
     ggplot2::geom_vline(
       xintercept = seq(0, age_threshold, 2e3),
       colour = "gray90",
-      size = 0.1
+      linewidth = 0.1
     ) +
     ggplot2::coord_flip(
       xlim = c(age_threshold, 0),
@@ -162,7 +164,7 @@ plot_roc <- function(
     ) +
     ggplot2::geom_line(
       alpha = 1,
-      size = 1,
+      linewidth = 1,
       color = "gray30"
     ) +
     ggplot2::geom_hline(
@@ -200,7 +202,7 @@ plot_roc <- function(
         ggplot2::geom_hline(
           yintercept = stats::median(data_source_filter$ROC),
           color = "blue",
-          size = 1
+          linewidth = 1
         )
     }
 
@@ -216,7 +218,7 @@ plot_roc <- function(
             Age = data_source$Age
           ),
           color = "blue",
-          size = 1
+          linewidth = 1
         )
     }
 
@@ -232,7 +234,7 @@ plot_roc <- function(
             Age = data_source$Age
           ),
           color = "blue",
-          size = 1
+          linewidth = 1
         )
     }
   }

--- a/R/plot_roc.R
+++ b/R/plot_roc.R
@@ -89,14 +89,14 @@ plot_roc <- function(
   silent =FALSE
 ) {
   # age_threshold
-  RUtilpol::check_class("data_source", "data.frame")
+  util_check_class(data_source, "data.frame")
 
-  RUtilpol::check_col_names(
-    "data_source",
+  util_check_col_names(
+    data_source,
     c("Age", "ROC", "ROC_up", "ROC_dw")
   )
 
-  RUtilpol::check_class("age_threshold", c("NULL", "numeric"))
+  util_check_class(age_threshold, c("NULL", "numeric"))
 
   if (isTRUE(is.null(age_threshold))) {
     age_threshold <- max(data_source$Age)
@@ -114,13 +114,13 @@ plot_roc <- function(
   }
 
   # roc_threshold
-  RUtilpol::check_class("roc_threshold", c("NULL", "numeric"))
+  util_check_class(roc_threshold, c("NULL", "numeric"))
 
   if (isTRUE(is.null(roc_threshold))) {
     roc_threshold <- max(data_source$ROC_up)
   }
 
-  RUtilpol::check_class("peaks", "logical")
+  util_check_class(peaks, "logical")
 
   assertthat::assert_that(
     base::length(peaks) == 1,
@@ -132,7 +132,7 @@ plot_roc <- function(
     msg = "'peaks' must not be NA"
   )
 
-  RUtilpol::check_class("trend", c("NULL", "character"))
+  util_check_class(trend, c("NULL", "character"))
 
   p_res <-
     ggplot2::ggplot(
@@ -176,14 +176,14 @@ plot_roc <- function(
     )
 
   if (isFALSE(is.null(trend))) {
-    RUtilpol::check_vector_values(
-      "trend",
+    util_check_vector_values(
+      trend,
       c("threshold", "trend_linear", "trend_non_linear")
     )
 
     if (isFALSE(peaks)) {
       if (isFALSE(silent)) {
-        RUtilpol::output_comment(
+        util_output_comment(
           msg = paste(
             "'trend' has been set to NOT 'NULL',",
             "'peaks' will be plotted"
@@ -238,7 +238,7 @@ plot_roc <- function(
   }
 
   if (isTRUE(peaks)) {
-    RUtilpol::check_col_names("data_source", "Peak")
+    util_check_col_names(data_source, "Peak")
 
     p_res <-
       p_res +

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -14,7 +14,7 @@ prepare_data <- function(
   number_of_shifts = 5,
   rand = NULL
 ) {
-  RUtilpol::check_class("data_source_prep", "list")
+  util_check_class(data_source_prep, "list")
 
   assertthat::assert_that(
     !base::is.null(data_source_prep$community) &&
@@ -28,19 +28,19 @@ prepare_data <- function(
     msg = "'data_source_prep$age' must not be empty"
   )
 
-  RUtilpol::check_class("working_units", "character")
+  util_check_class(working_units, "character")
 
-  RUtilpol::check_vector_values("working_units", c("levels", "bins", "MW"))
+  util_check_vector_values(working_units, c("levels", "bins", "MW"))
 
   working_units <- match.arg(working_units)
 
   if (working_units != "levels") {
-    RUtilpol::check_class("bin_size", "numeric")
+    util_check_class(bin_size, "numeric")
 
-    RUtilpol::check_if_integer("bin_size")
+    util_check_if_integer(bin_size)
   }
 
-  RUtilpol::check_class("rand", c("NULL", "numeric"))
+  util_check_class(rand, c("NULL", "numeric"))
 
   # check the condition
   is_shift_present <-
@@ -49,15 +49,15 @@ prepare_data <- function(
   if (isFALSE(is_shift_present)) {
     number_of_shifts <- 1
   } else {
-    RUtilpol::check_class("number_of_shifts", "numeric")
-    RUtilpol::check_if_integer("number_of_shifts")
+    util_check_class(number_of_shifts, "numeric")
+    util_check_if_integer(number_of_shifts)
   }
 
   is_rand_present <-
     isFALSE(is.null(rand))
 
   if (isTRUE(is_rand_present)) {
-    RUtilpol::check_if_integer("rand")
+    util_check_if_integer(rand)
   } else {
     rand <- 1
   }

--- a/R/reduce_data.R
+++ b/R/reduce_data.R
@@ -47,9 +47,14 @@ reduce_data <-
       valid_samples_community <-
         data_source_reduce$community %>%
         tibble::rownames_to_column("sample_id") %>%
-        dplyr::mutate(row_sum = rowSums(dplyr::across(-sample_id), na.rm = TRUE)) %>%
-        dplyr::filter(row_sum > 0) %>%
-        dplyr::pull(sample_id)
+        dplyr::mutate(
+          row_sum = base::rowSums(
+            dplyr::pick(-"sample_id"),
+            na.rm = TRUE
+          )
+        ) %>%
+        dplyr::filter(.data$row_sum > 0) %>%
+        dplyr::pull("sample_id")
 
       valid_levels_age_comm <-
         intersect(
@@ -59,13 +64,13 @@ reduce_data <-
       data_source_reduce$community <-
         data_source_reduce$community %>%
         tibble::rownames_to_column("sample_id") %>%
-        dplyr::filter(sample_id %in% valid_levels_age_comm) %>%
+        dplyr::filter(.data$sample_id %in% valid_levels_age_comm) %>%
         tibble::column_to_rownames("sample_id")
 
       data_source_reduce$age <-
         data_source_reduce$age %>%
         tibble::rownames_to_column("sample_id") %>%
-        dplyr::filter(sample_id %in% valid_levels_age_comm) %>%
+        dplyr::filter(.data$sample_id %in% valid_levels_age_comm) %>%
         tibble::column_to_rownames("sample_id")
 
       if (
@@ -80,13 +85,13 @@ reduce_data <-
         data_source_reduce$community <-
           data_source_reduce$community %>%
           tibble::rownames_to_column("sample_id") %>%
-          dplyr::filter(sample_id %in% valid_samples_all) %>%
+          dplyr::filter(.data$sample_id %in% valid_samples_all) %>%
           tibble::column_to_rownames("sample_id")
 
         data_source_reduce$age <-
           data_source_reduce$age %>%
           tibble::rownames_to_column("sample_id") %>%
-          dplyr::filter(sample_id %in% valid_samples_all) %>%
+          dplyr::filter(.data$sample_id %in% valid_samples_all) %>%
           tibble::column_to_rownames("sample_id")
 
         data_source_reduce$age_un <-

--- a/R/reduce_data.R
+++ b/R/reduce_data.R
@@ -10,11 +10,11 @@ reduce_data <-
   function(data_source_reduce,
            check_taxa = TRUE,
            check_levels = TRUE) {
-    RUtilpol::check_class("data_source_reduce", "list")
+    util_check_class(data_source_reduce, "list")
 
-    RUtilpol::check_class("check_taxa", "logical")
+    util_check_class(check_taxa, "logical")
 
-    RUtilpol::check_class("check_levels", "logical")
+    util_check_class(check_levels, "logical")
 
     assertthat::assert_that(
       !base::is.null(data_source_reduce$community),

--- a/R/reduce_data_simple.R
+++ b/R/reduce_data_simple.R
@@ -12,21 +12,21 @@ reduce_data_simple <-
              ommit_vars = c("label", "res_age", "age_diff"),
              check_taxa = TRUE,
              check_levels = TRUE) {
-        RUtilpol::check_class("data_source_reduce", "data.frame")
+        util_check_class(data_source_reduce, "data.frame")
 
         assertthat::assert_that(
             base::nrow(data_source_reduce) > 0,
             msg = "'data_source_reduce' must not be empty"
         )
 
-        RUtilpol::check_class("check_taxa", "logical")
+        util_check_class(check_taxa, "logical")
 
         assertthat::assert_that(
             base::length(check_taxa) == 1,
             msg = "'check_taxa' must be a single TRUE or FALSE"
         )
 
-        RUtilpol::check_class("check_levels", "logical")
+        util_check_class(check_levels, "logical")
 
         assertthat::assert_that(
             base::length(check_levels) == 1,

--- a/R/run_iteration.R
+++ b/R/run_iteration.R
@@ -25,23 +25,23 @@ run_iteration <- function(
   verbose = FALSE,
   silent = FALSE
 ) {
-  RUtilpol::check_class("data_source_run", "list")
+  util_check_class(data_source_run, "list")
 
-  RUtilpol::check_class("standardise", "logical")
+  util_check_class(standardise, "logical")
 
   assertthat::assert_that(
     base::length(standardise) == 1,
     msg = "'standardise' must be a single TRUE or FALSE"
   )
 
-  RUtilpol::check_class("tranform_to_proportions", "logical")
+  util_check_class(tranform_to_proportions, "logical")
 
   assertthat::assert_that(
     base::length(tranform_to_proportions) == 1,
     msg = "'tranform_to_proportions' must be a single TRUE or FALSE"
   )
 
-  RUtilpol::check_class("verbose", "logical")
+  util_check_class(verbose, "logical")
 
   assertthat::assert_that(
     base::length(verbose) == 1,

--- a/R/smooth_community_data.R
+++ b/R/smooth_community_data.R
@@ -43,11 +43,7 @@ smooth_community_data <- function(
   # SETUP -----
   # ----------------------------------------------
   # Mandatory assertions for all methods:
-  # Assert data_source_smooth is a list
-  assertthat::assert_that(
-    is.list(data_source_smooth),
-    msg = "'data_source_smooth' must be a list"
-  )
+  util_check_class(data_source_smooth, "list")
   # Assert that community is not empty
   assertthat::assert_that(
     nrow(data_source_smooth$community) > 0,
@@ -193,7 +189,7 @@ smooth_community_data <- function(
     switch(
       smooth_method,
       "m.avg" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           paste(
             "Data will be smoothed by 'moving average' over",
             smooth_n_points,
@@ -202,7 +198,7 @@ smooth_community_data <- function(
         )
       },
       "grim" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           paste(
             "Data will be smoothed by 'Grimm method' with min samples",
             smooth_n_points,
@@ -214,7 +210,7 @@ smooth_community_data <- function(
         )
       },
       "age.w" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           paste(
             "Data will be smoothed by 'age-weighed average' over",
             smooth_n_points,
@@ -224,7 +220,7 @@ smooth_community_data <- function(
         )
       },
       "shep" = {
-        RUtilpol::output_comment(
+        util_output_comment(
           paste(
             "Data will be smoothed by 'Shepard's 5-term filter'"
           )

--- a/R/standardise_community_data.R
+++ b/R/standardise_community_data.R
@@ -11,9 +11,9 @@
 standardise_community_data <-
   function(data_source_standard,
            n_individuals = 150) {
-    RUtilpol::check_class("data_source_standard", "data.frame")
+    util_check_class(data_source_standard, "data.frame")
 
-    RUtilpol::check_class("n_individuals", "numeric")
+    util_check_class(n_individuals, "numeric")
 
     assertthat::assert_that(
       !base::is.na(n_individuals) && n_individuals > 0,

--- a/R/subset_community.R
+++ b/R/subset_community.R
@@ -7,7 +7,7 @@
 subset_community <-
     function(data_source,
              ommit_vars = c("label", "res_age", "age_diff", "age")) {
-        RUtilpol::check_class("data_source", "data.frame")
+        util_check_class(data_source, "data.frame")
 
         assertthat::assert_that(
             base::nrow(data_source) > 0,

--- a/R/transform_into_proportions.r
+++ b/R/transform_into_proportions.r
@@ -13,17 +13,17 @@ transform_into_proportions <- function(
   verbose = FALSE,
   silent =FALSE
 ) {
-  RUtilpol::check_class("data_source_trans", "data.frame")
+  util_check_class(data_source_trans, "data.frame")
 
   assertthat::assert_that(
     base::nrow(data_source_trans) > 0,
     msg = "'data_source_trans' must not be empty"
   )
 
-  RUtilpol::check_class("sel_method", "character")
+  util_check_class(sel_method, "character")
 
-  RUtilpol::check_vector_values(
-    "sel_method",
+  util_check_vector_values(
+    sel_method,
     c("percentages", "proportions")
   )
 
@@ -34,12 +34,12 @@ transform_into_proportions <- function(
 
   sel_method <- match.arg(sel_method)
 
-  RUtilpol::check_class("verbose", "logical")
+  util_check_class(verbose, "logical")
 
-  RUtilpol::check_class("silent", "logical")
+  util_check_class(silent, "logical")
 
   if (isFALSE(silent) && isTRUE(verbose)) {
-    RUtilpol::output_comment(
+    util_output_comment(
       "Community data values are being converted to proportions"
     )
   }

--- a/R/util_internal.R
+++ b/R/util_internal.R
@@ -1,0 +1,110 @@
+#' @keywords internal
+#' @noRd
+util_paste_as_vector <- function(var_list, sep = "'") {
+  paste(
+    paste0(sep, var_list, sep),
+    collapse = ", "
+  )
+}
+
+#' @keywords internal
+#' @noRd
+util_check_class <- function(x, sel_class) {
+  var_name <- deparse(substitute(x))
+  assertthat::assert_that(
+    any(class(x) %in% sel_class),
+    msg = paste0(
+      "'", var_name, "' must be one of the following: ",
+      util_paste_as_vector(sel_class)
+    )
+  )
+}
+
+#' @keywords internal
+#' @noRd
+util_check_col_names <- function(x, var_list) {
+  var_name <- deparse(substitute(x))
+  assertthat::assert_that(
+    all(var_list %in% names(x)),
+    msg = paste0(
+      "'", var_name,
+      "' must contains following columns: ",
+      util_paste_as_vector(var_list)
+    )
+  )
+}
+
+#' @keywords internal
+#' @noRd
+util_check_vector_values <- function(x, var_list) {
+  var_name <- deparse(substitute(x))
+  assertthat::assert_that(
+    any(var_list %in% x),
+    msg = paste0(
+      "'", var_name,
+      "' must contains one of the following values: ",
+      util_paste_as_vector(var_list)
+    )
+  )
+}
+
+#' @keywords internal
+#' @noRd
+util_check_if_integer <- function(x) {
+  var_name <- deparse(substitute(x))
+  assertthat::assert_that(
+    round(x) == x,
+    msg = paste0("'", var_name, "' must be an integer")
+  )
+}
+
+#' @keywords internal
+#' @noRd
+util_output_comment <- function(msg = "") {
+  message(msg)
+}
+
+#' @keywords internal
+#' @noRd
+util_output_heading <- function(msg = "", size = c("h1", "h2", "h3")) {
+  size <- match.arg(size)
+  sep_line <-
+    switch(
+      size,
+      h1 = "#----------------------------------------------------------#",
+      h2 = "#--------------------------------------------------#",
+      h3 = "#----------------------------------------#"
+    )
+  message(sep_line)
+  message(msg)
+  message(sep_line)
+}
+
+#' @keywords internal
+#' @noRd
+util_output_warning <- function(msg = "") {
+  warning(msg, call. = FALSE)
+}
+
+#' @title Flatten the list by one level
+#' @param data_source A named list
+#' @description
+#' Returns a flat list whose names are the concatenation of the
+#' parent and child names separated by `"-"`.
+#' @keywords internal
+#' @noRd
+util_flatten_list_by_one <- function(data_source) {
+  assertthat::assert_that(
+    is.list(data_source),
+    msg = "'data_source' must be a list"
+  )
+  names_high <- names(data_source)
+  res <- vector("list", 0)
+  for (i in seq_along(data_source)) {
+    sel_item <- data_source[[i]]
+    names(sel_item) <-
+      paste(names_high[i], names(sel_item), sep = "-")
+    res <- c(res, sel_item)
+  }
+  return(res)
+}

--- a/R/util_search_parameter.R
+++ b/R/util_search_parameter.R
@@ -1,7 +1,7 @@
 #' Window growth helper for GRIMM smoothing
 #'
-#' Expands the indices [A, B] while respecting (a) dataset bounds,
-#' (b) maximum window size, and (c) maximum age range.
+#' Expands the indices `A` and `B` while respecting dataset bounds,
+#' maximum window size, and maximum age range.
 #'
 #' @keywords internal
 #' @noRd

--- a/man/RRatepol-package.Rd
+++ b/man/RRatepol-package.Rd
@@ -18,5 +18,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Ondrej Mottl \email{ondrej.mottl@gmail.com}
 
+Other contributors:
+\itemize{
+  \item Friederike Wolke \email{friederike.woelke@gmail.com} [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/check_data.Rd
+++ b/man/check_data.Rd
@@ -4,10 +4,12 @@
 \alias{check_data}
 \title{Check the data}
 \usage{
-check_data(data_source_check)
+check_data(data_source_check, silent = FALSE)
 }
 \arguments{
 \item{data_source_check}{List with \code{community} and \code{age}}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs. Useful for testing.}
 }
 \description{
 Output summary information about the data

--- a/man/estimate_dissimilarity_coefficient.Rd
+++ b/man/estimate_dissimilarity_coefficient.Rd
@@ -7,7 +7,8 @@
 estimate_dissimilarity_coefficient(
   data_source_dc,
   dissimilarity_coefficient = "chord",
-  verbose = FALSE
+  verbose = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ between Working Units. See \code{vegan::vegdist} for more details.
 }}
 
 \item{verbose}{Logical. If \code{TRUE}, function will output messages about internal processes}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs (overrides verbose). Useful for testing.}
 }
 \description{
 Calculate the dissimilarity coeficient

--- a/man/estimate_roc.Rd
+++ b/man/estimate_roc.Rd
@@ -24,7 +24,8 @@ estimate_roc(
   use_parallel = FALSE,
   interest_threshold = NULL,
   time_standardisation = NULL,
-  verbose = FALSE
+  verbose = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -122,6 +123,8 @@ if \code{time_standardisation} = 100, the RoC will be reported as
 dissimilarity per 100 yr.}
 
 \item{verbose}{Logical. If \code{TRUE}, function will output messages about internal processes}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs (overrides verbose). Useful for testing.}
 }
 \description{
 A function to estimate Rate of change in community data in time series

--- a/man/extract_data.Rd
+++ b/man/extract_data.Rd
@@ -8,7 +8,8 @@ extract_data(
   data_community_extract,
   data_age_extract,
   age_uncertainty = NULL,
-  verbose = FALSE
+  verbose = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -31,6 +32,8 @@ sampled from age-depth model uncertainties at the beginning of each run.
 
 \item{verbose}{DESCRIPTION.
 Logical. If \code{TRUE}, function will output messages about internal processes}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs (overrides verbose). Useful for testing.}
 }
 \description{
 Function for general preparation of input data

--- a/man/plot_roc.Rd
+++ b/man/plot_roc.Rd
@@ -9,7 +9,8 @@ plot_roc(
   age_threshold = NULL,
   roc_threshold = NULL,
   peaks = FALSE,
-  trend = NULL
+  trend = NULL,
+  silent = FALSE
 )
 }
 \arguments{
@@ -40,6 +41,8 @@ fitted value is calculated (residuals). The standard deviation (SD) is
 calculated from all the residuals. A peak is considered significant if it
 is 2 SD higher than the model.
 }}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs. Useful for testing.}
 }
 \description{
 Plot Rate-of-Change sequence with a error estimate and trend
@@ -83,7 +86,7 @@ sequence_02 <-
   )
 
 sequence_02_peak <-
-  detect_peak_points(sequence_01, sel_method = "trend_non_linear")
+  detect_peak_points(sequence_02, sel_method = "trend_non_linear")
 
 plot_roc(
   sequence_02_peak,

--- a/man/run_iteration.Rd
+++ b/man/run_iteration.Rd
@@ -12,7 +12,8 @@ run_iteration(
   tranform_to_proportions = TRUE,
   dissimilarity_coefficient = "euc",
   time_standardisation = 500,
-  verbose = FALSE
+  verbose = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -53,6 +54,8 @@ if \code{time_standardisation} = 100, the RoC will be reported as
 dissimilarity per 100 yr.}
 
 \item{verbose}{Logical. If \code{TRUE}, function will output messages about internal processes}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs (overrides verbose). Useful for testing.}
 }
 \description{
 A single run is computed following the simple steps:

--- a/man/smooth_community_data.Rd
+++ b/man/smooth_community_data.Rd
@@ -11,7 +11,8 @@ smooth_community_data(
   smooth_n_max = 9,
   smooth_age_range = 500,
   round_results = FALSE,
-  verbose = FALSE
+  verbose = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -36,6 +37,8 @@ Grimm and Age-Weighted smoothing (odd number)}
 \item{round_results}{Logical. Should smoothed values be rounded to integers?}
 
 \item{verbose}{Logical. If \code{TRUE}, function will output messages about internal processes}
+
+\item{silent}{Logical. If \code{TRUE}, suppress all console outputs (overrides verbose). Useful for testing.}
 }
 \description{
 A function to apply one of the 4 smoothers.

--- a/man/transform_into_proportions.Rd
+++ b/man/transform_into_proportions.Rd
@@ -7,7 +7,8 @@
 transform_into_proportions(
   data_source_trans,
   sel_method = c("proportions", "percentages"),
-  verbose = FALSE
+  verbose = FALSE,
+  silent = FALSE
 )
 }
 \arguments{

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -28,7 +28,7 @@ make_run_data <- function() {
     )
 
   purrr::chuck(
-    RUtilpol::flatten_list_by_one(data_prepared),
+    util_flatten_list_by_one(data_prepared),
     1
   )
 }
@@ -101,7 +101,7 @@ make_dc_data <- function(sel_method = "proportions") {
 
   data_flat <-
     purrr::chuck(
-      RUtilpol::flatten_list_by_one(data_prepared),
+      util_flatten_list_by_one(data_prepared),
       1
     )
 

--- a/tests/testthat/test-check_data.R
+++ b/tests/testthat/test-check_data.R
@@ -55,7 +55,10 @@ test_that(
 
 
 test_that(
-  "does not return NA in min, max, mean, median age if there is NA in the data",
+  paste(
+    "check_data() reports cleaned missing-value counts and finite age",
+    "summary values"
+  ),
   {
     # introduce NAs:
     example_community_NA <-
@@ -96,7 +99,22 @@ test_that(
     expect_true(
       any(
         grepl(
-          "Community data has 0 NAs. Age data has 6 NAs. Age uncertainty data has 6 NAs.",
+          paste0(
+            "Community data has 0 NAs\\. Age data has 0 NAs\\. ",
+            "Age uncertainty data has 0 NAs\\."
+          ),
+          msg
+        )
+      )
+    )
+
+    expect_true(
+      any(
+        grepl(
+          paste0(
+            "Age data has values of min -21, max 8402, mean 4806, ",
+            "and median 4970"
+          ),
           msg
         )
       )


### PR DESCRIPTION
## Summary

This PR removes the dependency on RUtilpol by replacing external helper calls
with internal `util_*` helpers for validation, console output, and list
flattening.

It also extends console output control with `silent` support across the
relevant functions and fixes `prepare_data()` so `bin_size` is not required
when `working_units = "levels"`.

## Changes

- replace `RUtilpol::*` helper calls with internal `util_*` helpers
- remove the external `RUtilpol` dependency from the package
- add or propagate `silent` console-output control where needed
- fix `prepare_data()` handling of `working_units = "levels"` with
  `bin_size = NULL`
- align `check_data()` missing-value and age-summary reporting with the
  cleaned data that are actually used downstream

- closes #79